### PR TITLE
[codex] sync README changelog summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,22 @@ https://github.com/Imbad0202/academic-research-skills
 
 ## Changelog
 
+### v3.3.3 (2026-04-15) — Release Prep + Lint Hardening
+
+- Hardened SKILL frontmatter linting: missing closing `---` fences now fail cleanly instead of being parsed as valid YAML.
+- Frontmatter that parses as valid YAML but not as a mapping now reports a readable error instead of crashing.
+- Fixed the broken showcase link for the post-publication audit report in both READMEs.
+- Added README relative-link validation to the spec consistency check so dead links fail CI.
+- Aligned the DOCX output contract across the docs: direct `.docx` generation is Pandoc-dependent, with Markdown + conversion instructions as fallback.
+- Prepared the `v3.3.3` release: suite version bump, `academic-paper` -> v3.0.2, `academic-pipeline` -> v3.2.2.
+
+### v3.3.2 (2026-04-15) — Data Access Levels + Task Type Metadata
+
+- Added `metadata.data_access_level` to all top-level `SKILL.md` files with enforced vocabulary: `raw`, `redacted`, `verified_only`.
+- Added `metadata.task_type` to all top-level `SKILL.md` files with enforced vocabulary: `open-ended`, `outcome-gradable`.
+- Added lint scripts and unit tests for both metadata fields, wired into the GitHub Actions spec consistency workflow.
+- Added `shared/ground_truth_isolation_pattern.md` and linked the new vocabulary from `shared/handoff_schemas.md`.
+
 ### v3.3.1 (2026-04-14) — Spec Consistency Patch
 
 - Synced README, `.claude/CLAUDE.md`, `MODE_REGISTRY.md`, and `SKILL.md` files to the current mode counts and published skill versions.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -622,6 +622,22 @@ https://github.com/Imbad0202/academic-research-skills
 
 ## 更新紀錄
 
+### v3.3.3 (2026-04-15) — Release Prep + Lint 強化
+
+- 強化 SKILL frontmatter lint：缺少 closing `---` fence 時，現在會明確報錯，不再把整份檔案後半段誤當成合法 YAML。
+- frontmatter 若可被 YAML 解析但不是 mapping，現在會回報可讀錯誤，而不是直接 crash。
+- 修正中英文 README 中 post-publication audit showcase 連結失效的問題。
+- 在 spec consistency check 補上 README 相對連結驗證，之後 dead link 會直接讓 CI fail。
+- 將 DOCX 輸出契約在文件中統一：直接產出 `.docx` 依賴 Pandoc，否則回退為 Markdown + 轉換說明。
+- 完成 `v3.3.3` 發版準備：suite version bump，`academic-paper` -> v3.0.2，`academic-pipeline` -> v3.2.2。
+
+### v3.3.2 (2026-04-15) — Data Access Level + Task Type Metadata
+
+- 所有頂層 `SKILL.md` 新增 `metadata.data_access_level`，並以 `raw`、`redacted`、`verified_only` 為強制詞彙。
+- 所有頂層 `SKILL.md` 新增 `metadata.task_type`，並以 `open-ended`、`outcome-gradable` 為強制詞彙。
+- 為兩個 metadata 欄位新增 lint script 與單元測試，並接到 GitHub Actions spec consistency workflow。
+- 新增 `shared/ground_truth_isolation_pattern.md`，並在 `shared/handoff_schemas.md` 中補上對新詞彙的說明入口。
+
 ### v3.3.1 (2026-04-14) — 規格一致性修補
 
 - 同步 README、`.claude/CLAUDE.md`、`MODE_REGISTRY.md` 與各 `SKILL.md` 的 mode 數量與公開版本標示。

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -138,6 +138,8 @@ def check_readme_sections() -> None:
 
     expect_contains(rel_path, "version-v3.3.3-blue")
     expect_contains(rel_path, "releases/tag/v3.3.3")
+    expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
+    expect_contains(rel_path, "### v3.3.2 (2026-04-15)")
     for heading in (
         "#### Deep Research (7 modes)",
         "#### Academic Paper (10 modes)",
@@ -194,6 +196,8 @@ def check_readme_zh_sections() -> None:
 
     expect_contains(rel_path, "version-v3.3.3-blue")
     expect_contains(rel_path, "releases/tag/v3.3.3")
+    expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
+    expect_contains(rel_path, "### v3.3.2 (2026-04-15)")
     for heading in (
         "#### Deep Research（深度研究，7 種模式）",
         "#### Academic Paper（學術論文撰寫，10 種模式）",


### PR DESCRIPTION
## Summary
- add `v3.3.3` and `v3.3.2` entries to the embedded changelog sections in both `README.md` and `README.zh-TW.md`
- extend `scripts/check_spec_consistency.py` so future README changelog drift is caught in CI

## Why
The release metadata had already been updated to `v3.3.3`, but the changelog summaries embedded in the READMEs still stopped at `v3.3.1`.

## Validation
- `python scripts/check_spec_consistency.py`