### PR TITLE
feat: benchmark report schema + artifact reproducibility lockfile (v3.3.5)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,7 +80,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.3.4 (per CHANGELOG.md)
+- **Suite version**: 3.3.5 (per CHANGELOG.md)
 - **Last Updated**: 2026-04-15
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
-          cache-dependency-path: scripts/_skill_lint.py
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install lint dependencies
-        run: pip install pyyaml
+        run: pip install -r requirements-dev.txt
 
       - name: Run spec consistency check
         run: python3 scripts/check_spec_consistency.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.3.5] - 2026-04-15
+
+### Added
+- `shared/benchmark_report.schema.json` — JSON Schema (draft-2020-12) defining required fields for ARS benchmark reports. Catches the "n=2 author-conducted baseline" failure mode from Anthropic's automated-w2s-researcher paper.
+- `shared/benchmark_report_pattern.md` — narrative hub doc explaining the schema.
+- `scripts/check_benchmark_report.py` + tests — validator with self-scored and small-sample warnings.
+- `examples/benchmark_report_template.json` — fillable template.
+- `repro_lock` optional sub-block added to Material Passport (Schema 9 in `shared/handoff_schemas.md`). Configuration lockfile; NOT a deterministic replay guarantee.
+- `shared/artifact_reproducibility_pattern.md` — hub doc with mandatory "not a replay guarantee" disclaimer section and required `stochasticity_declaration` field.
+- `scripts/check_repro_lock.py` + tests — passport validator.
+- `examples/passport_with_repro_lock.yaml` — example.
+- `requirements-dev.txt` — formal Python dev dep manifest (pyyaml + jsonschema).
+
+### Changed
+- `.github/workflows/spec-consistency.yml` installs via `pip install -r requirements-dev.txt` instead of ad-hoc `pip install`.
+- `academic-pipeline/references/reproducibility_audit.md` cross-links to new artifact-reproducibility pattern.
+
 ## [3.3.4] - 2026-04-15
 
 ### Fixed

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **24 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.3.4 (2026-04-15)
+Last updated: v3.3.5 (2026-04-15)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.4)
+[![Version](https://img.shields.io/badge/version-v3.3.5-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.5)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -48,6 +48,8 @@ v3.3 was inspired by [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Son
 - **Academic Pipeline** — Full 10-stage pipeline orchestrator with adaptive checkpoints, claim verification, material passport, **optional cross-model integrity verification**, **mid-conversation reinforcement**, **self-check questions**, and **score trajectory tracking**
 - **Data Access Level Metadata** (v3.3.2+) — Every skill declares a `data_access_level` (`raw`, `redacted`, or `verified_only`) so pipelines and CI can reason about isolation boundaries. Enforced by `scripts/check_data_access_level.py`. Pattern adapted from Anthropic's automated-w2s-researcher (2026).
 - **Task Type Annotation** (v3.3.2+) — Every skill declares a `task_type` (`open-ended` or `outcome-gradable`). All current ARS skills are `open-ended`: a truth-in-advertising signal that ARS targets domain-judgment work, not benchmark tasks. Enforced by `scripts/check_task_type.py`.
+- **Benchmark Report Schema** (v3.3.5+) — JSON Schema + lint for honest benchmark comparisons. Catches n=2-author-conducted, self-scored, empty-caveats failure modes. See [`shared/benchmark_report_pattern.md`](shared/benchmark_report_pattern.md).
+- **Artifact Reproducibility Lockfile** (v3.3.5+) — Optional `repro_lock` sub-block on Material Passport capturing model family, ARS version, prompt/material hashes. **Configuration documentation, not replay guarantee** — LLM outputs are not byte-reproducible. See [`shared/artifact_reproducibility_pattern.md`](shared/artifact_reproducibility_pattern.md).
 
 ### Skill posture (v3.3.2+)
 
@@ -650,6 +652,9 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.3.5 (2026-04-15)
+- Added `benchmark_report.schema.json` + `repro_lock` optional block on Material Passport. Both ship with pattern docs, lints, and examples. First formal Python dev dep manifest (`requirements-dev.txt`).
 
 ### v3.3.4 (2026-04-15) — README Changelog Sync Patch
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.4)
+[![Version](https://img.shields.io/badge/version-v3.3.5-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.5)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -49,6 +49,8 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 - **Academic Pipeline** — 10 階段全流程調度器，含自適應 checkpoint、宣稱驗證、素材護照、**可選跨模型誠信驗證**、**中途強化機制**、**自我檢查問題**、**分數軌跡追蹤**
 - **資料存取層級標註**（v3.3.2+）— 每個 skill 在 frontmatter 宣告 `data_access_level`（`raw`、`redacted`、`verified_only`），讓 pipeline 與 CI 能對隔離邊界做靜態檢查。由 `scripts/check_data_access_level.py` 強制執行。設計靈感來自 Anthropic 的 automated-w2s-researcher（2026）的三層隔離模式。
 - **任務類型標註**（v3.3.2+）— 每個 skill 宣告 `task_type`（`open-ended` 或 `outcome-gradable`）。目前 ARS 所有 skills 皆為 `open-ended`：誠信標示，明確告訴使用者 ARS 適用於需要領域判斷的工作，而非可量化的 benchmark 任務。由 `scripts/check_task_type.py` 強制執行。
+- **Benchmark 報告 Schema**（v3.3.5+）— JSON Schema + lint script，要求誠實的 benchmark 比較報告。擋掉 n=2 作者自測、self-scored、空 caveats 等失敗模式。詳見 [`shared/benchmark_report_pattern.md`](shared/benchmark_report_pattern.md)。
+- **Artifact 可重現性 Lockfile**（v3.3.5+）— Material Passport 新增可選 `repro_lock` 子區塊，記錄 model 家族、ARS 版本、prompt/material hash。**是設定文件化，不是重播保證** — LLM 輸出不是位元可重現。詳見 [`shared/artifact_reproducibility_pattern.md`](shared/artifact_reproducibility_pattern.md)。
 
 ### Skill 屬性一覽（v3.3.2+）
 
@@ -621,6 +623,9 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.3.5 (2026-04-15)
+- 新增 `benchmark_report.schema.json` 與 Material Passport 的 `repro_lock` 可選區塊。兩者都附 pattern 文件、lint、範例。首次引入正式的 Python 開發依賴清單（`requirements-dev.txt`）。
 
 ### v3.3.4 (2026-04-15) — README 更新紀錄同步修補
 

--- a/academic-pipeline/references/reproducibility_audit.md
+++ b/academic-pipeline/references/reproducibility_audit.md
@@ -40,3 +40,15 @@ Integrity Summary:
   Final: [X] refs checked, [Y] issues found, [Y] fixed
   Overall: [CLEAN / ISSUES NOTED]
 ```
+
+## Computational reproducibility (v3.3.5+)
+
+This document defines PROCESS reproducibility — consistent stages, fixed reviewer angles,
+explicit pass/fail thresholds. That's one of two meanings of "reproducible."
+
+The other is COMPUTATIONAL re-run — could a third party re-execute the same pipeline and
+produce the same (or near-same) output? For that, see [`../../shared/artifact_reproducibility_pattern.md`](../../shared/artifact_reproducibility_pattern.md).
+
+Process reproducibility is enforced at the pipeline level. Computational documentation is
+captured in the Material Passport's optional `repro_lock` sub-block. Both are complementary;
+neither replaces the other.

--- a/examples/benchmark_report_template.json
+++ b/examples/benchmark_report_template.json
@@ -1,0 +1,29 @@
+{
+  "ars_version": "3.3.5",
+  "task_definition": {
+    "description": "FILL IN: one-sentence description of the task",
+    "task_type": "open-ended",
+    "outcome_gradable": false
+  },
+  "human_baseline": {
+    "sample_size": 0,
+    "author_independence": "author-conducted",
+    "hours_spent": 0,
+    "recruitment": "FILL IN: how participants were recruited",
+    "tools_allowed": ["FILL IN: list of tools"]
+  },
+  "ars_run": {
+    "hours_spent": 0,
+    "cost_usd": 0,
+    "skills_used": ["academic-pipeline"],
+    "data_access_level_declared": "raw"
+  },
+  "metrics": {
+    "primary_metric": "FILL IN: metric name",
+    "primary_metric_value": 0,
+    "scoring_independence": "authors-scored"
+  },
+  "caveats": [
+    "FILL IN: at least one known limitation"
+  ]
+}

--- a/examples/passport_with_repro_lock.yaml
+++ b/examples/passport_with_repro_lock.yaml
@@ -1,0 +1,39 @@
+# Example Material Passport with populated repro_lock block.
+# Validates with `python scripts/check_repro_lock.py examples/passport_with_repro_lock.yaml`.
+
+origin_skill: deep-research
+origin_mode: full
+origin_date: "2026-04-15T10:00:00Z"
+verification_status: VERIFIED
+version_label: "v1.0"
+integrity_pass_date: "2026-04-15T10:15:00Z"
+content_hash: "sha256:a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd"
+
+repro_lock:
+  schema_version: "1.0"
+
+  stochasticity_declaration: "LLM outputs are not byte-reproducible. This lockfile documents configuration, not a deterministic replay guarantee."
+
+  ars_version: "3.3.5"
+
+  model:
+    family: claude
+    id: claude-opus-4-6
+    weight_stable: false
+
+  prompts:
+    hash_timing: skill-load
+    skill_md_hash: "sha256:b2c3d4e5f6789012345678901234567890123456789012345678901234abcd01"
+    agents_bundle_hash: "sha256:c3d4e5f6789012345678901234567890123456789012345678901234abcd0123"
+
+  materials:
+    list_hash: "sha256:d4e5f6789012345678901234567890123456789012345678901234abcd012345"
+    count: 8
+
+  external_protocols:
+    s2_api_protocol_version: "3.3"
+    s2_snapshot_available: false
+
+  cross_model:
+    enabled: false
+    secondary_model_id: null

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pyyaml
+jsonschema

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pyyaml
-jsonschema
+jsonschema>=4.17

--- a/scripts/_test_helpers.py
+++ b/scripts/_test_helpers.py
@@ -1,0 +1,42 @@
+"""Shared helpers for script unit tests.
+
+Avoid duplicating subprocess.run boilerplate across multiple test files.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_script(
+    script_path: Path,
+    *args: str,
+    cwd: Path | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke a script via subprocess, capturing stdout/stderr as text.
+
+    extra_env values are merged into os.environ (not replaced).
+    """
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(script_path), *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+
+
+def run_skill_linter(script_path: Path, root: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke a SKILL.md linter (--path arg + PYTHONPATH=scripts/)."""
+    return run_script(
+        script_path,
+        "--path",
+        str(root),
+        extra_env={"PYTHONPATH": str(script_path.parent)},
+    )

--- a/scripts/check_benchmark_report.py
+++ b/scripts/check_benchmark_report.py
@@ -61,7 +61,11 @@ def main() -> int:
     if errors:
         for e in errors:
             print(f"ERROR: {e}")
-        print(f"\n{len(errors)} schema violation(s).", file=sys.stderr)
+        print(
+            f"\n{len(errors)} schema violation(s). "
+            f"See shared/benchmark_report_pattern.md for field rationale.",
+            file=sys.stderr,
+        )
         return 1
 
     for w in warn_self_scored(report):

--- a/scripts/check_benchmark_report.py
+++ b/scripts/check_benchmark_report.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate an ARS benchmark report against benchmark_report.schema.json.
+
+Usage: python scripts/check_benchmark_report.py path/to/report.json
+
+Exit 0 on pass (warnings may still be printed to stderr).
+Exit 1 on validation failure.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "shared" / "benchmark_report.schema.json"
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def validate(report: dict) -> list[str]:
+    schema = load_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    return [f"{list(e.absolute_path)}: {e.message}" for e in validator.iter_errors(report)]
+
+
+def warn_self_scored(report: dict) -> list[str]:
+    warnings = []
+    scoring = report.get("metrics", {}).get("scoring_independence")
+    if scoring == "self-scored":
+        warnings.append(
+            "WARNING: metrics.scoring_independence = 'self-scored'. "
+            "Self-scoring is permitted but a known reward-hacking risk. "
+            "Consider blind-scored or third-party-scored instead."
+        )
+    sample = report.get("human_baseline", {}).get("sample_size", 0)
+    if isinstance(sample, int) and 1 <= sample <= 2:
+        warnings.append(
+            f"WARNING: human_baseline.sample_size = {sample}. "
+            "n<=2 is dramatic, not statistical. Consider n>=5 or explicit disclosure in caveats."
+        )
+    return warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="Path to the benchmark report JSON")
+    args = parser.parse_args()
+
+    try:
+        report = json.loads(args.report.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"ERROR: failed to load {args.report}: {exc}")
+        return 1
+
+    errors = validate(report)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}")
+        print(f"\n{len(errors)} schema violation(s).", file=sys.stderr)
+        return 1
+
+    for w in warn_self_scored(report):
+        print(w, file=sys.stderr)
+
+    print("OK: benchmark report validates.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_repro_lock.py
+++ b/scripts/check_repro_lock.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import yaml
 
 SUPPORTED_SCHEMA_VERSIONS = {"1.0"}
+SUPPORTED_HASH_TIMINGS = {"skill-load"}
 
 REQUIRED_FIELDS = {
     "schema_version",
@@ -67,9 +68,10 @@ def validate_block(lock: dict) -> list[str]:
     prompts = lock.get("prompts")
     if isinstance(prompts, dict):
         ht = prompts.get("hash_timing")
-        if ht is not None and ht != "skill-load":
+        if ht is not None and ht not in SUPPORTED_HASH_TIMINGS:
             errors.append(
-                f"repro_lock.prompts.hash_timing = {ht!r}, must be 'skill-load' (only supported value in v1.0)"
+                f"repro_lock.prompts.hash_timing = {ht!r}, "
+                f"must be one of {sorted(SUPPORTED_HASH_TIMINGS)} (see shared/artifact_reproducibility_pattern.md)"
             )
 
     return errors

--- a/scripts/check_repro_lock.py
+++ b/scripts/check_repro_lock.py
@@ -110,7 +110,11 @@ def main() -> int:
     if errors:
         for e in errors:
             print(f"ERROR: {e}")
-        print(f"\n{len(errors)} violation(s).", file=sys.stderr)
+        print(
+            f"\n{len(errors)} violation(s). "
+            f"See shared/artifact_reproducibility_pattern.md for required fields.",
+            file=sys.stderr,
+        )
         return 1
 
     print("OK: passport repro_lock is valid.")

--- a/scripts/check_repro_lock.py
+++ b/scripts/check_repro_lock.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Validate a Material Passport YAML's `repro_lock` sub-block.
+
+Usage: python scripts/check_repro_lock.py path/to/passport.yaml
+
+- Missing `repro_lock` key (not even null): ERROR, exit 1.
+- `repro_lock: null`: WARN, exit 0 (honest opt-out).
+- Populated block with all required sub-fields: OK, exit 0.
+- Populated block with missing sub-field or unknown schema_version: ERROR, exit 1.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+SUPPORTED_SCHEMA_VERSIONS = {"1.0"}
+
+REQUIRED_FIELDS = {
+    "schema_version",
+    "stochasticity_declaration",
+    "ars_version",
+    "model",
+    "prompts",
+    "materials",
+    "external_protocols",
+    "cross_model",
+}
+
+REQUIRED_MODEL = {"family", "id", "weight_stable"}
+REQUIRED_PROMPTS = {"hash_timing", "skill_md_hash", "agents_bundle_hash"}
+REQUIRED_MATERIALS = {"list_hash", "count"}
+REQUIRED_EXTERNAL = {"s2_api_protocol_version", "s2_snapshot_available"}
+REQUIRED_CROSSMODEL = {"enabled", "secondary_model_id"}
+
+
+def validate_block(lock: dict) -> list[str]:
+    errors = []
+
+    missing = REQUIRED_FIELDS - set(lock.keys())
+    for m in sorted(missing):
+        errors.append(f"repro_lock: missing required field '{m}'")
+
+    sv = lock.get("schema_version")
+    if sv is not None and sv not in SUPPORTED_SCHEMA_VERSIONS:
+        errors.append(
+            f"repro_lock.schema_version = {sv!r}, must be one of {sorted(SUPPORTED_SCHEMA_VERSIONS)}"
+        )
+
+    for name, required, sub in [
+        ("model", REQUIRED_MODEL, lock.get("model")),
+        ("prompts", REQUIRED_PROMPTS, lock.get("prompts")),
+        ("materials", REQUIRED_MATERIALS, lock.get("materials")),
+        ("external_protocols", REQUIRED_EXTERNAL, lock.get("external_protocols")),
+        ("cross_model", REQUIRED_CROSSMODEL, lock.get("cross_model")),
+    ]:
+        if sub is None:
+            continue  # missing top-level already reported
+        if not isinstance(sub, dict):
+            errors.append(f"repro_lock.{name} must be a mapping")
+            continue
+        for m in sorted(required - set(sub.keys())):
+            errors.append(f"repro_lock.{name}: missing required field '{m}'")
+
+    prompts = lock.get("prompts")
+    if isinstance(prompts, dict):
+        ht = prompts.get("hash_timing")
+        if ht is not None and ht != "skill-load":
+            errors.append(
+                f"repro_lock.prompts.hash_timing = {ht!r}, must be 'skill-load' (only supported value in v1.0)"
+            )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("passport", type=Path)
+    args = parser.parse_args()
+
+    try:
+        doc = yaml.safe_load(args.passport.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"ERROR: failed to load {args.passport}: {exc}")
+        return 1
+
+    if not isinstance(doc, dict):
+        print(f"ERROR: {args.passport}: top-level must be a mapping")
+        return 1
+
+    if "repro_lock" not in doc:
+        print("ERROR: repro_lock key is missing. Set 'repro_lock: null' to opt out explicitly.")
+        return 1
+
+    lock = doc["repro_lock"]
+    if lock is None:
+        print("WARN: repro_lock is null — honest opt-out. Reproducibility reduced.", file=sys.stderr)
+        print("OK: passport is valid (repro_lock explicitly null).")
+        return 0
+
+    if not isinstance(lock, dict):
+        print(f"ERROR: repro_lock must be null or a mapping, got {type(lock).__name__}")
+        return 1
+
+    errors = validate_block(lock)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}")
+        print(f"\n{len(errors)} violation(s).", file=sys.stderr)
+        return 1
+
+    print("OK: passport repro_lock is valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_repro_lock.py
+++ b/scripts/check_repro_lock.py
@@ -99,7 +99,7 @@ def main() -> int:
     lock = doc["repro_lock"]
     if lock is None:
         print("WARN: repro_lock is null — honest opt-out. Reproducibility reduced.", file=sys.stderr)
-        print("OK: passport is valid (repro_lock explicitly null).")
+        print("OK (with WARN): passport valid; repro_lock explicitly null — see stderr.", flush=True)
         return 0
 
     if not isinstance(lock, dict):

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.3.4 (2026-04-15)")
+    expect_contains(rel_path, "Last updated: v3.3.5 (2026-04-15)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.3.4")
+    expect_contains(rel_path, "**Suite version**: 3.3.5")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.4-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.4")
+    expect_contains(rel_path, "version-v3.3.5-blue")
+    expect_contains(rel_path, "releases/tag/v3.3.5")
+    expect_contains(rel_path, "### v3.3.5 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.4 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.2 (2026-04-15)")
@@ -195,8 +196,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.4-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.4")
+    expect_contains(rel_path, "version-v3.3.5-blue")
+    expect_contains(rel_path, "releases/tag/v3.3.5")
+    expect_contains(rel_path, "### v3.3.5 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.4 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.2 (2026-04-15)")

--- a/scripts/test_check_benchmark_report.py
+++ b/scripts/test_check_benchmark_report.py
@@ -105,6 +105,16 @@ class TestBenchmarkReport(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
             self.assertIn("self-scored", result.stderr.lower() + result.stdout.lower())
 
+    def test_empty_tools_allowed_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            r = _valid_report()
+            r["human_baseline"]["tools_allowed"] = []
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(r))
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("tools_allowed", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_benchmark_report.py
+++ b/scripts/test_check_benchmark_report.py
@@ -1,10 +1,11 @@
 """Unit tests for check_benchmark_report.py."""
 import json
 import subprocess
-import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
 
 SCRIPT = Path(__file__).resolve().parent / "check_benchmark_report.py"
 SCHEMA = Path(__file__).resolve().parent.parent / "shared" / "benchmark_report.schema.json"
@@ -41,11 +42,7 @@ def _valid_report() -> dict:
 
 
 def _run(path: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), str(path)],
-        capture_output=True,
-        text=True,
-    )
+    return run_script(SCRIPT, str(path))
 
 
 class TestBenchmarkReport(unittest.TestCase):

--- a/scripts/test_check_benchmark_report.py
+++ b/scripts/test_check_benchmark_report.py
@@ -1,0 +1,110 @@
+"""Unit tests for check_benchmark_report.py."""
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+SCRIPT = Path(__file__).resolve().parent / "check_benchmark_report.py"
+SCHEMA = Path(__file__).resolve().parent.parent / "shared" / "benchmark_report.schema.json"
+
+
+def _valid_report() -> dict:
+    return {
+        "ars_version": "3.3.5",
+        "task_definition": {
+            "description": "Literature review on X",
+            "task_type": "open-ended",
+            "outcome_gradable": False,
+        },
+        "human_baseline": {
+            "sample_size": 3,
+            "author_independence": "third-party-conducted",
+            "hours_spent": 20,
+            "recruitment": "Posted on university mailing list",
+            "tools_allowed": ["Google Scholar", "Zotero"],
+        },
+        "ars_run": {
+            "hours_spent": 4,
+            "cost_usd": 15.20,
+            "skills_used": ["deep-research", "academic-paper"],
+            "data_access_level_declared": "raw",
+        },
+        "metrics": {
+            "primary_metric": "rubric_score_0_100",
+            "primary_metric_value": 72,
+            "scoring_independence": "blind-scored",
+        },
+        "caveats": ["Small baseline sample; single task type"],
+    }
+
+
+def _run(path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestBenchmarkReport(unittest.TestCase):
+    def test_valid_report_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(_valid_report()))
+            result = _run(p)
+            self.assertEqual(result.returncode, 0, msg=result.stderr + result.stdout)
+
+    def test_missing_sample_size_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            r = _valid_report()
+            del r["human_baseline"]["sample_size"]
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(r))
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("sample_size", result.stdout)
+
+    def test_zero_sample_size_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            r = _valid_report()
+            r["human_baseline"]["sample_size"] = 0
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(r))
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_empty_caveats_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            r = _valid_report()
+            r["caveats"] = []
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(r))
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("caveats", result.stdout)
+
+    def test_invalid_author_independence_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            r = _valid_report()
+            r["human_baseline"]["author_independence"] = "unspecified"
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(r))
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_self_scored_passes_with_warning(self) -> None:
+        with TemporaryDirectory() as tmp:
+            r = _valid_report()
+            r["metrics"]["scoring_independence"] = "self-scored"
+            p = Path(tmp) / "r.json"
+            p.write_text(json.dumps(r))
+            result = _run(p)
+            # Schema permits; script emits warning to stderr, exits 0.
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("self-scored", result.stderr.lower() + result.stdout.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_data_access_level.py
+++ b/scripts/test_check_data_access_level.py
@@ -1,26 +1,17 @@
 """Unit tests for check_data_access_level.py lint script."""
-import os
 import subprocess
-import sys
 import textwrap
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from scripts._test_helpers import run_skill_linter
+
 SCRIPT = Path(__file__).resolve().parent / "check_data_access_level.py"
 
 
 def _run(root: Path) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(SCRIPT.parent) + (
-        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
-    )
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), "--path", str(root)],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    return run_skill_linter(SCRIPT, root)
 
 
 def _write_skill(root: Path, name: str, frontmatter_body: str) -> None:

--- a/scripts/test_check_repro_lock.py
+++ b/scripts/test_check_repro_lock.py
@@ -1,0 +1,108 @@
+"""Unit tests for check_repro_lock.py."""
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import textwrap
+
+SCRIPT = Path(__file__).resolve().parent / "check_repro_lock.py"
+
+
+def _run(path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _valid_passport_yaml() -> str:
+    return textwrap.dedent("""\
+        origin_skill: deep-research
+        origin_mode: full
+        origin_date: "2026-04-15T10:00:00Z"
+        verification_status: VERIFIED
+        version_label: "v1.0"
+        repro_lock:
+          schema_version: "1.0"
+          stochasticity_declaration: "LLM outputs are not byte-reproducible. This lockfile documents configuration, not a deterministic replay guarantee."
+          ars_version: "3.3.5"
+          model:
+            family: claude
+            id: claude-opus-4-6
+            weight_stable: false
+          prompts:
+            hash_timing: skill-load
+            skill_md_hash: "sha256:abc123"
+            agents_bundle_hash: "sha256:def456"
+          materials:
+            list_hash: "sha256:ghi789"
+            count: 12
+          external_protocols:
+            s2_api_protocol_version: "3.3"
+            s2_snapshot_available: false
+          cross_model:
+            enabled: false
+            secondary_model_id: null
+        """)
+
+
+class TestReproLock(unittest.TestCase):
+    def test_valid_block_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "passport.yaml"
+            p.write_text(_valid_passport_yaml())
+            result = _run(p)
+            self.assertEqual(result.returncode, 0, msg=result.stderr + result.stdout)
+
+    def test_null_repro_lock_passes_with_warning(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "passport.yaml"
+            y = _valid_passport_yaml().split("repro_lock:")[0] + "repro_lock: null\n"
+            p.write_text(y)
+            result = _run(p)
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("WARN", result.stdout + result.stderr)
+
+    def test_missing_key_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "passport.yaml"
+            y = _valid_passport_yaml().split("repro_lock:")[0]  # strip the key entirely
+            p.write_text(y)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("repro_lock", result.stdout)
+
+    def test_missing_subfield_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "passport.yaml"
+            y = _valid_passport_yaml().replace('ars_version: "3.3.5"\n  ', '')
+            p.write_text(y)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("ars_version", result.stdout)
+
+    def test_unknown_schema_version_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "passport.yaml"
+            y = _valid_passport_yaml().replace('schema_version: "1.0"', 'schema_version: "9.9"')
+            p.write_text(y)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("schema_version", result.stdout)
+
+    def test_missing_stochasticity_declaration_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "passport.yaml"
+            y = _valid_passport_yaml()
+            # Remove the stochasticity_declaration line
+            lines = [l for l in y.splitlines() if "stochasticity_declaration" not in l]
+            p.write_text("\n".join(lines) + "\n")
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("stochasticity_declaration", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_repro_lock.py
+++ b/scripts/test_check_repro_lock.py
@@ -1,20 +1,17 @@
 """Unit tests for check_repro_lock.py."""
 import subprocess
-import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import textwrap
 
+from scripts._test_helpers import run_script
+
 SCRIPT = Path(__file__).resolve().parent / "check_repro_lock.py"
 
 
 def _run(path: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), str(path)],
-        capture_output=True,
-        text=True,
-    )
+    return run_script(SCRIPT, str(path))
 
 
 def _valid_passport_yaml() -> str:

--- a/scripts/test_check_repro_lock.py
+++ b/scripts/test_check_repro_lock.py
@@ -63,7 +63,9 @@ class TestReproLock(unittest.TestCase):
             p.write_text(y)
             result = _run(p)
             self.assertEqual(result.returncode, 0)
-            self.assertIn("WARN", result.stdout + result.stderr)
+            # WARN signal must reach at least stderr; stdout OK line also mentions WARN
+            self.assertIn("WARN", result.stderr)
+            self.assertIn("with WARN", result.stdout)
 
     def test_missing_key_fails(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/scripts/test_check_task_type.py
+++ b/scripts/test_check_task_type.py
@@ -1,27 +1,18 @@
 # scripts/test_check_task_type.py
 """Unit tests for check_task_type.py lint script."""
-import os
 import subprocess
-import sys
 import textwrap
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from scripts._test_helpers import run_skill_linter
+
 SCRIPT = Path(__file__).resolve().parent / "check_task_type.py"
 
 
 def _run(root: Path) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(SCRIPT.parent) + (
-        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
-    )
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), "--path", str(root)],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    return run_skill_linter(SCRIPT, root)
 
 
 def _write_skill(root: Path, name: str, frontmatter_body: str) -> None:

--- a/shared/artifact_reproducibility_pattern.md
+++ b/shared/artifact_reproducibility_pattern.md
@@ -1,0 +1,173 @@
+# Artifact Reproducibility Pattern (v3.3.5+)
+
+## Why this exists
+
+ARS produces research artifacts — draft papers, literature reviews, review reports. A year
+from now, you may want to reproduce one. Today's Material Passport (Schema 9) captures WHO
+produced the artifact and WHEN, but not WITH WHAT. Which LLM? Which ARS version? Which
+skill files? Which session materials?
+
+The `repro_lock` sub-block fills that gap.
+
+When the Anthropic automated-w2s-researcher paper (2026) claimed "2 researchers × 7 days
+vs 9 agents × 5 days," readers had no way to audit the conditions. This pattern ensures
+that ARS-produced artifacts carry their configuration on record — not as a replay mechanism,
+but as an honest documentation trail.
+
+## What this pattern IS NOT (read this first)
+
+This is non-negotiable. Every future user MUST read this section before assuming the lock
+guarantees anything it does not.
+
+1. **LLM outputs are not byte-reproducible even at temperature 0.** Model providers update
+   weights without changing the model id. `model.weight_stable: false` acknowledges this
+   explicitly. `model.id` is an identifier, not a weight hash.
+
+2. **Live external API queries are recorded as protocol versions, not snapshots.** The S2
+   API changes daily. A paper citing DOI 10.1000/x today may return different metadata
+   tomorrow. `s2_api_protocol_version` records which VERSION of our query logic ran, not
+   a snapshot of the response.
+
+3. **Mid-skill prompt mutations are not captured.** `prompts.hash_timing: "skill-load"` is
+   a declaration: hashes are taken when the skill loads, not per agent call. Late injection
+   of user-provided reference files, conditional branches, and dynamic prompt modifications
+   are NOT reflected in the hash. This is a known imprecision.
+
+4. **`stochasticity_declaration` is required, not optional.** Omitting it makes the lock
+   dishonest by implication. Every generated passport includes the declaration verbatim.
+
+If you want deterministic replay, you are reading the wrong pattern. This pattern gives
+you CONFIGURATION DOCUMENTATION sufficient to INVESTIGATE divergence — not to PREVENT it.
+
+## The block at a glance
+
+```yaml
+repro_lock:
+  schema_version: "1.0"                    # lock schema version
+  stochasticity_declaration: "LLM outputs are not byte-reproducible. This lockfile documents configuration, not a deterministic replay guarantee."
+  ars_version: "3.3.5"                     # suite version at run time
+
+  model:
+    family: claude                          # provider family
+    id: claude-opus-4-6                    # model identifier (not weight hash)
+    weight_stable: false                    # always false until signed attestation exists
+
+  prompts:
+    hash_timing: skill-load                 # when hashes were taken
+    skill_md_hash: "sha256:..."            # hash of the skill SKILL.md file
+    agents_bundle_hash: "sha256:..."       # hash of agent prompt bundle
+
+  materials:
+    list_hash: "sha256:..."                # hash of [{filename, sha256}, ...] manifest
+    count: 8                               # number of session materials
+
+  external_protocols:
+    s2_api_protocol_version: "3.3"         # S2 query protocol version
+    s2_snapshot_available: false           # whether a response cache exists
+
+  cross_model:
+    enabled: false                         # whether cross-model verification ran
+    secondary_model_id: null               # secondary model id if enabled
+```
+
+The block lives as an optional child of the Material Passport (Schema 9 in
+`shared/handoff_schemas.md`). A missing key fails the lint. A null value passes with a
+warning. A populated block with all required sub-fields passes silently.
+
+## Field-by-field rationale
+
+### schema_version
+
+`"1.0"` currently supported. Schema evolution policy: breaking changes bump major,
+additions bump minor. Old readers fail loudly on unknown versions — `check_repro_lock.py`
+will exit 1 if it encounters an unrecognized version, forcing the user to upgrade their
+tooling or audit the change manually.
+
+### ars_version
+
+Suite version from CHANGELOG. This couples the prompt hashes to the release: changing
+`ars_version` will change the bundle hash even if individual prompt files didn't change.
+That coupling is intentional — version boundaries mark coordinated changes.
+
+### model.weight_stable
+
+Currently always `false`. Reserved for a future world where a provider guarantees weight
+stability with a signed attestation. Not today. If you see `true`, treat it as suspicious
+until a signed attestation mechanism exists.
+
+### prompts.hash_timing
+
+Fixed at `"skill-load"` in v1.0. A future `"per-call"` variant would require runtime
+instrumentation not present today. The spec is left open for future work. For now, the
+hash captures the state of files at skill initialization, not at every agent invocation.
+
+### materials.list_hash
+
+Hash of a sorted manifest: `[{filename, sha256}, ...]` sorted by filename. If the user
+edits a session material between runs, the hash changes — which is the correct behavior.
+An identical hash across two runs means the input materials were identical; different
+hashes mean inputs diverged.
+
+### external_protocols.s2_snapshot_available
+
+Almost always `false` today. If a future version of the pipeline caches S2 responses per
+run and stores them alongside the passport, this flag flips to `true` and the snapshot path
+appears in the passport. Until that exists, S2 responses are live queries and are not
+reproducible.
+
+## How it composes with existing infrastructure
+
+- Material Passport (Schema 9) is the PARENT document. `repro_lock` is an OPTIONAL CHILD
+  field. A passport without `repro_lock` fails the v3.3.5+ lint; a passport with
+  `repro_lock: null` passes with a warning (explicit opt-out).
+- Existing passports with `repro_lock` absent fail the new lint. Existing passports with
+  `repro_lock: null` pass with a warning. Populated blocks pass silently.
+- The integrity gate (Stage 2.5, Stage 4.5 in the academic pipeline) does NOT read
+  `repro_lock`. The lock is for post-hoc reproducibility investigation, not runtime
+  validation. Adding it does not change pipeline behavior.
+- `check_repro_lock.py` can be run standalone on any passport file. It is not wired into
+  the CI lint suite by default — it validates on-demand against specific passport files.
+
+## Red flags when reading a populated repro_lock
+
+- `model.weight_stable: true` — this value is not implemented yet; if you see it, the
+  passport author is claiming something the infrastructure cannot verify. Treat as
+  suspicious until a signed attestation mechanism exists.
+- `prompts.hash_timing` anything other than `"skill-load"` — this is an unknown variant
+  that the current tooling does not understand. The lint will not flag it as invalid, but
+  the semantics are undefined.
+- Empty or stub hashes (`"sha256:"` prefix with no content, or a short placeholder string
+  like `"sha256:abc123"`) — the generator was broken or the author filled in a placeholder.
+  Hashes should be 64-character hex strings for SHA-256.
+- `stochasticity_declaration` modified from the verbatim required string — the author is
+  signalling they believe the lock is stronger than it is. Read the entire passport twice
+  before trusting any claims about reproducibility.
+
+## How to generate a lock (for agent authors)
+
+At skill-load time, compute `skill_md_hash` over the SKILL.md content and
+`agents_bundle_hash` over the concatenated agent prompts (canonical ordering). Build the
+materials manifest by listing session files with their SHA-256 digests, sort by filename,
+then hash the JSON serialization. Write the block to the passport before handing off to
+downstream stages. The `stochasticity_declaration` must be included verbatim — do not
+paraphrase or abbreviate it.
+
+## Honesty red line (restate)
+
+This pattern enables HONEST DOCUMENTATION. It does not enable REPLAY. Every field has a
+reason and a limitation. Users who treat the lock as a replay guarantee will be burned.
+Authors who publish passports without `stochasticity_declaration` are failing their readers.
+The locked configuration tells you what ran; it cannot tell you what would run again.
+
+The distinction matters: documentation lets a third party investigate what happened and
+ask whether divergence is expected or alarming. Replay would require weight-frozen models,
+deterministic schedulers, and cached external data — none of which ARS controls today.
+
+## Future evolution
+
+- v1.1: add `cache_snapshot_available: true` support once the pipeline caches S2 responses.
+  The snapshot path would appear as a sibling field in `external_protocols`.
+- v2.0: if weight-signed attestations exist, `model.weight_stable: true` becomes meaningful.
+  Until then the field is reserved.
+- Never: byte-level replay guarantees. LLMs don't work like that; no schema version will
+  change that fact.

--- a/shared/benchmark_report.schema.json
+++ b/shared/benchmark_report.schema.json
@@ -39,7 +39,8 @@
         "recruitment": { "type": "string", "minLength": 1 },
         "tools_allowed": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
         }
       }
     },

--- a/shared/benchmark_report.schema.json
+++ b/shared/benchmark_report.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/benchmark_report.schema.json",
+  "title": "ARS Benchmark Report",
+  "type": "object",
+  "required": [
+    "ars_version",
+    "task_definition",
+    "human_baseline",
+    "ars_run",
+    "metrics",
+    "caveats"
+  ],
+  "properties": {
+    "ars_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Exact ARS version the benchmark was run against"
+    },
+    "task_definition": {
+      "type": "object",
+      "required": ["description", "task_type", "outcome_gradable"],
+      "properties": {
+        "description": { "type": "string", "minLength": 1 },
+        "task_type": { "enum": ["outcome-gradable", "open-ended"] },
+        "outcome_gradable": { "type": "boolean" }
+      }
+    },
+    "human_baseline": {
+      "type": "object",
+      "required": ["sample_size", "author_independence", "hours_spent", "recruitment", "tools_allowed"],
+      "properties": {
+        "sample_size": { "type": "integer", "minimum": 1 },
+        "author_independence": {
+          "enum": ["author-conducted", "author-blinded", "third-party-conducted"],
+          "description": "author-conducted means the benchmark creators also did the human baseline (downward bias risk)"
+        },
+        "hours_spent": { "type": "number", "minimum": 0 },
+        "recruitment": { "type": "string", "minLength": 1 },
+        "tools_allowed": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "ars_run": {
+      "type": "object",
+      "required": ["hours_spent", "cost_usd", "skills_used", "data_access_level_declared"],
+      "properties": {
+        "hours_spent": { "type": "number", "minimum": 0 },
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "skills_used": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "data_access_level_declared": {
+          "enum": ["raw", "redacted", "verified_only"]
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["primary_metric", "primary_metric_value", "scoring_independence"],
+      "properties": {
+        "primary_metric": { "type": "string", "minLength": 1 },
+        "primary_metric_value": { "type": "number" },
+        "scoring_independence": {
+          "enum": ["authors-scored", "third-party-scored", "blind-scored", "self-scored"]
+        }
+      }
+    },
+    "caveats": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "Known limitations. Empty array not permitted — honest disclosure required."
+    }
+  }
+}

--- a/shared/benchmark_report_pattern.md
+++ b/shared/benchmark_report_pattern.md
@@ -1,0 +1,180 @@
+# Benchmark Report Pattern (v3.3.5+)
+
+**Status**: v3.3.5 — hub doc for benchmark disclosure schema  
+**Schema**: `shared/benchmark_report.schema.json`  
+**Validator**: `scripts/check_benchmark_report.py`  
+**Template**: `examples/benchmark_report_template.json`
+
+---
+
+## Why this exists
+
+The Anthropic automated-w2s-researcher (2026) paper headlined a performance comparison:
+"2 researchers × 7 days (PGR=0.23) vs 9 agents × 5 days (PGR=0.97)."
+
+Dramatic. Also: n=2, author-conducted, no independence, self-scored. Not a scientific
+comparison — a presentation artifact. The authors knew what the agent would produce before
+sitting down to do the human baseline; their "7 days" is implicitly benchmarked against
+their own foreknowledge. Unaware external researchers doing the same task cold would
+likely score higher. The gap may partly be a sandbagged human baseline.
+
+ARS inherits this risk the moment a user publishes an "ARS beats manual" claim. This
+pattern defines a mandatory schema for anyone publishing an ARS benchmark comparison.
+Reports that don't satisfy the schema aren't "ARS benchmarks" — they're anecdotes.
+
+---
+
+## The schema at a glance
+
+Six required top-level fields in `benchmark_report.schema.json`:
+
+- **`ars_version`** — exact semver the benchmark ran against; ties results to a specific
+  skill version so readers can check whether that version is still current.
+- **`task_definition`** — description, task_type (outcome-gradable or open-ended), and
+  outcome_gradable flag; distinguishes rubric-scored tasks from genuinely open-ended ones.
+- **`human_baseline`** — the five provenance fields that determine whether the human side
+  of the comparison is credible (see field-by-field rationale below).
+- **`ars_run`** — cost, time, skills used, and declared data access level; lets readers
+  check the "agents are cheap" or "agents are fast" claims against concrete numbers.
+- **`metrics`** — primary metric name, numeric value, and scoring independence; forces
+  explicit disclosure of who scored the outputs.
+- **`caveats`** — non-empty array of known limitations; at least one honest statement is
+  required by schema enforcement.
+
+---
+
+## Field-by-field rationale
+
+### `human_baseline`
+
+This block exists because the human side of a comparison is where benchmark credibility
+lives or dies. A weak human baseline inflates an agent's apparent advantage.
+
+- **`sample_size`** (integer, minimum 1): Schema rejects zero, forces an explicit number.
+  n=1 or n=2 get a validator warning rather than a hard failure — some tasks are
+  expert-bounded — but the number must be stated. Silence is worse than admitting n=1.
+
+- **`author_independence`** (enum: author-conducted | author-blinded | third-party-conducted):
+  `author-conducted` is the "2 authors did it themselves" trap: allowed, but the schema
+  flags the downward-bias risk. Authors know what a good ARS output looks like; their
+  human effort is calibrated against that prior. `author-blinded` (authors worked without
+  seeing ARS outputs first) is better. `third-party-conducted` eliminates experimenter
+  bias entirely.
+
+- **`hours_spent`** (number, minimum 0): Lets third parties sanity-check the time claim.
+  "7 days" reads differently against 20 papers versus 400.
+
+- **`recruitment`** (non-empty string): One sentence forces self-description of selection
+  bias. "Authors," "hired on Upwork," "convenience sample" are all honest. Blank is not
+  permitted.
+
+- **`tools_allowed`** (array of strings): "No tools" vs "ChatGPT allowed" is not the same
+  comparison as ARS. If the human baseline used no AI assistance while ARS ran full
+  pipeline, the comparison is testing infrastructure access, not cognitive quality.
+
+### `ars_run`
+
+- **`cost_usd`** (number, minimum 0): A run costing $500 in API tokens is not "cheap"
+  just because it took 3 hours. Hours and cost together are needed for a fair comparison.
+
+- **`data_access_level_declared`** (enum: raw | redacted | verified_only): If ARS ran
+  on `raw` data while the human baseline used redacted data, the benchmark is testing
+  data privilege, not skill. Cross-references ground-truth isolation from v3.3.2.
+
+- **`skills_used`** (array, minItems 1): A benchmark running `academic-pipeline`
+  full-mode is not comparable to one running only `deep-research`. Both are ARS;
+  they're different scope claims.
+
+### `metrics.scoring_independence`
+
+Four enum values: `authors-scored`, `third-party-scored`, `blind-scored`, `self-scored`.
+
+`self-scored` parses and exits 0, but the validator emits a warning to stderr. Self-scoring
+is the worst-case alignment failure: the same agents that produced the output are being
+asked whether the output is good. `blind-scored` (human raters without knowledge of which
+output came from ARS versus human baseline) is the minimum credible standard for any
+claim that will be shared publicly.
+
+### `caveats`
+
+Non-empty array, items non-empty strings, minItems 1. The schema physically prevents an
+empty caveats field. A benchmark report with no caveats either has no known limitations
+(implausible for any real-world evaluation) or the author didn't think about limitations
+(which disqualifies the report more than any specific limitation would).
+
+The caveats field is where sample size warnings, scorer bias, task-selection bias, and
+tool-access asymmetries should land when they don't rise to schema errors. It is the
+honest disclosure box.
+
+---
+
+## How to use
+
+1. Copy `examples/benchmark_report_template.json` to your benchmark directory.
+2. Fill every `FILL IN:` field with real values.
+3. Set `human_baseline.sample_size` to the actual number (schema rejects 0).
+4. Run: `python scripts/check_benchmark_report.py your-report.json`
+5. Fix all `ERROR:` lines (schema violations, exit 1).
+6. Read the `WARNING:` lines (stderr, exit 0). Either address them in your methodology or
+   document them explicitly in the `caveats` array.
+7. Publish the JSON file in your repository alongside the benchmark write-up. The
+   machine-readable format lets future scripts cross-check version-specific claims.
+
+---
+
+## What this pattern is NOT
+
+- **Not a quality gate for your methodology.** A report can be schema-valid and still be
+  methodologically weak. The schema forces disclosure; it does not evaluate task choice,
+  rubric validity, or baseline skill. Compliance is necessary but not sufficient.
+
+- **Not a way to launder self-scored or n=2 comparisons.** `self-scored` and
+  `sample_size: 2` produce a valid document. The warnings are loud. Schema compliance
+  means the claim is honest about its weaknesses — not that the claim is strong.
+
+- **Not a substitute for peer review.** The schema is the minimum bar for internal
+  credibility. Peer review catches confounded variables, cherry-picked tasks, post-hoc
+  metric selection — problems the schema cannot see.
+
+- **Not frozen.** A benchmark declaring `ars_version: 3.3.5` is always checked against
+  the v3.3.5 schema. Future versions may add fields without invalidating existing reports.
+
+---
+
+## Honesty red lines
+
+These are behaviors the schema is specifically designed to make visible. They are not
+prohibited — the schema accepts all of them — but they will appear in validator output
+or be apparent to any reader of the JSON.
+
+- **Omitting sample size.** The field is required. There is no valid ARS benchmark report
+  without a stated `human_baseline.sample_size`. n=1 is worse than n=10, but it is
+  infinitely better than unstated.
+
+- **Author-conducted with no caveat disclosure.** Using `author-conducted` is allowed.
+  Not noting it in `caveats` as a limitation is an editorial failure, not a schema
+  failure — but reviewers will notice.
+
+- **Self-scoring with no warning acknowledgment.** `self-scored` produces a warning on
+  every validator run. If you publish a report with `self-scored` and don't address it
+  in caveats, the omission is visible in the JSON to anyone who checks.
+
+- **Empty or single-word caveats.** The schema requires `minLength: 1` per item and
+  `minItems: 1` for the array. A caveat of `"none"` is technically valid but signals
+  that the author did not engage seriously with limitations.
+
+- **Claiming ARS advantage without disclosing cost_usd.** The field is required. A claim
+  that "ARS completed this in 4 hours vs 40 human hours" without a dollar figure omits
+  the dimension where the trade-off may be reversed.
+
+---
+
+## Future evolution
+
+Per-skill benchmark templates (a `deep-research`-specific template, an
+`academic-paper-reviewer`-specific template) are likely as v3.4 adds domain-specific
+evaluation protocols. The `cost_usd` field may split into `cost_usd_api` and
+`cost_usd_compute` once cloud execution costs become a factor. The
+`data_access_level_declared` enum may expand to match the v3.4 ground-truth tier
+vocabulary if that spec evolves. None of these changes will break existing v3.3.5
+reports, which remain valid against the version they declared in `ars_version`.

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -499,6 +499,7 @@ score_trajectory: {
 | `integrity_pass_date` | string | ISO 8601 timestamp of last integrity verification pass (if applicable) |
 | `content_hash` | string | SHA-256 hash of the content (for change detection) |
 | `upstream_dependencies` | list[string] | Version labels of artifacts this one depends on |
+| `repro_lock` | object \| null | configuration lockfile for artifact reproducibility. See [`artifact_reproducibility_pattern.md`](artifact_reproducibility_pattern.md). `null` = honest opt-out. Required from v3.3.5+ — omitted key fails lint. |
 
 ### Example
 
@@ -642,3 +643,9 @@ This is a declarative truth-in-advertising signal. All current ARS skills are `o
 Enforced by `scripts/check_task_type.py` in CI.
 
 See [`ground_truth_isolation_pattern.md`](ground_truth_isolation_pattern.md) for the rationale and rules behind this annotation.
+
+
+## v3.3.5 additions
+
+- `benchmark_report.schema.json` + [`benchmark_report_pattern.md`](benchmark_report_pattern.md) — schema for publishing ARS benchmark comparisons with required human baseline + independence fields.
+- `repro_lock` sub-block on Material Passport + [`artifact_reproducibility_pattern.md`](artifact_reproducibility_pattern.md) — configuration lockfile (NOT replay guarantee).


### PR DESCRIPTION
## Summary

Two honesty-first additions following the same automated-w2s-researcher review lens as v3.3.2:

### 1. Benchmark Report Schema
`shared/benchmark_report.schema.json` (draft-2020-12) + `scripts/check_benchmark_report.py` + pattern doc. Enforces required fields for anyone publishing an "ARS benchmark" comparison: human baseline `sample_size`, `author_independence`, `tools_allowed` (minItems: 1), scoring independence, non-empty caveats. Catches the "n=2 authors × 7 days (PGR 0.23) vs 9 agents (PGR 0.97)" failure mode directly.

### 2. Artifact Reproducibility Lockfile
`repro_lock` optional sub-block added to Material Passport (Schema 9). Records ARS version, model family/id, skill/agent/material hashes, S2 API protocol version. **Configuration documentation, NOT replay guarantee** — `stochasticity_declaration` required verbatim; pattern doc's mandatory §"What this is NOT" explains why LLM outputs are not byte-reproducible.

Both ship with lint scripts, unit tests, examples, and pattern docs. First formal Python dev-dep manifest (`requirements-dev.txt` with `pyyaml` + `jsonschema>=4.17`).

## Honesty red lines

- Benchmark: `caveats: []` fails validation; `self-scored` + `n<=2` emit loud warnings
- Repro-lock: missing `stochasticity_declaration` fails; `prompts.hash_timing` fixed to `"skill-load"` (declared imprecision)
- No replay guarantees promised anywhere

## Test plan

- [x] `python scripts/check_data_access_level.py && check_task_type.py && check_spec_consistency.py && check_repro_lock.py examples/passport_with_repro_lock.yaml` — all exit 0
- [x] `python -m unittest discover -s scripts -p "test_*.py"` — 25/25 pass (7 benchmark + 6 repro-lock + 6 data-access + 6 task-type; +1 from post-/simplify `tools_allowed` fix)
- [x] CI workflow updated to `pip install -r requirements-dev.txt`; cache-key pinned to that file
- [x] /simplify review run post-implementation: 6 findings fixed (schema constraint, stringly-typed hash_timing, stderr/stdout mixing, docs pointers in errors, test helper extraction, dep floor)

## Files (17 commits, 22 files, +1040/-36)

**New:**
- `requirements-dev.txt`
- `shared/benchmark_report.schema.json` + `shared/benchmark_report_pattern.md` (180 lines)
- `shared/artifact_reproducibility_pattern.md` (173 lines)
- `scripts/check_benchmark_report.py` + `check_repro_lock.py` + their tests
- `scripts/_test_helpers.py` (shared subprocess/env helpers for 4 test files)
- `examples/benchmark_report_template.json` + `passport_with_repro_lock.yaml`

**Modified:**
- `shared/handoff_schemas.md` — Schema 9 optional `repro_lock` + `## v3.3.5 additions` pointer
- `academic-pipeline/references/reproducibility_audit.md` — cross-link to new pattern
- `.github/workflows/spec-consistency.yml` — requirements-dev-based install + cache
- `CHANGELOG.md`, `README.md`, `README.zh-TW.md`, `.claude/CLAUDE.md`, `MODE_REGISTRY.md`, `scripts/check_spec_consistency.py` — v3.3.4 → v3.3.5 sync

## Release

v3.3.5 (patch — additive, no skill behavior changes). Tag + GitHub release after merge per auto-push convention. Notes drafted at `.local-plans/release-notes-v3.3.5.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)