### PR TITLE
feat: data_access_level + task_type + ground-truth isolation pattern (v3.3.2)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,10 +6,10 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 
 | Skill | Purpose | Key Modes |
 |-------|---------|-----------|
-| `deep-research` v2.8 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
-| `academic-paper` v3.0 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
-| `academic-paper-reviewer` v1.8 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.2 | Full pipeline orchestrator | (coordinates all above) |
+| `deep-research` v2.8.1 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
+| `academic-paper` v3.0.1 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
+| `academic-paper-reviewer` v1.8.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
+| `academic-pipeline` v3.2.1 | Full pipeline orchestrator | (coordinates all above) |
 
 ## v3.3 Key Additions
 
@@ -80,7 +80,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.3.1 (per CHANGELOG.md)
-- **Last Updated**: 2026-04-14
+- **Suite version**: 3.3.2 (per CHANGELOG.md)
+- **Last Updated**: 2026-04-15
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -15,15 +15,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-
-      - name: Run spec consistency check
-        run: python3 scripts/check_spec_consistency.py
+          cache: pip
+          cache-dependency-path: scripts/_skill_lint.py
 
       - name: Install lint dependencies
         run: pip install pyyaml
 
+      - name: Run spec consistency check
+        run: python3 scripts/check_spec_consistency.py
+
       - name: Check data_access_level declarations
+        env:
+          PYTHONPATH: scripts
         run: python3 scripts/check_data_access_level.py
 
       - name: Check task_type declarations
+        env:
+          PYTHONPATH: scripts
         run: python3 scripts/check_task_type.py

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Check data_access_level declarations
         run: python3 scripts/check_data_access_level.py
+
+      - name: Check task_type declarations
+        run: python3 scripts/check_task_type.py

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -18,3 +18,9 @@ jobs:
 
       - name: Run spec consistency check
         run: python3 scripts/check_spec_consistency.py
+
+      - name: Install lint dependencies
+        run: pip install pyyaml
+
+      - name: Check data_access_level declarations
+        run: python3 scripts/check_data_access_level.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   - `academic-pipeline` = `verified_only`
 - `scripts/check_data_access_level.py` lint script with unit tests; wired into `.github/workflows/spec-consistency.yml`.
 - Pointer section in `shared/handoff_schemas.md` documenting the vocabulary for future skill authors.
+- `metadata.task_type` field on every top-level SKILL.md. Two-value vocabulary (`open-ended` | `outcome-gradable`) declaring whether the task has a scalar ground-truth metric. All current ARS skills are `open-ended` — the field is a truth-in-advertising signal that ARS targets domain-judgment work, not benchmark tasks.
+- `scripts/check_task_type.py` lint script with 4 unit tests; wired into the same CI workflow.
+- Pointer section in `shared/handoff_schemas.md` for the `task_type` vocabulary.
 
 ### Changed
 - Per-skill `metadata.version` patch-bumped on all 4 SKILL.md files; `last_updated` refreshed to 2026-04-15.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.3.2] - 2026-04-15
+
+### Added
+- `metadata.data_access_level` field on every top-level SKILL.md. Three-tier vocabulary (`raw` | `redacted` | `verified_only`) declaring what kind of data each skill may consume. Inspired by the three-tier isolation pattern in Anthropic's automated-w2s-researcher (2026).
+  - `deep-research` = `raw`
+  - `academic-paper` = `redacted`
+  - `academic-paper-reviewer` = `verified_only`
+  - `academic-pipeline` = `verified_only`
+- `scripts/check_data_access_level.py` lint script with unit tests; wired into `.github/workflows/spec-consistency.yml`.
+- Pointer section in `shared/handoff_schemas.md` documenting the vocabulary for future skill authors.
+
+### Changed
+- Per-skill `metadata.version` patch-bumped on all 4 SKILL.md files; `last_updated` refreshed to 2026-04-15.
+- Suite version bumped to 3.3.2 across `README.md`, `README.zh-TW.md`, and `.claude/CLAUDE.md`.
+
 ## [3.3.1] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `metadata.task_type` field on every top-level SKILL.md. Two-value vocabulary (`open-ended` | `outcome-gradable`) declaring whether the task has a scalar ground-truth metric. All current ARS skills are `open-ended` — the field is a truth-in-advertising signal that ARS targets domain-judgment work, not benchmark tasks.
 - `scripts/check_task_type.py` lint script with 4 unit tests; wired into the same CI workflow.
 - Pointer section in `shared/handoff_schemas.md` for the `task_type` vocabulary.
+- `shared/ground_truth_isolation_pattern.md` — narrative pattern doc explaining the three-layer model behind `data_access_level` and `task_type`. Cross-references existing protocols (S2 verification, anti-leakage, integrity gates, calibration mode). Linked from `handoff_schemas.md` and `CONTRIBUTING.md`.
 
 ### Changed
 - Per-skill `metadata.version` patch-bumped on all 4 SKILL.md files; `last_updated` refreshed to 2026-04-15.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,3 +82,7 @@ Contributors are credited in commit messages, CHANGELOG entries, and the Contrib
 ## License
 
 By contributing, you agree that your contributions will be licensed under [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/). See [POSITIONING.md](POSITIONING.md) for usage terms.
