### PR TITLE
docs: align repo metadata with v3.3.4 release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,7 +80,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.3.3 (per CHANGELOG.md)
+- **Suite version**: 3.3.4 (per CHANGELOG.md)
 - **Last Updated**: 2026-04-15
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.3.4] - 2026-04-15
+
+### Fixed
+- Embedded changelog sections in `README.md` and `README.zh-TW.md` now include the missing `v3.3.3` and `v3.3.2` summaries, so the README history matches the published releases.
+- `scripts/check_spec_consistency.py` now verifies that the README changelog summaries include the latest release entries, so future drift fails CI.
+
+### Changed
+- Suite version bumped to `3.3.4` across release-facing docs after the README changelog sync patch release.
+
 ## [3.3.3] - 2026-04-15
 
 ### Fixed

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **24 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.3.3 (2026-04-15)
+Last updated: v3.3.4 (2026-04-15)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.3-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.3)
+[![Version](https://img.shields.io/badge/version-v3.3.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.4)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -651,6 +651,10 @@ https://github.com/Imbad0202/academic-research-skills
 
 ## Changelog
 
+### v3.3.4 (2026-04-15) — README Changelog Sync Patch
+
+- Synced the embedded changelog sections in `README.md` and `README.zh-TW.md` so they include the missing `v3.3.3` and `v3.3.2` release summaries.
+- Extended `scripts/check_spec_consistency.py` so future README changelog drift fails CI.
 ### v3.3.3 (2026-04-15) — Release Prep + Lint Hardening
 
 - Hardened SKILL frontmatter linting: missing closing `---` fences now fail cleanly instead of being parsed as valid YAML.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.3-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.3)
+[![Version](https://img.shields.io/badge/version-v3.3.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.4)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -622,6 +622,10 @@ https://github.com/Imbad0202/academic-research-skills
 
 ## 更新紀錄
 
+### v3.3.4 (2026-04-15) — README 更新紀錄同步修補
+
+- 同步 `README.md` 與 `README.zh-TW.md` 內嵌的 changelog 區塊，補上原本缺漏的 `v3.3.3` 與 `v3.3.2` 發版摘要。
+- 擴充 `scripts/check_spec_consistency.py`，之後 README changelog 若再漂移，CI 會直接 fail。
 ### v3.3.3 (2026-04-15) — Release Prep + Lint 強化
 
 - 強化 SKILL frontmatter lint：缺少 closing `---` fence 時，現在會明確報錯，不再把整份檔案後半段誤當成合法 YAML。

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.3.3 (2026-04-15)")
+    expect_contains(rel_path, "Last updated: v3.3.4 (2026-04-15)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.3.3")
+    expect_contains(rel_path, "**Suite version**: 3.3.4")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.3-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.3")
+    expect_contains(rel_path, "version-v3.3.4-blue")
+    expect_contains(rel_path, "releases/tag/v3.3.4")
+    expect_contains(rel_path, "### v3.3.4 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.2 (2026-04-15)")
     for heading in (
@@ -194,8 +195,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.3-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.3")
+    expect_contains(rel_path, "version-v3.3.4-blue")
+    expect_contains(rel_path, "releases/tag/v3.3.4")
+    expect_contains(rel_path, "### v3.3.4 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.2 (2026-04-15)")
     for heading in (


### PR DESCRIPTION
## Summary
- sync README badge/link and embedded changelog summaries with the published `v3.3.4` release
- add a `3.3.4` entry to `CHANGELOG.md` and update release-facing version metadata
- extend `scripts/check_spec_consistency.py` so future README changelog drift fails CI

## Validation
- `python scripts/check_spec_consistency.py`