### PR TITLE
docs: align model references with Opus 4.7 + adaptive thinking

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -229,7 +229,7 @@ Inspired by patterns from [aspi6246/Claude-Code-Skills-for-Academics](https://gi
 - Known apa7 quirks documented: `noextraspace` removed in v2.15, pandoc `\LTcaptype{none}` needs `\newcounter{none}`, `\addORCIDlink` takes ID only (not full URL)
 
 **README updates**:
-- Added Performance Notes section: recommended model Claude Opus 4.6 with Max plan; large token consumption warning
+- Added Performance Notes section: recommended model Claude Opus 4.7 with Max plan; large token consumption warning
 - Updated pipeline stage 5 description in both EN and zh-TW READMEs
 
 **Lesson**: Always ask the user which academic formatting style they want (APA 7.0, Chicago, IEEE, etc.) before generating the final PDF — formatting style is a separate concern from citation style

--- a/academic-paper/references/disclosure_mode_protocol.md
+++ b/academic-paper/references/disclosure_mode_protocol.md
@@ -65,7 +65,7 @@ Example output for Nature (which requires disclosure in Methods):
 ```
 ## AI-assisted tools
 
-The authors used Claude Opus 4.6 (Anthropic), orchestrated via the
+The authors used Claude [MODEL_VERSION] (Anthropic), orchestrated via the
 Academic Research Skills pipeline (Wu, 2026), during the preparation
 of this manuscript. Specifically, the tool was used for literature
 search assistance, citation verification, drafting of section outlines,
@@ -73,6 +73,8 @@ and internal peer-review simulation prior to submission. All
 AI-assisted output was reviewed, edited, and verified by the authors,
 who take full responsibility for the content of this article.
 ```
+
+**Note**: Replace `[MODEL_VERSION]` with the actual model used in this run (e.g., `Opus 4.7`, `Sonnet 4.6`). Pull the identifier from session metadata rather than hard-coding a version, since Anthropic's lineup changes over time.
 
 ### Phase 5: Placement instructions
 

--- a/academic-pipeline/agents/pipeline_orchestrator_agent.md
+++ b/academic-pipeline/agents/pipeline_orchestrator_agent.md
@@ -410,7 +410,7 @@ Mid-Entry Material Passport Check:
 
 ## Communication Style
 
-- Concise and clear, not verbose
+- Direct and precise — state decisions and rationale without filler
 - Clearly explain what the next step is and why at each transition
 - Present options in bullet format for quick user selection
 - Language follows the user (English to English, etc.)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # ARS Performance Notes
 
-> **Recommended model: Claude Opus 4.6** with **Max plan** (or equivalent extended-thinking configuration).
+> **Recommended model: Claude Opus 4.7** with **Max plan** (or equivalent configuration). Opus 4.7 uses adaptive thinking; you no longer set a fixed thinking budget.
 >
 > The full academic pipeline (10 stages) consumes a **large amount of tokens** — a single end-to-end run can exceed 200K input + 100K output tokens depending on paper length and revision rounds. Budget accordingly.
 >
@@ -8,7 +8,7 @@
 
 ## Estimated token usage by mode
 
-| Skill / Mode | Input Tokens | Output Tokens | Estimated Cost (Opus 4.6) |
+| Skill / Mode | Input Tokens | Output Tokens | Estimated Cost (Opus 4.7) |
 |---|---|---|---|
 | `deep-research` socratic | ~30K | ~15K | ~$0.60 |
 | `deep-research` full | ~60K | ~30K | ~$1.20 |

--- a/docs/PERFORMANCE.zh-TW.md
+++ b/docs/PERFORMANCE.zh-TW.md
@@ -1,6 +1,6 @@
 # ARS 效能說明
 
-> **建議模型：Claude Opus 4.6**，搭配 **Max plan**（或同等的延伸思考設定）。
+> **建議模型：Claude Opus 4.7**，搭配 **Max plan**（或同等配置）。Opus 4.7 採用 adaptive thinking，不需要手動指定 thinking budget。
 >
 > 完整學術 pipeline（10 階段）會消耗**大量 token** — 單次完整執行可能超過 200K 輸入 + 100K 輸出 token，視論文長度和修訂輪數而定。請依預算斟酌使用。
 >
@@ -8,7 +8,7 @@
 
 ## 各模式 Token 消耗估算
 
-| Skill / 模式 | 輸入 Token | 輸出 Token | 估算費用（Opus 4.6）|
+| Skill / 模式 | 輸入 Token | 輸出 Token | 估算費用（Opus 4.7）|
 |---|---|---|---|
 | `deep-research` socratic | ~30K | ~15K | ~$0.60 |
 | `deep-research` full | ~60K | ~30K | ~$1.20 |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,6 @@
 # ARS Setup
 
-Prerequisites and optional setup for Academic Research Skills. If you only need Markdown output and the default Claude Opus 4.6 pipeline, you can skip most of this — see "Minimum viable setup" below.
+Prerequisites and optional setup for Academic Research Skills. If you only need Markdown output and the default Claude Opus 4.7 pipeline, you can skip most of this — see "Minimum viable setup" below.
 
 ---
 
@@ -92,7 +92,7 @@ curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net | sh
 
 ## Cross-model verification (optional)
 
-ARS works with Claude Opus 4.6 alone. For higher confidence, you can optionally enable a second AI model to independently verify integrity checks and challenge the devil's advocate.
+ARS works with Claude Opus 4.7 alone. For higher confidence, you can optionally enable a second AI model to independently verify integrity checks and challenge the devil's advocate.
 
 ### Quick setup
 

--- a/docs/SETUP.zh-TW.md
+++ b/docs/SETUP.zh-TW.md
@@ -1,6 +1,6 @@
 # ARS 安裝設定
 
-Academic Research Skills 的前置需求與選用設定。只需要 Markdown 輸出 + 預設 Claude Opus 4.6 pipeline 的人，大部分內容可以略過 — 見下方「最小可行設定」。
+Academic Research Skills 的前置需求與選用設定。只需要 Markdown 輸出 + 預設 Claude Opus 4.7 pipeline 的人，大部分內容可以略過 — 見下方「最小可行設定」。
 
 ---
 
@@ -92,7 +92,7 @@ curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net | sh
 
 ## 跨模型驗證（選用）
 
-ARS 使用 Claude Opus 4.6 即可完整運作。想要更高信心，可選擇啟用第二 AI 模型獨立驗證。
+ARS 使用 Claude Opus 4.7 即可完整運作。想要更高信心，可選擇啟用第二 AI 模型獨立驗證。
 
 ### 快速設定
 

--- a/examples/passport_with_repro_lock.yaml
+++ b/examples/passport_with_repro_lock.yaml
@@ -18,7 +18,7 @@ repro_lock:
 
   model:
     family: claude
-    id: claude-opus-4-6
+    id: claude-opus-4-7
     weight_stable: false
 
   prompts:

--- a/scripts/test_check_repro_lock.py
+++ b/scripts/test_check_repro_lock.py
@@ -27,7 +27,7 @@ def _valid_passport_yaml() -> str:
           ars_version: "3.3.5"
           model:
             family: claude
-            id: claude-opus-4-6
+            id: claude-opus-4-7
             weight_stable: false
           prompts:
             hash_timing: skill-load

--- a/shared/artifact_reproducibility_pattern.md
+++ b/shared/artifact_reproducibility_pattern.md
@@ -49,7 +49,7 @@ repro_lock:
 
   model:
     family: claude                          # provider family
-    id: claude-opus-4-6                    # model identifier (not weight hash)
+    id: claude-opus-4-7                    # model identifier (not weight hash)
     weight_stable: false                    # always false until signed attestation exists
 
   prompts:

--- a/shared/cross_model_verification.md
+++ b/shared/cross_model_verification.md
@@ -4,7 +4,7 @@
 
 This protocol enables optional cross-model verification for high-stakes AI judgments. When enabled, a second AI model independently reviews outputs from the primary model, reducing shared-bias blind spots.
 
-**This is entirely optional.** All ARS skills work with Claude Opus 4.6 alone. Cross-model verification is an additional layer for users who want higher confidence in integrity checks, devil's advocate challenges, and review judgments.
+**This is entirely optional.** All ARS skills work with Claude Opus 4.7 alone. Cross-model verification is an additional layer for users who want higher confidence in integrity checks, devil's advocate challenges, and review judgments.
 
 ## Why Cross-Model Verification
 
@@ -18,12 +18,12 @@ A stress test of 68 AI-generated citations found 31% had problems — and all pa
 
 | Model | API ID | Provider | Best For |
 |-------|--------|----------|----------|
-| Claude Opus 4.6 | `claude-opus-4-6` | Anthropic | Primary model (default for all ARS skills) |
+| Claude Opus 4.7 | `claude-opus-4-7` | Anthropic | Primary model (default for all ARS skills) |
 | GPT-5.4 Pro | `gpt-5.4-pro` | OpenAI | Cross-verification — strongest reasoning |
 | GPT-5.4 | `gpt-5.4` | OpenAI | Cross-verification — balanced cost/performance |
 | Gemini 3.1 Pro | `gemini-3.1-pro-preview` | Google | Cross-verification — strong at factual verification |
 
-**Recommended cross-verification pair:** Claude Opus 4.6 (primary) + GPT-5.4 Pro or Gemini 3.1 Pro (verifier).
+**Recommended cross-verification pair:** Claude Opus 4.7 (primary) + GPT-5.4 Pro or Gemini 3.1 Pro (verifier).
 
 Using two non-Anthropic models as primary+verifier is possible but not tested with ARS prompts.
 


### PR DESCRIPTION
## Summary

Bring ARS documentation in line with the [Opus 4.7 best-practices guide](https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code):

- **Model ID sweep**: opus-4-6 → opus-4-7 across 10 files (PERFORMANCE + SETUP guides in EN/zh-TW, cross_model_verification, artifact_reproducibility_pattern, passport example + its test, CHANGELOG, disclosure protocol, orchestrator agent).
- **Drop fixed-thinking-budget phrasing**: PERFORMANCE guides no longer mention "extended-thinking configuration" — Opus 4.7 uses adaptive thinking, so the model decides how deeply to reason per turn; there's no user-facing budget to set.
- **Disclosure example → placeholder**: the hard-coded "Claude Opus 4.6 (Anthropic)" sample AI-usage statement becomes `Claude [MODEL_VERSION]` with a note telling agents to pull the identifier from session metadata. Keeps the example forward-compatible when the next model ships.
- **Negative-framing fix**: `pipeline_orchestrator_agent.md` replaces "Concise and clear, not verbose" with a positive direction ("Direct and precise — state decisions and rationale without filler") per Opus 4.7 guidance.

## Test plan

- [x] `python3 -m scripts.test_check_repro_lock` — 6/6 pass (passport example still parses)
- [x] No behavioral changes in SKILL.md files
- [x] No PII leakage (scanned diff for heeact / hei-platform / internal names — 0 hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)