+
+## When adding a new skill
+
+Read [`shared/ground_truth_isolation_pattern.md`](shared/ground_truth_isolation_pattern.md) before writing the SKILL.md. It explains the three-layer model behind the `data_access_level` and `task_type` frontmatter fields and lists the do/don't rules for handling evaluation rubrics, gold labels, and answer keys.

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **24 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.3.1 (2026-04-14)
+Last updated: v3.3.2 (2026-04-15)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.1)
+[![Version](https://img.shields.io/badge/version-v3.3.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -46,6 +46,7 @@ v3.3 was inspired by [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Son
 - **Academic Paper** — 12-agent paper writing with Style Calibration, Writing Quality Check, LaTeX output hardening, visualization, revision coaching, citation conversion, **writing judgment framework**, **anti-leakage protocol**, and **VLM figure verification**
 - **Academic Paper Reviewer** — Multi-perspective peer review with 0-100 quality rubrics (EIC + 3 dynamic reviewers + Devil's Advocate with **concession threshold protocol** + **attack intensity preservation** + **optional cross-model DA critique / calibration**) + **R&R traceability matrix** + **read-only constraint** + **review quality thinking framework**
 - **Academic Pipeline** — Full 10-stage pipeline orchestrator with adaptive checkpoints, claim verification, material passport, **optional cross-model integrity verification**, **mid-conversation reinforcement**, **self-check questions**, and **score trajectory tracking**
+- **Data Access Level Metadata** (v3.3.2+) — Every skill declares a `data_access_level` (`raw`, `redacted`, or `verified_only`) so pipelines and CI can reason about isolation boundaries. Enforced by `scripts/check_data_access_level.py`. Pattern adapted from Anthropic's automated-w2s-researcher (2026).
 
 ### Full Pipeline
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,7 @@ v3.3 was inspired by [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Son
 
 ### Skill posture (v3.3.2+)
 
-| Skill | data_access_level | task_type |
-|---|---|---|
-| deep-research | raw | open-ended |
-| academic-paper | redacted | open-ended |
-| academic-paper-reviewer | verified_only | open-ended |
-| academic-pipeline | verified_only | open-ended |
+Each SKILL.md declares `data_access_level` and `task_type` in its frontmatter. See [`shared/handoff_schemas.md`](shared/handoff_schemas.md) for the vocabulary and [`shared/ground_truth_isolation_pattern.md`](shared/ground_truth_isolation_pattern.md) for the rationale.
 
 ### Full Pipeline
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ v3.3 was inspired by [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Son
 - **Academic Paper Reviewer** — Multi-perspective peer review with 0-100 quality rubrics (EIC + 3 dynamic reviewers + Devil's Advocate with **concession threshold protocol** + **attack intensity preservation** + **optional cross-model DA critique / calibration**) + **R&R traceability matrix** + **read-only constraint** + **review quality thinking framework**
 - **Academic Pipeline** — Full 10-stage pipeline orchestrator with adaptive checkpoints, claim verification, material passport, **optional cross-model integrity verification**, **mid-conversation reinforcement**, **self-check questions**, and **score trajectory tracking**
 - **Data Access Level Metadata** (v3.3.2+) — Every skill declares a `data_access_level` (`raw`, `redacted`, or `verified_only`) so pipelines and CI can reason about isolation boundaries. Enforced by `scripts/check_data_access_level.py`. Pattern adapted from Anthropic's automated-w2s-researcher (2026).
+- **Task Type Annotation** (v3.3.2+) — Every skill declares a `task_type` (`open-ended` or `outcome-gradable`). All current ARS skills are `open-ended`: a truth-in-advertising signal that ARS targets domain-judgment work, not benchmark tasks. Enforced by `scripts/check_task_type.py`.
+
+### Skill posture (v3.3.2+)
+
+| Skill | data_access_level | task_type |
+|---|---|---|
+| deep-research | raw | open-ended |
+| academic-paper | redacted | open-ended |
+| academic-paper-reviewer | verified_only | open-ended |
+| academic-pipeline | verified_only | open-ended |
 
 ### Full Pipeline
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -52,12 +52,7 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 
 ### Skill 屬性一覽（v3.3.2+）
 
-| Skill | data_access_level | task_type |
-|---|---|---|
-| deep-research | raw | open-ended |
-| academic-paper | redacted | open-ended |
-| academic-paper-reviewer | verified_only | open-ended |
-| academic-pipeline | verified_only | open-ended |
+每個 SKILL.md 在 frontmatter 宣告 `data_access_level` 與 `task_type`。詞彙定義見 [`shared/handoff_schemas.md`](shared/handoff_schemas.md)，設計理念見 [`shared/ground_truth_isolation_pattern.md`](shared/ground_truth_isolation_pattern.md)。
 
 ### 完整 Pipeline
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.1)
+[![Version](https://img.shields.io/badge/version-v3.3.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -47,6 +47,7 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 - **Academic Paper** — 12 個 Agent 的論文撰寫團隊，含風格校準、寫作品質檢查、LaTeX 輸出強化、視覺化、修訂教練、引用格式轉換、**寫作判斷力框架**、**反洩漏協議**、**VLM 圖表驗證**
 - **Academic Paper Reviewer** — 多視角同儕審查，0-100 品質量表（主編 + 3 位動態審查者 + 魔鬼代言人，含**讓步門檻協議** + **攻擊強度保持** + **可選跨模型 DA critique / calibration**）+ **R&R 追溯矩陣** + **唯讀約束** + **審查品質思維框架**
 - **Academic Pipeline** — 10 階段全流程調度器，含自適應 checkpoint、宣稱驗證、素材護照、**可選跨模型誠信驗證**、**中途強化機制**、**自我檢查問題**、**分數軌跡追蹤**
+- **資料存取層級標註**（v3.3.2+）— 每個 skill 在 frontmatter 宣告 `data_access_level`（`raw`、`redacted`、`verified_only`），讓 pipeline 與 CI 能對隔離邊界做靜態檢查。由 `scripts/check_data_access_level.py` 強制執行。設計靈感來自 Anthropic 的 automated-w2s-researcher（2026）的三層隔離模式。
 
 ### 完整 Pipeline
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -48,6 +48,16 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 - **Academic Paper Reviewer** — 多視角同儕審查，0-100 品質量表（主編 + 3 位動態審查者 + 魔鬼代言人，含**讓步門檻協議** + **攻擊強度保持** + **可選跨模型 DA critique / calibration**）+ **R&R 追溯矩陣** + **唯讀約束** + **審查品質思維框架**
 - **Academic Pipeline** — 10 階段全流程調度器，含自適應 checkpoint、宣稱驗證、素材護照、**可選跨模型誠信驗證**、**中途強化機制**、**自我檢查問題**、**分數軌跡追蹤**
 - **資料存取層級標註**（v3.3.2+）— 每個 skill 在 frontmatter 宣告 `data_access_level`（`raw`、`redacted`、`verified_only`），讓 pipeline 與 CI 能對隔離邊界做靜態檢查。由 `scripts/check_data_access_level.py` 強制執行。設計靈感來自 Anthropic 的 automated-w2s-researcher（2026）的三層隔離模式。
+- **任務類型標註**（v3.3.2+）— 每個 skill 宣告 `task_type`（`open-ended` 或 `outcome-gradable`）。目前 ARS 所有 skills 皆為 `open-ended`：誠信標示，明確告訴使用者 ARS 適用於需要領域判斷的工作，而非可量化的 benchmark 任務。由 `scripts/check_task_type.py` 強制執行。
+
+### Skill 屬性一覽（v3.3.2+）
+
+| Skill | data_access_level | task_type |
+|---|---|---|
+| deep-research | raw | open-ended |
+| academic-paper | redacted | open-ended |
+| academic-paper-reviewer | verified_only | open-ended |
+| academic-pipeline | verified_only | open-ended |
 
 ### 完整 Pipeline
 

--- a/academic-paper-reviewer/SKILL.md
+++ b/academic-paper-reviewer/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   last_updated: "2026-04-15"
   status: active
   data_access_level: verified_only
+  task_type: open-ended
   related_skills:
     - academic-paper
     - academic-pipeline

--- a/academic-paper-reviewer/SKILL.md
+++ b/academic-paper-reviewer/SKILL.md
@@ -2,9 +2,10 @@
 name: academic-paper-reviewer
 description: "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy."
 metadata:
-  version: "1.8"
-  last_updated: "2026-04-09"
+  version: "1.8.1"
+  last_updated: "2026-04-15"
   status: active
+  data_access_level: verified_only
   related_skills:
     - academic-paper
     - academic-pipeline

--- a/academic-paper-reviewer/SKILL.md
+++ b/academic-paper-reviewer/SKILL.md
@@ -11,7 +11,7 @@ metadata:
     - academic-pipeline
 ---
 
-# Academic Paper Reviewer v1.8 — Multi-Perspective Academic Paper Review Agent Team
+# Academic Paper Reviewer v1.8.1 — Multi-Perspective Academic Paper Review Agent Team
 
 Simulates a complete international journal peer review process: automatically identifies the paper's field, dynamically configures 5 reviewers (Editor-in-Chief + 3 peer reviewers + Devil's Advocate) who review from four non-overlapping perspectives — methodology, domain expertise, cross-disciplinary viewpoints, and core argument challenges — ultimately producing a structured Editorial Decision and Revision Roadmap.
 
@@ -375,8 +375,8 @@ Follows the paper's language. Academic terms remain in English. User can overrid
 
 | Item | Content |
 |------|---------|
-| Skill Version | 1.8 |
-| Last Updated | 2026-04-09 |
+| Skill Version | 1.8.1 |
+| Last Updated | 2026-04-15 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | academic-paper v1.0+ (upstream/downstream integration) |
 | Role | Multi-perspective academic paper review simulator |

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -2,9 +2,10 @@
 name: academic-paper
 description: "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見."
 metadata:
-  version: "3.0"
-  last_updated: "2026-04-09"
+  version: "3.0.1"
+  last_updated: "2026-04-15"
   status: active
+  data_access_level: redacted
   related_skills:
     - deep-research
     - academic-paper-reviewer

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   last_updated: "2026-04-15"
   status: active
   data_access_level: redacted
+  task_type: open-ended
   related_skills:
     - deep-research
     - academic-paper-reviewer

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -315,8 +315,8 @@ academic-paper + academic-paper-reviewer -> Peer review -> revision loop
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.0 |
-| Last Updated | 2026-04-09 |
+| Skill Version | 3.0.1 |
+| Last Updated | 2026-04-15 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v1.0+ (upstream), academic-paper-reviewer v1.0+ (downstream) |
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only
+  task_type: open-ended
   related_skills:
     - deep-research
     - academic-paper

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     - academic-paper-reviewer
 ---
 
-# Academic Pipeline v3.2 — Full Academic Research Workflow Orchestrator
+# Academic Pipeline v3.2.1 — Full Academic Research Workflow Orchestrator
 
 A lightweight orchestrator that manages the complete academic pipeline from research exploration to final manuscript. It does not perform substantive work — it only detects stages, recommends modes, dispatches skills, manages transitions, and tracks state.
 
@@ -532,8 +532,8 @@ Stage 5: academic-paper (format-convert mode)
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.2 |
-| Last Updated | 2026-04-09 |
+| Skill Version | 3.2.1 |
+| Last Updated | 2026-04-15 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v2.0+, academic-paper v2.0+, academic-paper-reviewer v1.1+ |
 | Role | Full academic research workflow orchestrator |

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,10 +2,11 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.2"
-  last_updated: "2026-04-09"
+  version: "3.2.1"
+  last_updated: "2026-04-15"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
+  data_access_level: verified_only
   related_skills:
     - deep-research
     - academic-paper

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   last_updated: "2026-04-15"
   status: active
   data_access_level: raw
+  task_type: open-ended
   related_skills:
     - academic-paper
     - academic-pipeline

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -2,9 +2,10 @@
 name: deep-research
 description: "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題."
 metadata:
-  version: "2.8"
-  last_updated: "2026-04-09"
+  version: "2.8.1"
+  last_updated: "2026-04-15"
   status: active
+  data_access_level: raw
   related_skills:
     - academic-paper
     - academic-pipeline

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -469,8 +469,8 @@ deep-research (systematic-review) + academic-paper -> PRISMA systematic review p
 
 | Item | Content |
 |------|---------|
-| Skill Version | 2.8 |
-| Last Updated | 2026-04-09 |
+| Skill Version | 2.8.1 |
+| Last Updated | 2026-04-15 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | academic-paper v1.0+ (downstream) |
 

--- a/scripts/_skill_lint.py
+++ b/scripts/_skill_lint.py
@@ -1,0 +1,111 @@
+"""Shared helpers for SKILL.md frontmatter linting.
+
+Used by check_data_access_level.py and check_task_type.py to validate
+that every top-level SKILL.md declares a required metadata field with
+a value drawn from a closed vocabulary.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+SKIP_DIRS = frozenset(
+    {"shared", "scripts", "docs", ".git", ".github", "examples", ".local-plans", ".claude"}
+)
+
+
+class FrontmatterError(Exception):
+    """Raised when SKILL.md frontmatter cannot be parsed.
+
+    Distinct from a missing fence (returns None) and an empty fence
+    (returns {}). Callers should catch this and surface the path +
+    parser detail on stdout, not stderr — CI logs commonly capture
+    only stdout.
+    """
+
+
+def iter_skill_files(root: Path) -> list[Path]:
+    """Top-level SKILL.md files only. Skips SKIP_DIRS."""
+    results: list[Path] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name in SKIP_DIRS:
+            continue
+        skill_md = child / "SKILL.md"
+        if skill_md.is_file():
+            results.append(skill_md)
+    return results
+
+
+def parse_frontmatter(path: Path) -> dict | None:
+    """Parse the YAML frontmatter of a SKILL.md.
+
+    Three outcomes:
+      - dict (possibly empty) — fence present and parseable
+      - None                  — no opening '---' fence
+      - raises FrontmatterError — fence present but YAML invalid
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    _, _, rest = text.partition("---\n")
+    fm, _, _ = rest.partition("\n---\n")
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError as exc:
+        raise FrontmatterError(f"{path}: malformed YAML frontmatter: {exc}") from exc
+
+
+def check_metadata_field(
+    root: Path,
+    field: str,
+    legal_values: set[str] | frozenset[str],
+) -> list[str]:
+    """Return a list of human-readable violation messages, empty if all pass."""
+    violations: list[str] = []
+    skills = iter_skill_files(root)
+    if not skills:
+        violations.append(f"no SKILL.md files found under {root}")
+        return violations
+    for path in skills:
+        try:
+            fm = parse_frontmatter(path)
+        except FrontmatterError as exc:
+            violations.append(str(exc))
+            continue
+        if fm is None:
+            violations.append(f"{path}: missing YAML frontmatter")
+            continue
+        metadata = fm.get("metadata") or {}
+        if field not in metadata:
+            violations.append(f"{path}: metadata.{field} is missing")
+            continue
+        value = metadata[field]
+        if value not in legal_values:
+            violations.append(
+                f"{path}: metadata.{field} = {value!r}, "
+                f"must be one of {sorted(legal_values)}"
+            )
+    return violations
+
+
+def run_lint(field: str, legal_values: set[str] | frozenset[str], ok_message: str) -> int:
+    """argparse + check + print + exit-code wrapper used by both check scripts."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    args = parser.parse_args()
+
+    violations = check_metadata_field(args.path, field, legal_values)
+    if violations:
+        for v in violations:
+            print(f"ERROR: {v}")
+        print(f"\n{len(violations)} violation(s) found.", file=sys.stderr)
+        return 1
+    print(ok_message)
+    return 0

--- a/scripts/check_data_access_level.py
+++ b/scripts/check_data_access_level.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Lint: every top-level SKILL.md must declare metadata.data_access_level.
+
+Legal values: raw | redacted | verified_only.
+
+Exit 0 on success, 1 on any violation.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+LEGAL_VALUES = {"raw", "redacted", "verified_only"}
+SKIP_DIRS = {"shared", "scripts", "docs", ".git", ".github", "examples", ".local-plans"}
+
+
+def _iter_skill_files(root: Path) -> list[Path]:
+    results: list[Path] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name in SKIP_DIRS:
+            continue
+        skill_md = child / "SKILL.md"
+        if skill_md.is_file():
+            results.append(skill_md)
+    return results
+
+
+def _parse_frontmatter(path: Path) -> dict | None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    _, _, rest = text.partition("---\n")
+    fm, _, _ = rest.partition("\n---")
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError as exc:
+        print(f"ERROR: {path}: malformed YAML frontmatter: {exc}", file=sys.stderr)
+        return None
+
+
+def check(root: Path) -> list[str]:
+    violations: list[str] = []
+    skills = _iter_skill_files(root)
+    if not skills:
+        violations.append(f"no SKILL.md files found under {root}")
+        return violations
+    for path in skills:
+        fm = _parse_frontmatter(path)
+        if fm is None:
+            violations.append(f"{path}: could not parse frontmatter")
+            continue
+        metadata = fm.get("metadata") or {}
+        if "data_access_level" not in metadata:
+            violations.append(
+                f"{path}: metadata.data_access_level is missing"
+            )
+            continue
+        value = metadata["data_access_level"]
+        if value not in LEGAL_VALUES:
+            violations.append(
+                f"{path}: metadata.data_access_level = {value!r}, "
+                f"must be one of {sorted(LEGAL_VALUES)}"
+            )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repo root (default: script's parent)",
+    )
+    args = parser.parse_args()
+
+    violations = check(args.path)
+    if violations:
+        for v in violations:
+            print(f"ERROR: {v}")
+        print(f"\n{len(violations)} violation(s) found.", file=sys.stderr)
+        return 1
+    print("OK: all SKILL.md files declare a valid data_access_level.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_data_access_level.py
+++ b/scripts/check_data_access_level.py
@@ -17,6 +17,10 @@ LEGAL_VALUES = {"raw", "redacted", "verified_only"}
 SKIP_DIRS = {"shared", "scripts", "docs", ".git", ".github", "examples", ".local-plans"}
 
 
+class FrontmatterError(Exception):
+    """Raised when SKILL.md frontmatter cannot be parsed."""
+
+
 def _iter_skill_files(root: Path) -> list[Path]:
     results: list[Path] = []
     for child in sorted(root.iterdir()):
@@ -33,12 +37,11 @@ def _parse_frontmatter(path: Path) -> dict | None:
     if not text.startswith("---"):
         return None
     _, _, rest = text.partition("---\n")
-    fm, _, _ = rest.partition("\n---")
+    fm, _, _ = rest.partition("\n---\n")
     try:
         return yaml.safe_load(fm) or {}
     except yaml.YAMLError as exc:
-        print(f"ERROR: {path}: malformed YAML frontmatter: {exc}", file=sys.stderr)
-        return None
+        raise FrontmatterError(f"{path}: malformed YAML frontmatter: {exc}") from exc
 
 
 def check(root: Path) -> list[str]:
@@ -48,9 +51,13 @@ def check(root: Path) -> list[str]:
         violations.append(f"no SKILL.md files found under {root}")
         return violations
     for path in skills:
-        fm = _parse_frontmatter(path)
+        try:
+            fm = _parse_frontmatter(path)
+        except FrontmatterError as exc:
+            violations.append(str(exc))
+            continue
         if fm is None:
-            violations.append(f"{path}: could not parse frontmatter")
+            violations.append(f"{path}: missing YAML frontmatter")
             continue
         metadata = fm.get("metadata") or {}
         if "data_access_level" not in metadata:

--- a/scripts/check_data_access_level.py
+++ b/scripts/check_data_access_level.py
@@ -2,97 +2,21 @@
 """Lint: every top-level SKILL.md must declare metadata.data_access_level.
 
 Legal values: raw | redacted | verified_only.
-
-Exit 0 on success, 1 on any violation.
 """
 from __future__ import annotations
 
-import argparse
 import sys
-from pathlib import Path
 
-import yaml
+from _skill_lint import run_lint
 
-LEGAL_VALUES = {"raw", "redacted", "verified_only"}
-SKIP_DIRS = {"shared", "scripts", "docs", ".git", ".github", "examples", ".local-plans"}
-
-
-class FrontmatterError(Exception):
-    """Raised when SKILL.md frontmatter cannot be parsed."""
-
-
-def _iter_skill_files(root: Path) -> list[Path]:
-    results: list[Path] = []
-    for child in sorted(root.iterdir()):
-        if not child.is_dir() or child.name in SKIP_DIRS:
-            continue
-        skill_md = child / "SKILL.md"
-        if skill_md.is_file():
-            results.append(skill_md)
-    return results
-
-
-def _parse_frontmatter(path: Path) -> dict | None:
-    text = path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
-        return None
-    _, _, rest = text.partition("---\n")
-    fm, _, _ = rest.partition("\n---\n")
-    try:
-        return yaml.safe_load(fm) or {}
-    except yaml.YAMLError as exc:
-        raise FrontmatterError(f"{path}: malformed YAML frontmatter: {exc}") from exc
-
-
-def check(root: Path) -> list[str]:
-    violations: list[str] = []
-    skills = _iter_skill_files(root)
-    if not skills:
-        violations.append(f"no SKILL.md files found under {root}")
-        return violations
-    for path in skills:
-        try:
-            fm = _parse_frontmatter(path)
-        except FrontmatterError as exc:
-            violations.append(str(exc))
-            continue
-        if fm is None:
-            violations.append(f"{path}: missing YAML frontmatter")
-            continue
-        metadata = fm.get("metadata") or {}
-        if "data_access_level" not in metadata:
-            violations.append(
-                f"{path}: metadata.data_access_level is missing"
-            )
-            continue
-        value = metadata["data_access_level"]
-        if value not in LEGAL_VALUES:
-            violations.append(
-                f"{path}: metadata.data_access_level = {value!r}, "
-                f"must be one of {sorted(LEGAL_VALUES)}"
-            )
-    return violations
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--path",
-        type=Path,
-        default=Path(__file__).resolve().parent.parent,
-        help="Repo root (default: script's parent)",
-    )
-    args = parser.parse_args()
-
-    violations = check(args.path)
-    if violations:
-        for v in violations:
-            print(f"ERROR: {v}")
-        print(f"\n{len(violations)} violation(s) found.", file=sys.stderr)
-        return 1
-    print("OK: all SKILL.md files declare a valid data_access_level.")
-    return 0
+LEGAL_VALUES = frozenset({"raw", "redacted", "verified_only"})
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(
+        run_lint(
+            field="data_access_level",
+            legal_values=LEGAL_VALUES,
+            ok_message="OK: all SKILL.md files declare a valid data_access_level.",
+        )
+    )

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -46,7 +46,7 @@ def extract_section(text: str, start: str, end: str) -> str:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.3.1 (2026-04-14)")
+    expect_contains(rel_path, "Last updated: v3.3.2 (2026-04-15)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -60,7 +60,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.3.1")
+    expect_contains(rel_path, "**Suite version**: 3.3.2")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -121,8 +121,8 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.1-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.1")
+    expect_contains(rel_path, "version-v3.3.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.3.2")
     for heading in (
         "#### Deep Research (7 modes)",
         "#### Academic Paper (10 modes)",
@@ -170,8 +170,8 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.1-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.1")
+    expect_contains(rel_path, "version-v3.3.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.3.2")
     for heading in (
         "#### Deep Research（深度研究，7 種模式）",
         "#### Academic Paper（學術論文撰寫，10 種模式）",

--- a/scripts/check_task_type.py
+++ b/scripts/check_task_type.py
@@ -2,95 +2,21 @@
 """Lint: every top-level SKILL.md must declare metadata.task_type.
 
 Legal values: open-ended | outcome-gradable.
-
-Exit 0 on success, 1 on any violation. Errors written to stdout so CI
-logs that capture stdout preserve the root cause.
 """
 from __future__ import annotations
 
-import argparse
 import sys
-from pathlib import Path
 
-import yaml
+from _skill_lint import run_lint
 
-LEGAL_VALUES = {"open-ended", "outcome-gradable"}
-SKIP_DIRS = {"shared", "scripts", "docs", ".git", ".github", "examples", ".local-plans"}
-
-
-class FrontmatterError(Exception):
-    """Raised when SKILL.md frontmatter cannot be parsed."""
-
-
-def _iter_skill_files(root: Path) -> list[Path]:
-    results: list[Path] = []
-    for child in sorted(root.iterdir()):
-        if not child.is_dir() or child.name in SKIP_DIRS:
-            continue
-        skill_md = child / "SKILL.md"
-        if skill_md.is_file():
-            results.append(skill_md)
-    return results
-
-
-def _parse_frontmatter(path: Path) -> dict | None:
-    text = path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
-        return None
-    _, _, rest = text.partition("---\n")
-    fm, _, _ = rest.partition("\n---\n")
-    try:
-        return yaml.safe_load(fm) or {}
-    except yaml.YAMLError as exc:
-        raise FrontmatterError(f"{path}: malformed YAML frontmatter: {exc}") from exc
-
-
-def check(root: Path) -> list[str]:
-    violations: list[str] = []
-    skills = _iter_skill_files(root)
-    if not skills:
-        violations.append(f"no SKILL.md files found under {root}")
-        return violations
-    for path in skills:
-        try:
-            fm = _parse_frontmatter(path)
-        except FrontmatterError as exc:
-            violations.append(str(exc))
-            continue
-        if fm is None:
-            violations.append(f"{path}: missing YAML frontmatter")
-            continue
-        metadata = fm.get("metadata") or {}
-        if "task_type" not in metadata:
-            violations.append(f"{path}: metadata.task_type is missing")
-            continue
-        value = metadata["task_type"]
-        if value not in LEGAL_VALUES:
-            violations.append(
-                f"{path}: metadata.task_type = {value!r}, "
-                f"must be one of {sorted(LEGAL_VALUES)}"
-            )
-    return violations
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--path",
-        type=Path,
-        default=Path(__file__).resolve().parent.parent,
-    )
-    args = parser.parse_args()
-
-    violations = check(args.path)
-    if violations:
-        for v in violations:
-            print(f"ERROR: {v}")
-        print(f"\n{len(violations)} violation(s) found.", file=sys.stderr)
-        return 1
-    print("OK: all SKILL.md files declare a valid task_type.")
-    return 0
+LEGAL_VALUES = frozenset({"open-ended", "outcome-gradable"})
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(
+        run_lint(
+            field="task_type",
+            legal_values=LEGAL_VALUES,
+            ok_message="OK: all SKILL.md files declare a valid task_type.",
+        )
+    )

--- a/scripts/check_task_type.py
+++ b/scripts/check_task_type.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Lint: every top-level SKILL.md must declare metadata.task_type.
+
+Legal values: open-ended | outcome-gradable.
+
+Exit 0 on success, 1 on any violation. Errors written to stdout so CI
+logs that capture stdout preserve the root cause.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+LEGAL_VALUES = {"open-ended", "outcome-gradable"}
+SKIP_DIRS = {"shared", "scripts", "docs", ".git", ".github", "examples", ".local-plans"}
+
+
+class FrontmatterError(Exception):
+    """Raised when SKILL.md frontmatter cannot be parsed."""
+
+
+def _iter_skill_files(root: Path) -> list[Path]:
+    results: list[Path] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name in SKIP_DIRS:
+            continue
+        skill_md = child / "SKILL.md"
+        if skill_md.is_file():
+            results.append(skill_md)
+    return results
+
+
+def _parse_frontmatter(path: Path) -> dict | None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    _, _, rest = text.partition("---\n")
+    fm, _, _ = rest.partition("\n---\n")
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError as exc:
+        raise FrontmatterError(f"{path}: malformed YAML frontmatter: {exc}") from exc
+
+
+def check(root: Path) -> list[str]:
+    violations: list[str] = []
+    skills = _iter_skill_files(root)
+    if not skills:
+        violations.append(f"no SKILL.md files found under {root}")
+        return violations
+    for path in skills:
+        try:
+            fm = _parse_frontmatter(path)
+        except FrontmatterError as exc:
+            violations.append(str(exc))
+            continue
+        if fm is None:
+            violations.append(f"{path}: missing YAML frontmatter")
+            continue
+        metadata = fm.get("metadata") or {}
+        if "task_type" not in metadata:
+            violations.append(f"{path}: metadata.task_type is missing")
+            continue
+        value = metadata["task_type"]
+        if value not in LEGAL_VALUES:
+            violations.append(
+                f"{path}: metadata.task_type = {value!r}, "
+                f"must be one of {sorted(LEGAL_VALUES)}"
+            )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    args = parser.parse_args()
+
+    violations = check(args.path)
+    if violations:
+        for v in violations:
+            print(f"ERROR: {v}")
+        print(f"\n{len(violations)} violation(s) found.", file=sys.stderr)
+        return 1
+    print("OK: all SKILL.md files declare a valid task_type.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_data_access_level.py
+++ b/scripts/test_check_data_access_level.py
@@ -1,0 +1,98 @@
+"""Unit tests for check_data_access_level.py lint script."""
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+SCRIPT = Path(__file__).resolve().parent / "check_data_access_level.py"
+
+
+def _run(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--path", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_skill(root: Path, name: str, frontmatter_body: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\n{frontmatter_body}---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+class TestLintScript(unittest.TestCase):
+    def test_missing_field_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_skill(
+                root,
+                "example-skill",
+                textwrap.dedent(
+                    """\
+                    name: example-skill
+                    description: "test"
+                    metadata:
+                      version: "1.0"
+                      status: active
+                    """
+                ),
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("data_access_level", result.stdout + result.stderr)
+
+    def test_invalid_value_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_skill(
+                root,
+                "example-skill",
+                textwrap.dedent(
+                    """\
+                    name: example-skill
+                    description: "test"
+                    metadata:
+                      version: "1.0"
+                      status: active
+                      data_access_level: public
+                    """
+                ),
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("public", result.stdout + result.stderr)
+
+    def test_valid_value_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name, level in [
+                ("a", "raw"),
+                ("b", "redacted"),
+                ("c", "verified_only"),
+            ]:
+                _write_skill(
+                    root,
+                    name,
+                    textwrap.dedent(
+                        f"""\
+                        name: {name}
+                        description: "test"
+                        metadata:
+                          version: "1.0"
+                          status: active
+                          data_access_level: {level}
+                        """
+                    ),
+                )
+            result = _run(root)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_data_access_level.py
+++ b/scripts/test_check_data_access_level.py
@@ -93,6 +93,25 @@ class TestLintScript(unittest.TestCase):
             result = _run(root)
             self.assertEqual(result.returncode, 0, msg=result.stderr)
 
+    def test_malformed_yaml_reports_on_stdout(self) -> None:
+        """FrontmatterError detail must appear on stdout, not only stderr."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = root / "bad-skill"
+            skill_dir.mkdir()
+            # Deliberately invalid YAML: tab character where spaces are required
+            (skill_dir / "SKILL.md").write_text(
+                "---\nkey: valid\n\tbad_indent: boom\n---\n\n# bad-skill\n",
+                encoding="utf-8",
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            # The yaml.YAMLError detail must be on stdout so CI stdout-only
+            # capture preserves the root cause.
+            self.assertIn("malformed YAML frontmatter", result.stdout)
+            # Nothing about this error should leak only to stderr.
+            self.assertNotIn("malformed YAML frontmatter", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_data_access_level.py
+++ b/scripts/test_check_data_access_level.py
@@ -1,4 +1,5 @@
 """Unit tests for check_data_access_level.py lint script."""
+import os
 import subprocess
 import sys
 import textwrap
@@ -10,10 +11,15 @@ SCRIPT = Path(__file__).resolve().parent / "check_data_access_level.py"
 
 
 def _run(root: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SCRIPT.parent) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--path", str(root)],
         capture_output=True,
         text=True,
+        env=env,
     )
 
 

--- a/scripts/test_check_task_type.py
+++ b/scripts/test_check_task_type.py
@@ -1,0 +1,100 @@
+# scripts/test_check_task_type.py
+"""Unit tests for check_task_type.py lint script."""
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+SCRIPT = Path(__file__).resolve().parent / "check_task_type.py"
+
+
+def _run(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--path", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_skill(root: Path, name: str, frontmatter_body: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\n{frontmatter_body}---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+class TestTaskTypeLint(unittest.TestCase):
+    def test_missing_field_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_skill(
+                root, "example",
+                textwrap.dedent("""\
+                    name: example
+                    description: "test"
+                    metadata:
+                      version: "1.0"
+                      status: active
+                    """),
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("task_type", result.stdout + result.stderr)
+
+    def test_invalid_value_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_skill(
+                root, "example",
+                textwrap.dedent("""\
+                    name: example
+                    description: "test"
+                    metadata:
+                      version: "1.0"
+                      status: active
+                      task_type: experimental
+                    """),
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("experimental", result.stdout + result.stderr)
+
+    def test_valid_value_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name, value in [("a", "open-ended"), ("b", "outcome-gradable")]:
+                _write_skill(
+                    root, name,
+                    textwrap.dedent(f"""\
+                        name: {name}
+                        description: "test"
+                        metadata:
+                          version: "1.0"
+                          status: active
+                          task_type: {value}
+                        """),
+                )
+            result = _run(root)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_malformed_yaml_reports_on_stdout(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = root / "broken"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: broken\nmetadata:\n\tversion: \"1.0\"\n---\n",
+                encoding="utf-8",
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("malformed YAML frontmatter", result.stdout)
+            self.assertNotIn("malformed YAML frontmatter", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_task_type.py
+++ b/scripts/test_check_task_type.py
@@ -1,5 +1,6 @@
 # scripts/test_check_task_type.py
 """Unit tests for check_task_type.py lint script."""
+import os
 import subprocess
 import sys
 import textwrap
@@ -11,10 +12,15 @@ SCRIPT = Path(__file__).resolve().parent / "check_task_type.py"
 
 
 def _run(root: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SCRIPT.parent) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--path", str(root)],
         capture_output=True,
         text=True,
+        env=env,
     )
 
 

--- a/shared/ground_truth_isolation_pattern.md
+++ b/shared/ground_truth_isolation_pattern.md
@@ -1,0 +1,229 @@
+# Ground-Truth Isolation Pattern
+
+**Status**: v3.3.2 — narrative hub doc; for declarative annotations see
+`shared/handoff_schemas.md`
+
+---
+
+## § 1 — Why ground-truth isolation matters
+
+When an agent can read the evaluation answer key while producing the candidate
+output, it learns to optimize directly against the rubric rather than against
+the underlying task. The result is inflated scores that do not transfer to
+held-out data — a textbook case of reward hacking. The failure is not about
+intent; it is architectural. An agent that can see what counts as a correct
+answer will, over time, route toward surface features of correctness rather
+than toward the underlying quality those features are supposed to signal.
+
+The failure mode appears at different granularities: a single agent session
+that reads a scoring key before generating; a pipeline stage that appends
+expected outputs to the prompt as "negative examples"; a calibration setup
+where the model has already processed the gold set before it reports confidence
+estimates. In every case, the shared presence of ground-truth material and
+candidate-output generation in the same context produces results that look
+strong on paper and fail on genuinely held-out evaluation.
+
+Two published cases make this concrete and directly inform the ARS design.
+
+Anthropic's automated-w2s-researcher (2026) uses a three-tier sandbox: local
+mode for development, docker-with-redacted-data for integration testing, and
+RunPod with server-side ground truth as the only valid evaluation tier. The
+architecture exists because earlier iterations without this separation produced
+unreliable results. Their README explicitly warns that local-mode results
+"might not be legit" because the agent can find `labeled_data` on the local
+filesystem. The solution is structural: ground truth never coexists in the same
+process or filesystem layer as the agent generating candidate answers.
+Isolation is a property of the system design, not a prompt-level instruction
+that can be added after the fact.
+
+Lu et al. (2026, *Nature* 651:914-919) document a related failure mode at
+pipeline scale, which they call "shortcut reliance." In their fully autonomous
+AI research system — the first to pass blind peer review end-to-end — models
+exploit spurious correlations in training data, achieve high scores on the
+target benchmark, and write papers describing the results as a genuine
+scientific solution. The failure is not dishonesty; the model optimizes
+whatever measurable signal is available. If the measurable signal leaks
+information about the evaluation criterion, the model finds that leak. The
+paper looks like a solved problem. The underlying scientific question remains
+open.
+
+ARS's human-in-the-loop pipeline already enforces the spirit of this
+isolation: researchers set their own research questions, review outputs at each
+integrity gate, and supply calibration gold sets at runtime rather than
+embedding them in the repository. This document makes the pattern explicit and
+machine-checkable via the `data_access_level` annotation declared in every
+top-level `SKILL.md`.
+
+---
+
+## § 2 — The three-layer mental model
+
+Every artifact in ARS belongs to one of three layers, and the direction of
+flow is strictly one-way. An artifact can be promoted from a lower layer to a
+higher one by passing an integrity gate. It cannot move in the other direction.
+Layer 3 material cannot appear as input to a process whose output is layer 1
+or 2.
+
+**Layer 1 — raw inputs** covers user queries, primary sources retrieved from
+web or database search, and agent-assembled bibliographies before any
+verification. Material at this layer is untrusted by default. It may be
+hallucinated, adversarially crafted, outdated, or contain PII. A skill
+operating at layer 1 must treat every factual claim as potentially wrong, flag
+gaps rather than silently filling them from parametric memory, and pass nothing
+downstream as verified fact without explicit gate passage. The `deep-research`
+skill operates here.
+
+**Layer 2 — verified artifacts** are outputs that have cleared an integrity
+gate: Semantic Scholar API existence confirmation, anti-leakage checks
+confirming claims came from session material rather than from the model's
+training-time memory, citation existence proofs, or the
+`integrity_verification_agent`'s seven-mode failure checklist at Stage 2.5 or
+4.5. Once an artifact is at layer 2, downstream skills may treat it as
+provisionally reliable for argument building and paper drafting. The provenance
+chain must remain traceable through the Material Passport carried with each
+artifact.
+
+**Layer 3 — ground truth and evaluation rubrics** includes gold labels,
+reviewer scoring rubrics, calibration sets, and any material that defines what
+a correct output looks like. This layer is distinct in kind, not just degree.
+The critical rule is that no agent operating on layer 1 or 2 inputs and
+producing layer 1 or 2 outputs should ever have layer 3 material in its
+context window. The boundary between layer 2 and layer 3 is not a quality
+filter — it is an epistemological firewall.
+
+The `data_access_level` annotation in `SKILL.md` frontmatter maps to this
+model as follows:
+
+| Value | Layer | Meaning |
+|---|---|---|
+| `raw` | Layer 1 | Operates on unverified sources; must assume adversarial or hallucinated input |
+| `redacted` | Boundary 1→2 | Operates on sanitized material with no new raw ingestion |
+| `verified_only` | Layer 2 | Runs only after upstream integrity gates have been passed |
+
+No ARS skill operates on layer 3 inputs and produces layer 1 or 2 outputs.
+The reviewer skill holds a rubric, but that rubric is either a structural
+format guide (not an answer key) or a calibration gold set supplied by the
+human researcher at runtime. The paper-writing agent never reads the rubric
+before generating its candidate output.
+
+---
+
+## § 3 — Rules for adding a skill or agent
+
+Isolation is a design-time decision. The time to reason about data layer
+boundaries is before writing any agent prompt, not after a skill is already
+in use.
+
+**DO: Declare `data_access_level` truthfully.** The value must reflect the
+dirtiest input the skill may legitimately consume across all its modes. If one
+mode processes raw web search results and another processes verified artifacts,
+the skill's declared level is `raw`. The annotation exists so pipeline authors
+can reason about data-flow safety without reading every agent definition file.
+
+**DO: Separate rubric files from skill input bundles.** Use `*/rubrics/` for
+repo-tracked rubric files that describe output format or structural
+requirements — not answer keys, not expected content. For calibration gold
+sets, require the human researcher to supply a session file at runtime. Never
+bundle gold labels into the repository or reference them from `SKILL.md` in a
+way that loads them unconditionally.
+
+**DO: Pass scores back through a reviewer agent that holds the rubric
+privately.** The review workflow is: reviewer reads paper + rubric → reviewer
+produces natural-language feedback → paper-writing agent reads paper +
+feedback. The paper-writing agent's context must never contain the rubric text
+or the expected scoring outcome before it produces its candidate output. The
+two agents must be separate invocations, or separated by a stage boundary
+where the context window does not carry rubric content forward.
+
+**DON'T: Embed answer keys, scoring rubrics, or test-set labels in any file
+an agent reads as part of normal context loading.** This applies to `SKILL.md`
+frontmatter, agent definition files, reference files loaded unconditionally at
+session start, and any file an agent accesses as background material. If the
+file loads at session initialization, it is layer 1 or 2 material — not
+layer 3.
+
+**DON'T: Pass an evaluation prompt that includes the expected output to the
+same agent that produces the candidate output.** The "negative example"
+framing does not protect against this: models pattern-match toward examples
+regardless of polarity labeling.
+
+**DON'T: Use the same model session for both output generation and output
+scoring without stripping rubric content from the generating context.** A
+model that has seen rubric text in the conversation history will orient toward
+it during generation even without explicit instruction. Separate invocations,
+not just separate instructions, are required.
+
+---
+
+## § 4 — Today's implementation
+
+The isolation pattern is already instantiated across the ARS codebase through
+a set of narrowly scoped protocol files. This section is a navigational map —
+not a duplication of their contents.
+
+| Mechanism | Where it lives |
+|---|---|
+| Source verification (S2 API) | `deep-research/references/semantic_scholar_api_protocol.md` |
+| Anti-leakage protocol | `academic-paper/references/anti_leakage_protocol.md` |
+| Integrity gates (Stage 2.5/4.5) + 7-mode failure checklist | `academic-pipeline/references/ai_research_failure_modes.md` |
+| Reviewer calibration mode (FNR/FPR with private gold set) | `academic-paper-reviewer/references/calibration_mode_protocol.md` |
+| Cross-model verification | `shared/cross_model_verification.md` |
+| Declarative posture | `shared/handoff_schemas.md` (`data_access_level` and `task_type` sections) |
+
+This pattern document is the narrative rationale; those six reference files
+are the implementation detail. If a specific rule here conflicts with language
+in one of those files, the more specific file governs for that mechanism —
+and that conflict should be surfaced as an issue so this document can be
+updated.
+
+---
+
+## § 5 — What this pattern is NOT
+
+**Not a runtime permission system.** Nothing in ARS enforces isolation at
+execution time by blocking API calls, sandboxing the filesystem, or
+intercepting prompt construction. The mechanism is convention, declarative
+annotation, and CI lint via `scripts/check_data_access_level.py`. That script
+confirms every `SKILL.md` carries a valid annotation; it does not inspect
+context windows at runtime. A contributor who deliberately passes ground-truth
+material into a raw-layer skill's context can do so — the pattern is a design
+commitment and an audit surface, not a technical lock.
+
+**Not a substitute for human review at integrity gates.** Stage 2.5 and
+Stage 4.5 are the actual enforcement points in the pipeline. The human
+researcher reviews the integrity agent's reports and makes go/no-go decisions
+at each gate. This pattern document explains the design reasoning behind those
+gates and the data-flow structure that makes them meaningful. Reading this
+document does not grant confidence that any specific pipeline run was clean.
+Only a passed integrity gate with a verified Material Passport does that.
+
+**Not a benchmark protocol.** All current ARS skills are `task_type:
+open-ended` because ARS targets humanities research, higher-education quality
+assurance, and policy analysis — work whose quality depends on domain judgment
+and interpretive context that no scalar metric fully captures. This pattern
+keeps that posture honest by making it harder to accidentally introduce
+benchmark-style optimization into the pipeline. It does not provide
+infrastructure for running ARS outputs through automatic scoring against a
+held-out test set, and that gap is intentional.
+
+---
+
+## § 6 — Future evolution (intentionally out of scope)
+
+Version 3.3.2 ships the pattern document, the `data_access_level` annotation
+across all four top-level `SKILL.md` files, and the `task_type` annotation.
+The isolation pattern is fully stated at the declarative and documentation
+level. Several natural extensions are foreseeable but explicitly out of scope
+for this release: a server-side rubric endpoint that supplies evaluation
+criteria to reviewer agents without exposing them in the local context window
+(directly analogous to the RunPod tier in Anthropic's w2s sandbox); per-agent
+rather than per-skill access levels, allowing a multi-mode skill to tag
+individual agent definition files with the layer they operate on; runtime
+verification that the Material Passport's declared `data_access_level` chain
+is consistent with the actual handoff sequence before a consuming agent accepts
+an artifact; and automated detection of rubric or gold-label content appearing
+in a generating agent's context. These possibilities are listed here so future
+contributors do not propose them as overlooked features — they are deferred,
+not missing. If you want to pursue one, open an issue referencing this section
+before writing code, so the tradeoffs can be discussed before implementation
+begins.

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -640,3 +640,5 @@ Every top-level `SKILL.md` declares `metadata.task_type` with one of two values:
 This is a declarative truth-in-advertising signal. All current ARS skills are `open-ended` because ARS targets humanities/QA/policy work, not benchmark tasks. When adding a new skill, do not invent a third value; if the skill genuinely spans both, split it into two skills.
 
 Enforced by `scripts/check_task_type.py` in CI.
+
+See [`ground_truth_isolation_pattern.md`](ground_truth_isolation_pattern.md) for the rationale and rules behind this annotation.

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -629,3 +629,14 @@ Every top-level `SKILL.md` declares `metadata.data_access_level` with one of thr
 - `verified_only` — runs only after upstream integrity gates
 
 This is a declarative signal (not a runtime permission system). Enforced by `scripts/check_data_access_level.py` in CI. When adding a new skill, pick the value matching the *dirtiest* input the skill may legitimately consume.
+
+## `task_type` (v3.3.2+)
+
+Every top-level `SKILL.md` declares `metadata.task_type` with one of two values:
+
+- `outcome-gradable` — the task has an objective scalar metric the skill optimizes against; a third party can score the output without deep context
+- `open-ended` — the task's quality depends on domain judgment, interpretive work, or context no metric captures
+
+This is a declarative truth-in-advertising signal. All current ARS skills are `open-ended` because ARS targets humanities/QA/policy work, not benchmark tasks. When adding a new skill, do not invent a third value; if the skill genuinely spans both, split it into two skills.
+
+Enforced by `scripts/check_task_type.py` in CI.

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -619,3 +619,13 @@ See `shared/style_calibration_protocol.md` for full consumption rules and confli
 10. **Passport freshness**: A Material Passport's integrity results are considered STALE if `integrity_pass_date` is more than 24 hours old relative to the current timestamp. Stale passports require re-verification before proceeding
 11. **Stage-skip eligibility via passport**: A passport allows skipping Stage 2.5 (pre-review integrity) ONLY when ALL of the following conditions are met: (a) `verification_status` = `"VERIFIED"`, (b) `integrity_pass_date` is within the current session or less than 24 hours old, (c) `version_label` matches the current artifact version (content has not been modified since verification), and (d) the user explicitly confirms the skip. If any condition fails, full Stage 2.5 re-verification is required
 12. **Passport does not grant Stage 4.5 skip**: The final integrity check (Stage 4.5) can NEVER be skipped via Material Passport, regardless of passport status. Stage 4.5 always requires full Mode 2 verification
+
+## `data_access_level` (v3.3.2+)
+
+Every top-level `SKILL.md` declares `metadata.data_access_level` with one of three values:
+
+- `raw` — consumes unverified sources; must assume adversarial/hallucinated input
+- `redacted` — operates on sanitized material; no new raw ingestion
+- `verified_only` — runs only after upstream integrity gates
+
+This is a declarative signal (not a runtime permission system). Enforced by `scripts/check_data_access_level.py` in CI. When adding a new skill, pick the value matching the *dirtiest* input the skill may legitimately consume.


### PR DESCRIPTION
## Summary

Three stacked features for the v3.3.2 release, all stemming from a review of Anthropic's [automated-w2s-researcher (2026)](https://alignment.anthropic.com/2026/automated-w2s-researcher/) and the lessons it surfaces (and avoids).

- **`data_access_level`** — declarative three-tier (`raw` / `redacted` / `verified_only`) frontmatter on every SKILL.md. Mirrors the automated-w2s-researcher three-tier sandbox isolation. Enforced by `scripts/check_data_access_level.py` + CI.
- **`task_type`** — declarative two-value (`open-ended` / `outcome-gradable`) frontmatter. All ARS skills are `open-ended` — a truth-in-advertising signal that ARS is built for domain judgment, not benchmark optimization. Enforced by `scripts/check_task_type.py` + CI.
- **Ground-truth isolation pattern doc** — `shared/ground_truth_isolation_pattern.md` (229 lines, hub-style): explains the three-layer model (raw → verified → ground truth) behind both fields. Cross-references existing protocols (S2 verification, anti-leakage, integrity gates, calibration mode) instead of duplicating them. Linked from `handoff_schemas.md` and `CONTRIBUTING.md`.

20 commits, 18 files (+758/-33). All three lints + existing `check_spec_consistency.py` + 8 unit tests green.

## Per-skill posture (this PR)

| Skill | data_access_level | task_type |
|---|---|---|
| deep-research | raw | open-ended |
| academic-paper | redacted | open-ended |
| academic-paper-reviewer | verified_only | open-ended |
| academic-pipeline | verified_only | open-ended |

## Test plan

- [x] `python scripts/check_data_access_level.py` — exit 0
- [x] `python scripts/check_task_type.py` — exit 0
- [x] `python scripts/check_spec_consistency.py` — exit 0 (version pins + body Version Info blocks synced to v3.3.2)
- [x] `python -m unittest scripts.test_check_data_access_level scripts.test_check_task_type` — 8/8 pass
- [x] CI workflow `spec-consistency.yml` extended with both new lint steps

## Release notes

Drafted at `.local-plans/release-notes-v3.3.2.md` (local-only, gitignored). Tag + GitHub Release will be created after merge per the user's auto-push convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)