### PR TITLE
feat: v3.4.0 compliance agent — PRISMA-trAIce + RAISE at Stage 2.5/4.5

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,10 +6,17 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 
 | Skill | Purpose | Key Modes |
 |-------|---------|-----------|
-| `deep-research` v2.8.1 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
-| `academic-paper` v3.0.2 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
+| `deep-research` v2.9.0 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
+| `academic-paper` v3.1.0 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.8.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.2.2 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.3.0 | Full pipeline orchestrator | (coordinates all above) |
+
+## v3.4 Key Additions
+
+- **Compliance Agent (shared)**: single mode-aware agent running PRISMA-trAIce 17 items + RAISE 4 principles + 8-role matrix. Hooks Stage 2.5 / 4.5 Integrity Gates with tier-based block. Non-SR entries run principles-only warn-only. See `shared/agents/compliance_agent.md`.
+- **Schema 12 compliance_report**: append-only audit trail in Material Passport via `compliance_history[]`.
+- **3-round override ladder**: user overrides produce auto-injected `disclosure_addendum`. See `shared/compliance_checkpoint_protocol.md`.
+- **Long-running session docs**: `docs/PERFORMANCE.md` now covers cross-session resume via Material Passport.
 
 ## v3.3 Key Additions
 
@@ -80,7 +87,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.3.6 (per CHANGELOG.md)
-- **Last Updated**: 2026-04-15
+- **Suite version**: 3.4.0 (per CHANGELOG.md)
+- **Last Updated**: 2026-04-20
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -1,0 +1,36 @@
+name: PRISMA-trAIce Freshness
+
+on:
+  schedule:
+    # Monday 09:00 UTC (17:00 Taipei) — weekly upstream drift check
+    - cron: "0 9 * * 1"
+  push:
+    paths:
+      - "shared/prisma_trAIce_protocol.md"
+      - "scripts/check_prisma_trAIce_freshness.py"
+  workflow_dispatch:
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install lint dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run freshness check (non-blocking)
+        env:
+          PYTHONPATH: .
+        run: python3 scripts/check_prisma_trAIce_freshness.py
+        # Stale snapshot surfaces a warning on stderr but exits 0. A
+        # non-zero exit means a parse error (missing/malformed
+        # snapshot_date), which SHOULD fail the workflow.

--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -10,6 +10,10 @@ on:
       - "scripts/check_prisma_trAIce_freshness.py"
   workflow_dispatch:
 
+concurrency:
+  group: freshness-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   freshness:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -33,3 +33,13 @@ jobs:
         env:
           PYTHONPATH: scripts
         run: python3 scripts/check_task_type.py
+
+      - name: Validate compliance_report fixtures against Schema 12
+        env:
+          PYTHONPATH: .
+        run: python3 scripts/validate_compliance_fixtures.py
+
+      - name: Run compliance validator unit tests
+        env:
+          PYTHONPATH: .
+        run: python3 -m unittest scripts.test_check_compliance_report scripts.test_validate_compliance_fixtures -v

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: spec-consistency-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spec-consistency:
     runs-on: ubuntu-latest
@@ -34,12 +38,7 @@ jobs:
           PYTHONPATH: scripts
         run: python3 scripts/check_task_type.py
 
-      - name: Validate compliance_report fixtures against Schema 12
-        env:
-          PYTHONPATH: .
-        run: python3 scripts/validate_compliance_fixtures.py
-
-      - name: Run compliance validator unit tests
+      - name: Run compliance validator + fixture unit tests
         env:
           PYTHONPATH: .
         run: python3 -m unittest scripts.test_check_compliance_report scripts.test_validate_compliance_fixtures -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.4.0] - 2026-04-20
+
+### Added
+
+- `shared/agents/compliance_agent.md` — single mode-aware agent for PRISMA-trAIce + RAISE compliance. Dispatches on `compliance_mode ∈ {systematic_review, primary_research, other_evidence_synthesis}`. See design spec `docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md`.
+- `shared/prisma_trAIce_protocol.md` — verbatim 17-item snapshot from `cqh4046/PRISMA-trAIce` (2025-12-10) + per-item ARS check procedure + 4-tier behaviour table. Citation: Holst et al. 2025, JMIR AI, doi:10.2196/80247.
+- `shared/raise_framework.md` — 4 principles (human oversight / transparency / reproducibility / fit-for-purpose) + 8-role matrix + mandatory scope disclaimer. Citation: Thomas et al. 2025, NIHR ESG Best Practice Working Group, 17 July 2025.
+- `shared/compliance_checkpoint_protocol.md` — Stage 2.5 / 4.5 dual-gate behaviour spec, decision precedence, override ladder, fail-loop integration, boundary behaviour for non-pipeline invocation.
+- `shared/compliance_report.schema.json` — Schema 12 validator (Draft 2020-12).
+- `examples/compliance/fixture_sr_full_compliant.yaml`, `fixture_sr_missing_M4.yaml`, `fixture_primary_raise_weak.yaml` — regression fixtures + user reference templates.
+- `scripts/check_compliance_report.py` + tests — Schema 12 CLI validator.
+- `scripts/validate_compliance_fixtures.py` + tests — YAML→JSON fixture loop used by CI.
+- `scripts/check_prisma_trAIce_freshness.py` + tests — non-blocking upstream-drift warning (180-day threshold).
+- `.github/workflows/freshness-check.yml` — weekly cron (Monday 09:00 UTC) + path-filtered push trigger for freshness check.
+- `docs/PERFORMANCE.md` + `.zh-TW.md`: new "Long-running session management" section + v3.4.0 token-cost deltas.
+
+### Changed
+
+- `shared/handoff_schemas.md`: Schema 12 pointer + Material Passport `compliance_history[]` (append-only audit trail).
+- `academic-pipeline/SKILL.md` (v3.2.2 → v3.3.0): Stage 2.5 / 4.5 extended with compliance payload; checkpoint dashboard gains compliance row.
+- `deep-research/SKILL.md` (v2.8.1 → v2.9.0): `systematic-review` mode now triggers `compliance_agent` at both gates.
+- `academic-paper/SKILL.md` (v3.0.2 → v3.1.0): `full` mode adds pre-finalize RAISE principles-only check (warn-only). `disclosure` mode unchanged and complementary.
+- `.github/workflows/spec-consistency.yml`: added compliance validator + unit test runner steps.
+- `scripts/check_spec_consistency.py`: version pins bumped.
+- `README.md`, `README.zh-TW.md`, `.claude/CLAUDE.md`, `MODE_REGISTRY.md`: suite version → 3.4.0.
+
+### Notes
+
+- Calibration philosophy: compliance_agent ships with transparent reporting, **no hard FNR/FPR threshold**. This is self-consistent with ARS's v3.3.2 `task_type: open-ended` truth-in-advertising annotation — publishing a hard gate would contradict the "not a benchmark task" declaration.
+- Compliance Mandatory failures in SR mode are blocking, but the 3-round override ladder preserves human-in-the-loop authority. Overrides auto-inject `disclosure_addendum` into the final manuscript — no detection evasion.
+- The v3.2 Failure Mode Checklist and the v3.4.0 compliance agent run in parallel at the same gates. Their scopes are non-overlapping: failure-mode checks research validity; compliance checks reporting transparency.
+- Internal numbering: compliance_report is Schema 12 (not 10). Schema 10 is Style Profile (v2.7+); Schema 11 is R&R Traceability Matrix. The plan's initial Schema 10 assignment was corrected mid-branch before Task 9.
+
 ## [3.3.6] - 2026-04-15
 
 ### Added

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **24 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.3.6 (2026-04-15)
+Last updated: v3.4.0 (2026-04-20)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.6-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.6)
+[![Version](https://img.shields.io/badge/version-v3.4.0-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.4.0)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -288,6 +288,15 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.4.0 (2026-04-20) — Compliance Agent + Schema 12
+
+- **Compliance Agent** (shared): single mode-aware agent running PRISMA-trAIce 17 items (SR mode only) + RAISE 4 principles + 8-role matrix. Hooks existing Stage 2.5 / 4.5 Integrity Gates; tier-based block (Mandatory → block, HR → warn, R/O → info). Non-SR entries run principles-only, warn-only.
+- **Schema 12 compliance_report** appended to Material Passport via `compliance_history[]` (append-only).
+- **3-round user-override ladder** auto-injects `disclosure_addendum` into manuscript. No detection evasion possible.
+- **Calibration with transparent reporting**, no hard FNR/FPR gate — self-consistent with `task_type: open-ended`.
+- **Upstream freshness CI** warns on PRISMA-trAIce drift (non-blocking).
+- **Long-running session docs**: Material Passport as cross-session resume mechanism.
 
 ### v3.3.6 (2026-04-15) — README Streamlining + ARCHITECTURE doc
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.3.6-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.3.6)
+[![Version](https://img.shields.io/badge/version-v3.4.0-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.4.0)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -269,6 +269,15 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.4.0（2026-04-20）— Compliance Agent + Schema 12
+
+- **Compliance Agent（shared）**：單一 mode-aware agent，同時跑 PRISMA-trAIce 17 項（限 SR mode）+ RAISE 四原則 + 8-role matrix。掛載既有 Stage 2.5 / 4.5 Integrity Gate；tier-based block（Mandatory → block、HR → warn、R/O → info）。非 SR 入口只跑原則、warn-only。
+- **Schema 12 compliance_report** 附加到 Material Passport 的 `compliance_history[]`（append-only）。
+- **三回合 user-override 階梯**，自動注入 `disclosure_addendum` 到 manuscript。無法規避揭露。
+- **Calibration 以透明公布取代硬門檻**，與 `task_type: open-ended` 自洽。
+- **Upstream freshness CI** 偵測 PRISMA-trAIce 上游漂移（non-blocking）。
+- **長時間 session 文件**：Material Passport 作為跨 session 續跑機制。
 
 ### v3.3.6 (2026-04-15) — README 精簡 + ARCHITECTURE 文件
 

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -138,7 +138,7 @@ Phase 7: FORMAT        -> [formatter]                  -> Final Output Package
 
 ---
 
-> **v3.4.0 compliance:** Before finalisation, `compliance_agent` runs RAISE principles-only check (warn-only; primary research is outside PRISMA-trAIce scope). Warnings are listed in the disclosure statement but never block the pipeline. See `shared/raise_framework.md §Scope disclaimer`.
+> **v3.4.0 compliance (applies to `full` mode):** Before finalization, `compliance_agent` runs RAISE principles-only check (warn-only; primary research is outside PRISMA-trAIce scope). Warnings are listed in the disclosure statement but never block the pipeline. See `shared/raise_framework.md §Scope disclaimer`.
 
 ## Operational Modes (10 Modes)
 
@@ -318,8 +318,8 @@ academic-paper + academic-paper-reviewer -> Peer review -> revision loop
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.0.2 |
-| Last Updated | 2026-04-15 |
+| Skill Version | 3.1.0 |
+| Last Updated | 2026-04-20 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v1.0+ (upstream), academic-paper-reviewer v1.0+ (downstream) |
 

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-paper
 description: "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見."
 metadata:
-  version: "3.0.2"
-  last_updated: "2026-04-15"
+  version: "3.1.0"
+  last_updated: "2026-04-20"
   status: active
   data_access_level: redacted
   task_type: open-ended
@@ -137,6 +137,8 @@ Phase 7: FORMAT        -> [formatter]                  -> Final Output Package
 5. User can skip Phase 1 (literature) if providing own sources
 
 ---
+
+> **v3.4.0 compliance:** Before finalisation, `compliance_agent` runs RAISE principles-only check (warn-only; primary research is outside PRISMA-trAIce scope). Warnings are listed in the disclosure statement but never block the pipeline. See `shared/raise_framework.md §Scope disclaimer`.
 
 ## Operational Modes (10 Modes)
 

--- a/academic-paper/references/anti_leakage_protocol.md
+++ b/academic-paper/references/anti_leakage_protocol.md
@@ -58,6 +58,8 @@ data, and methodology descriptions must come from session materials.
 
 ### [MATERIAL GAP] handling
 
+> **Tag vocabulary.** The `[MATERIAL GAP]`, `[WEAK EVIDENCE]`, `[GAP]` tags used throughout this protocol are canonically defined in [`shared/compliance_checkpoint_protocol.md#canonical-gap-tag-vocabulary`](../../shared/compliance_checkpoint_protocol.md#canonical-gap-tag-vocabulary). This section describes how the anti-leakage writing-time flag interacts with that vocabulary during manuscript production.
+
 When a `[MATERIAL GAP]` is flagged:
 1. The gap is surfaced at the next checkpoint
 2. The user can provide additional materials, or authorize LLM supplementation for that specific gap

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.2.2"
-  last_updated: "2026-04-15"
+  version: "3.3.0"
+  last_updated: "2026-04-20"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only
@@ -14,7 +14,7 @@ metadata:
     - academic-paper-reviewer
 ---
 
-# Academic Pipeline v3.2.2 — Full Academic Research Workflow Orchestrator
+# Academic Pipeline v3.3.0 — Full Academic Research Workflow Orchestrator
 
 A lightweight orchestrator that manages the complete academic pipeline from research exploration to final manuscript. It does not perform substantive work — it only detects stages, recommends modes, dispatches skills, manages transitions, and tracks state.
 
@@ -300,6 +300,8 @@ Stage 2.5 (pre-review) and Stage 4.5 (post-revision) verification. 5-phase proto
 > See `references/integrity_review_protocol.md` for the 5-phase citation/claim verification procedures.
 > See `references/ai_research_failure_modes.md` for the 7-mode AI research failure checklist and block/override logic.
 
+- [v3.4.0] `compliance_agent` runs mode-aware PRISMA-trAIce + RAISE compliance check; tier-based block semantics. See `shared/compliance_checkpoint_protocol.md`.
+
 ---
 
 ## Two-Stage Review Protocol
@@ -533,8 +535,8 @@ Stage 5: academic-paper (format-convert mode)
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.2.2 |
-| Last Updated | 2026-04-15 |
+| Skill Version | 3.3.0 |
+| Last Updated | 2026-04-20 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v2.0+, academic-paper v2.0+, academic-paper-reviewer v1.1+ |
 | Role | Full academic research workflow orchestrator |

--- a/academic-pipeline/references/progress_dashboard_template.md
+++ b/academic-pipeline/references/progress_dashboard_template.md
@@ -25,7 +25,9 @@ Users can say "status" or "pipeline status" at any time to view:
 | Integrity Verification:                     |
 |   Pre-review:  PASS (0 issues)              |
 |   Final:       In progress...               |
-| compliance     | [pass/warn/block] | PRISMA-trAIce: N/17 • RAISE: 4/4 principles |
+| Compliance (v3.4.0):                        |
+|   PRISMA-trAIce: pass (17/17)               |
+|   RAISE principles: pass (4/4)              |
 +---------------------------------------------+
 | Review History:                             |
 |   Round 1: Major Revision (5 required)      |

--- a/academic-pipeline/references/progress_dashboard_template.md
+++ b/academic-pipeline/references/progress_dashboard_template.md
@@ -25,6 +25,7 @@ Users can say "status" or "pipeline status" at any time to view:
 | Integrity Verification:                     |
 |   Pre-review:  PASS (0 issues)              |
 |   Final:       In progress...               |
+| compliance     | [pass/warn/block] | PRISMA-trAIce: N/17 • RAISE: 4/4 principles |
 +---------------------------------------------+
 | Review History:                             |
 |   Round 1: Major Revision (5 required)      |

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -472,8 +472,8 @@ deep-research (systematic-review) + academic-paper -> PRISMA systematic review p
 
 | Item | Content |
 |------|---------|
-| Skill Version | 2.8.1 |
-| Last Updated | 2026-04-15 |
+| Skill Version | 2.9.0 |
+| Last Updated | 2026-04-20 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | academic-paper v1.0+ (downstream) |
 

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -2,8 +2,8 @@
 name: deep-research
 description: "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題."
 metadata:
-  version: "2.8.1"
-  last_updated: "2026-04-15"
+  version: "2.9.0"
+  last_updated: "2026-04-20"
   status: active
   data_access_level: raw
   task_type: open-ended
@@ -267,6 +267,8 @@ User: "Research [topic]"
 ## Systematic Review Mode
 
 PRISMA 2020-compliant systematic review with optional meta-analysis. Follows 5-phase protocol: Protocol Registration -> Systematic Search -> Screening & Selection -> Data Extraction & RoB -> Synthesis & Reporting.
+
+> **v3.4.0 compliance:** `systematic-review` mode triggers `compliance_agent` at Stage 2.5 (Methods items) and Stage 4.5 (remaining items + RAISE 8-role matrix). PRISMA-trAIce Mandatory failures block the pipeline. See `shared/compliance_checkpoint_protocol.md`.
 
 > See `references/systematic_review_protocol.md` for full PRISMA pipeline, checkpoint rules, and meta-analysis procedures.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -36,16 +36,16 @@
 The full academic pipeline is designed for human-in-the-loop execution, with mandatory user confirmation at every stage. In practice, a full run often spans hours to days — longer than Anthropic's prompt cache TTL (5 minutes). Two consequences:
 
 1. **Cache misses between checkpoints are normal.** When a stage checkpoint pauses longer than 5 minutes, the next stage reads its context uncached. This is an unavoidable cost of human-paced pipelines.
-2. **Cross-session resume relies on Material Passport.** ARS does not persist session state inside Claude Code. To resume in a new session, paste your Material Passport YAML back; the orchestrator reads `compliance_history[]` and stage completion markers to locate your breakpoint.
+2. **Cross-session resume relies on Material Passport.** ARS does not maintain its own orchestrator state between sessions. To resume in a new session, paste your Material Passport YAML back; the orchestrator reads `compliance_history[]` and stage completion markers to locate your breakpoint.
 
 ### v3.4.0 compliance agent cost
 
 Adding the mode-aware `compliance_agent` to Stage 2.5 and Stage 4.5 increases full-pipeline SR tokens by approximately:
 
-| Skill / mode | Input token delta | Output token delta | Estimated cost delta |
+| Skill / Mode | Input Tokens | Output Tokens | Estimated Cost |
 |---|---|---|---|
-| `deep-research systematic-review` (2.5 only) | ~5–8K | ~3–5K | ~$0.15 |
-| Full pipeline SR (2.5 + 4.5) | ~10–15K | ~5–8K | ~$0.30 |
-| `academic-paper full` (pre-finalize) | ~3–5K | ~2–3K | ~$0.08 |
+| `deep-research systematic-review` (2.5 only) | +~5–8K | +~3–5K | +~$0.15 |
+| Full pipeline SR (2.5 + 4.5) | +~10–15K | +~5–8K | +~$0.30 |
+| `academic-paper full` (pre-finalize) | +~3–5K | +~2–3K | +~$0.08 |
 
-These are on top of the existing per-skill costs in the table above. Cross-model verification costs (if enabled) are unchanged.
+These are on top of the existing per-skill costs in the table above (same 15,000-word / 60-reference basis; see footnote on line 23). Cross-model verification costs (if enabled) are unchanged.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -30,3 +30,22 @@
 | **Skip Permissions** | Bypasses per-tool confirmation prompts, enabling uninterrupted autonomous execution across all pipeline stages | Launch with `claude --dangerously-skip-permissions` | [Permissions](https://docs.anthropic.com/en/docs/claude-code/cli-reference) · [Advanced Usage](https://docs.anthropic.com/en/docs/claude-code/advanced) |
 
 > **⚠️ Skip Permissions**: This flag disables all tool-use confirmation dialogs. Use at your own discretion — it is convenient for trusted, long-running pipelines but removes the safety net of manual approval. Only enable this in environments where you are comfortable with Claude executing file reads, writes, and shell commands without asking first.
+
+## Long-running session management
+
+The full academic pipeline is designed for human-in-the-loop execution, with mandatory user confirmation at every stage. In practice, a full run often spans hours to days — longer than Anthropic's prompt cache TTL (5 minutes). Two consequences:
+
+1. **Cache misses between checkpoints are normal.** When a stage checkpoint pauses longer than 5 minutes, the next stage reads its context uncached. This is an unavoidable cost of human-paced pipelines.
+2. **Cross-session resume relies on Material Passport.** ARS does not persist session state inside Claude Code. To resume in a new session, paste your Material Passport YAML back; the orchestrator reads `compliance_history[]` and stage completion markers to locate your breakpoint.
+
+### v3.4.0 compliance agent cost
+
+Adding the mode-aware `compliance_agent` to Stage 2.5 and Stage 4.5 increases full-pipeline SR tokens by approximately:
+
+| Skill / mode | Input token delta | Output token delta | Estimated cost delta |
+|---|---|---|---|
+| `deep-research systematic-review` (2.5 only) | ~5–8K | ~3–5K | ~$0.15 |
+| Full pipeline SR (2.5 + 4.5) | ~10–15K | ~5–8K | ~$0.30 |
+| `academic-paper full` (pre-finalize) | ~3–5K | ~2–3K | ~$0.08 |
+
+These are on top of the existing per-skill costs in the table above. Cross-model verification costs (if enabled) are unchanged.

--- a/docs/PERFORMANCE.zh-TW.md
+++ b/docs/PERFORMANCE.zh-TW.md
@@ -36,16 +36,16 @@
 完整 pipeline 設計為 human-in-the-loop，每個階段都需使用者確認。實務上一次完整執行會跨越數小時到數天，遠長於 Anthropic 的 prompt cache TTL（5 分鐘）。兩項結果：
 
 1. **階段間 cache miss 是常態。** 當 stage checkpoint 停留超過 5 分鐘，下一階段會以未快取狀態讀取 context。這是 human-paced pipeline 不可避免的成本。
-2. **跨 session 續跑依賴 Material Passport。** ARS 不在 Claude Code 內保留 session state；要在新 session 續跑，把 Material Passport YAML 貼回即可。orchestrator 讀取 `compliance_history[]` 與階段完成標記定位中斷點。
+2. **跨 session 續跑依賴 Material Passport。** ARS 本身不跨 session 保留 orchestrator 狀態。要在新 session 續跑，把 Material Passport YAML 貼回即可；orchestrator 讀取 `compliance_history[]` 與階段完成標記定位中斷點。
 
 ### v3.4.0 compliance agent 成本
 
 在 Stage 2.5 與 Stage 4.5 加上 mode-aware `compliance_agent` 會讓 SR 全 pipeline token 多出：
 
-| Skill / mode | Input token 增量 | Output token 增量 | 成本增量 |
+| Skill / 模式 | 輸入 Token | 輸出 Token | 估算費用 |
 |---|---|---|---|
-| `deep-research systematic-review`（僅 2.5）| ~5–8K | ~3–5K | ~$0.15 |
-| 全 pipeline SR（2.5 + 4.5）| ~10–15K | ~5–8K | ~$0.30 |
-| `academic-paper full`（pre-finalize）| ~3–5K | ~2–3K | ~$0.08 |
+| `deep-research systematic-review`（僅 2.5）| +~5–8K | +~3–5K | +~$0.15 |
+| 全 pipeline SR（2.5 + 4.5）| +~10–15K | +~5–8K | +~$0.30 |
+| `academic-paper full`（pre-finalize）| +~3–5K | +~2–3K | +~$0.08 |
 
-以上是在既有 per-skill 成本之上額外產生。Cross-model verification 成本（若啟用）維持不變。
+以上為既有 per-skill 成本之上的額外增量（與上表共用 15,000 字 / 60 篇引用基準，見上表下方 footnote）。跨模型驗證成本（若啟用）維持不變。

--- a/docs/PERFORMANCE.zh-TW.md
+++ b/docs/PERFORMANCE.zh-TW.md
@@ -30,3 +30,22 @@
 | **Skip Permissions** | 跳過每次工具使用的確認提示，實現全 pipeline 不中斷的自主執行 | 啟動時加上 `claude --dangerously-skip-permissions` | [Permissions](https://docs.anthropic.com/en/docs/claude-code/cli-reference) · [Advanced Usage](https://docs.anthropic.com/en/docs/claude-code/advanced) |
 
 > **⚠️ Skip Permissions 注意事項**：此旗標會停用所有工具使用的確認對話框。請自行斟酌使用 — 在可信任的長時間 pipeline 中非常方便，但會移除手動審核的安全機制。僅在你確定接受 Claude 自動執行檔案讀寫、shell 指令等操作時才啟用。
+
+## 長時間 session 管理
+
+完整 pipeline 設計為 human-in-the-loop，每個階段都需使用者確認。實務上一次完整執行會跨越數小時到數天，遠長於 Anthropic 的 prompt cache TTL（5 分鐘）。兩項結果：
+
+1. **階段間 cache miss 是常態。** 當 stage checkpoint 停留超過 5 分鐘，下一階段會以未快取狀態讀取 context。這是 human-paced pipeline 不可避免的成本。
+2. **跨 session 續跑依賴 Material Passport。** ARS 不在 Claude Code 內保留 session state；要在新 session 續跑，把 Material Passport YAML 貼回即可。orchestrator 讀取 `compliance_history[]` 與階段完成標記定位中斷點。
+
+### v3.4.0 compliance agent 成本
+
+在 Stage 2.5 與 Stage 4.5 加上 mode-aware `compliance_agent` 會讓 SR 全 pipeline token 多出：
+
+| Skill / mode | Input token 增量 | Output token 增量 | 成本增量 |
+|---|---|---|---|
+| `deep-research systematic-review`（僅 2.5）| ~5–8K | ~3–5K | ~$0.15 |
+| 全 pipeline SR（2.5 + 4.5）| ~10–15K | ~5–8K | ~$0.30 |
+| `academic-paper full`（pre-finalize）| ~3–5K | ~2–3K | ~$0.08 |
+
+以上是在既有 per-skill 成本之上額外產生。Cross-model verification 成本（若啟用）維持不變。

--- a/docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md
+++ b/docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md
@@ -50,7 +50,7 @@ shared/
 ├── prisma_trAIce_protocol.md            ← NEW: 17 items embedded verbatim
 ├── raise_framework.md                   ← NEW: principles + 8-role matrix + scope disclaimer
 ├── compliance_checkpoint_protocol.md    ← NEW: 2.5/4.5 gate behaviour spec
-└── handoff_schemas.md                   ← CHANGED: add Schema 10 compliance_report
+└── handoff_schemas.md                   ← CHANGED: add Schema 12 compliance_report
 
 academic-pipeline/SKILL.md               ← CHANGED: Stage 2.5/4.5 payload extended
 deep-research/SKILL.md                   ← CHANGED: systematic-review mode hooks compliance
@@ -141,7 +141,7 @@ user_metadata:
   ai_tools_used: [<list of {name, version, stage, purpose}>]
 ```
 
-**Output contract** — full schema defined in §4.5 Schema 10.
+**Output contract** — full schema defined in §4.5 Schema 12.
 
 **Scope guardrails**
 
@@ -221,7 +221,7 @@ Citation: Holst D, et al. Transparent Reporting of AI in Systematic Literature R
 
 **Fail loop** reuses `pipeline_state_machine.md §Integrity Check FAIL Loop`: after 3 unresolved rounds, user picks [manual handling / remove AI usage / continue with "partially non-compliant" warning]. See §6.3.
 
-### 4.5 `shared/handoff_schemas.md` — Schema 10
+### 4.5 `shared/handoff_schemas.md` — Schema 12
 
 ```yaml
 compliance_report:
@@ -408,7 +408,7 @@ new session starts → user pastes passport YAML
 | E2 | Mode mismatch | `academic-paper full` passes `compliance_mode=systematic_review` by mistake | compliance_agent entry-point validates mode vs skill context; on mismatch returns `{decision: abort, reason: "mode/context mismatch"}`, orchestrator re-evaluates mode |
 | E3 | Block loop > 3 rounds | Stage 2.5 FAIL → backfill → FAIL → … exceeds 3 | Existing `pipeline_state_machine §Integrity Check FAIL Loop`: list unresolvable items; user picks [manual handling / remove AI usage / continue with "partially non-compliant" warning] |
 | E4 | User override block | User chooses "acknowledge limitation" after a block | Allowed with audit: `compliance_report.user_override.decision=true`; AI Self-Reflection Report must record override; disclosure statement auto-adds line "PRISMA-trAIce Mandatory item X not met; authors acknowledge limitation" |
-| E5 | Schema validation fail | compliance_report does not match Schema 10 | Pipeline halts; orchestrator reports internal error; NOT appended to compliance_history (avoid polluting audit trail) |
+| E5 | Schema validation fail | compliance_report does not match Schema 12 | Pipeline halts; orchestrator reports internal error; NOT appended to compliance_history (avoid polluting audit trail) |
 | E6 | Upstream reference drift | `prisma_trAIce_protocol.md` snapshot_date diverges from GitHub canonical | No pipeline block; compliance_agent adds `upstream_sync_status: "stale"` to report; weekly CI `check_prisma_trAIce_freshness.py` emits warning annotation |
 
 ### 6.2 E4 user override design
@@ -443,7 +443,7 @@ When compliance_agent is invoked outside the pipeline (e.g., `academic-paper ful
 
 | Case | Behaviour |
 |---|---|
-| Loaded passport predates Schema 10 | Auto-migrate: append empty `compliance_history=[]`, warn user |
+| Loaded passport predates Schema 12 | Auto-migrate: append empty `compliance_history=[]`, warn user |
 | compliance_history shows unresolved Stage 2.5 block | Do not auto-retry; display dashboard, let user choose next step |
 | Upstream PRISMA-trAIce updated during pause | E6 path; do not interrupt resume |
 
@@ -460,7 +460,7 @@ When compliance_agent is invoked outside the pipeline (e.g., `academic-paper ful
 | Test file | Coverage |
 |---|---|
 | `scripts/test_compliance_agent.py` | Input contract, mode dispatch, tier-based decision |
-| `scripts/test_compliance_report_schema.py` | Schema 10 validator + positive/negative fixtures |
+| `scripts/test_compliance_report_schema.py` | Schema 12 validator + positive/negative fixtures |
 | `scripts/check_compliance_report.py` | CI validator (patterned after `check_repro_lock.py`, `check_benchmark_report.py`) |
 
 **Key unit cases:**
@@ -520,7 +520,7 @@ Extend `.github/workflows/spec-consistency.yml`:
 |---|---|
 | v3.2 Failure Mode Checklist | Stage 2.5/4.5 runs failure-mode + compliance simultaneously, separate reports, no cross-contamination |
 | v3.3 Score Trajectory | After compliance block → retry pass, trajectory correctly records delta |
-| Material Passport Schema 9 (repro_lock) | Adding Schema 10 does not break Schema 9; passport migration smoke test |
+| Material Passport Schema 9 (repro_lock) | Adding Schema 12 does not break Schema 9; passport migration smoke test |
 | `check_spec_consistency.py` | Add SKILL.md version ↔ compliance_agent.md version consistency check |
 
 ### 7.6 Calibration (release gate)

--- a/examples/compliance/fixture_primary_raise_weak.yaml
+++ b/examples/compliance/fixture_primary_raise_weak.yaml
@@ -1,0 +1,37 @@
+# Fixture: Primary Research — Weak human_oversight description → warn (primary mode never blocks)
+# Expected validator result: exit 0, overall_decision = warn, user_action_required = true
+# prisma_trAIce: null  (cross-field rule: primary_research → null)
+# raise.mode: principles_only → roles NOT required, omitted entirely
+# CA-4 does NOT fire: all pass principles (transparency, reproducibility, fit_for_purpose) have evidence.
+
+mode: primary_research
+stage: "4.5"
+generated_at: "2026-04-20T09:30:00Z"
+
+prisma_trAIce: null
+
+raise:
+  mode: principles_only
+  principles:
+    human_oversight: warn
+    transparency: pass
+    reproducibility: pass
+    fit_for_purpose: pass
+  principle_evidence:
+    human_oversight:
+      - "[weak evidence] Section 4: manuscript states 'the first author reviewed AI outputs' with no further detail on review protocol, criteria, or proportion of outputs checked."
+    transparency:
+      - "Methods 2.2: model name (claude-sonnet-4-6), API version, and prompt template included as supplementary material."
+      - "Author contribution statement: AI use declared per journal policy."
+    reproducibility:
+      - "GitHub repository github.com/example/study2026: analysis scripts and prompts archived under MIT license."
+      - "Methods 2.3: random seed fixed (42); environment pinned in requirements.txt."
+    fit_for_purpose:
+      - "Methods 1.3: AI assistance limited to literature synthesis; all statistical analyses performed with R 4.3 without AI involvement."
+      - "Discussion 5.1: AI tool selection rationale provided; alternatives considered and scope limitations acknowledged."
+  block_decision: warn
+
+overall_decision: warn
+user_action_required: true
+
+upstream_sync_status: current

--- a/examples/compliance/fixture_sr_full_compliant.yaml
+++ b/examples/compliance/fixture_sr_full_compliant.yaml
@@ -1,0 +1,79 @@
+# Fixture: Systematic Review — Full PRISMA-trAIce + Full RAISE, all pass
+# Expected validator result: exit 0, overall_decision = pass, user_action_required = false
+# No CA-3 warning (evidence[] is non-empty).  No CA-4 warning (all principles have evidence).
+
+mode: systematic_review
+stage: "4.5"
+generated_at: "2026-04-20T09:00:00Z"
+
+prisma_trAIce:
+  items_total: 17
+  by_tier:
+    mandatory:
+      total: 9
+      pass: 9
+      fail: []
+    highly_recommended:
+      total: 1
+      pass: 1
+      fail: []
+    recommended:
+      total: 4
+      pass: 4
+      fail: []
+    optional:
+      total: 3
+      pass: 3
+      fail: []
+  block_decision: pass
+
+raise:
+  mode: full
+  principles:
+    human_oversight: pass
+    transparency: pass
+    reproducibility: pass
+    fit_for_purpose: pass
+  principle_evidence:
+    human_oversight:
+      - "Section 2.3: Two independent reviewers validated all AI-assisted title/abstract screening decisions."
+      - "PROSPERO CRD42026999001: protocol pre-registered with explicit human-review checkpoints at each stage."
+    transparency:
+      - "Appendix A: full prompt library disclosed; model version (claude-sonnet-4-6, 2026-02-01) logged."
+      - "Methods 3.1: AI tool names, versions, and date of use reported per PRISMA-trAIce T1 guidance."
+    reproducibility:
+      - "OSF repository osf.io/xyz99: search strings, inclusion/exclusion decisions, and extraction sheets archived."
+      - "Methods 3.4: seed phrases and temperature settings documented; results replicable with provided scripts."
+    fit_for_purpose:
+      - "Methods 2.1: AI screening calibrated against 200-abstract gold set; Cohen's kappa = 0.87 before deployment."
+      - "Discussion 5.2: AI limitations for this evidence base explicitly acknowledged and bounded."
+  roles:
+    evidence_synthesists:
+      - "Lead author conducted final arbitration on all AI-flagged conflicts (n = 34)."
+    ai_development_teams:
+      - "Used published claude-sonnet-4-6 API; no custom fine-tuning; model card reviewed."
+    methodologists:
+      - "Statistical reviewer confirmed meta-analytic model selection was made independently of AI outputs."
+    publishers:
+      - "Submitted to JAMA Systematic Reviews under AI-disclosure policy v2025."
+    users:
+      - "All three authors completed PRISMA-trAIce training module before study start."
+    trainers:
+      - "Internal journal club session on AI-assisted SR conducted 2026-01-15 (slides archived)."
+    organisations:
+      - "HEEACT IRB waiver obtained (HE-2026-012); institutional AI use policy version 3.1 applied."
+    funders:
+      - "Grant NSC-2026-0045: funder aware of AI assistance; no restrictions on disclosure."
+  block_decision: pass
+
+overall_decision: pass
+user_action_required: false
+
+evidence:
+  - "Appendix A (prompt library, model versions)"
+  - "OSF osf.io/xyz99 (data and scripts)"
+  - "Methods 2.1 (calibration kappa)"
+  - "Methods 3.1 (AI disclosure)"
+  - "Section 2.3 (human review checkpoints)"
+
+upstream_sync_status: current

--- a/examples/compliance/fixture_sr_full_compliant.yaml
+++ b/examples/compliance/fixture_sr_full_compliant.yaml
@@ -10,16 +10,16 @@ prisma_trAIce:
   items_total: 17
   by_tier:
     mandatory:
-      total: 9
-      pass: 9
+      total: 10
+      pass: 10
       fail: []
     highly_recommended:
       total: 1
       pass: 1
       fail: []
     recommended:
-      total: 4
-      pass: 4
+      total: 3
+      pass: 3
       fail: []
     optional:
       total: 3

--- a/examples/compliance/fixture_sr_missing_M4.yaml
+++ b/examples/compliance/fixture_sr_missing_M4.yaml
@@ -1,0 +1,70 @@
+# Fixture: Systematic Review — PRISMA-trAIce M4 (Input Data) fail → block at Stage 2.5
+# Expected validator result: exit 0 (schema valid), overall_decision = block
+# CA-3 does NOT fire (not all 17 pass).
+# CA-4 may fire for transparency and reproducibility (warn, empty evidence) — acceptable.
+
+mode: systematic_review
+stage: "2.5"
+generated_at: "2026-04-20T09:15:00Z"
+
+prisma_trAIce:
+  items_total: 17
+  by_tier:
+    mandatory:
+      total: 9
+      pass: 8
+      fail:
+        - M4
+      gaps:
+        - item_id: M4
+          reason: "[MATERIAL GAP] Input data sources fed to the AI screening tool are not described. The manuscript reports AI-assisted title/abstract screening but does not identify which database exports were used as input, preventing reproducibility assessment."
+          evidence_path: "passport/prisma_trace/M4_input_data_gap.md"
+    highly_recommended:
+      total: 1
+      pass: 1
+      fail: []
+    recommended:
+      total: 4
+      pass: 4
+      fail: []
+    optional:
+      total: 3
+      pass: 3
+      fail: []
+  block_decision: block
+
+raise:
+  mode: full
+  principles:
+    human_oversight: pass
+    transparency: warn
+    reproducibility: warn
+    fit_for_purpose: pass
+  principle_evidence:
+    human_oversight:
+      - "Methods 2.4: dual-reviewer arbitration documented for all AI-flagged conflicts."
+    transparency: []
+    reproducibility: []
+    fit_for_purpose:
+      - "Methods 2.1: screening tool validated against 150-abstract pilot set before deployment."
+  roles:
+    evidence_synthesists:
+      - "[GAP] AI input data gap (M4) means AI contribution to evidence synthesis cannot be fully audited."
+    ai_development_teams: []
+    methodologists: []
+    publishers: []
+    users: []
+    trainers: []
+    organisations: []
+    funders: []
+  block_decision: warn
+
+overall_decision: block
+user_action_required: true
+
+evidence:
+  - "passport/prisma_trace/M4_input_data_gap.md"
+  - "Methods 2.4: dual-reviewer arbitration record"
+  - "Methods 2.1: pilot-set validation log"
+
+upstream_sync_status: current

--- a/examples/compliance/fixture_sr_missing_M4.yaml
+++ b/examples/compliance/fixture_sr_missing_M4.yaml
@@ -11,8 +11,8 @@ prisma_trAIce:
   items_total: 17
   by_tier:
     mandatory:
-      total: 9
-      pass: 8
+      total: 10
+      pass: 9
       fail:
         - M4
       gaps:
@@ -24,8 +24,8 @@ prisma_trAIce:
       pass: 1
       fail: []
     recommended:
-      total: 4
-      pass: 4
+      total: 3
+      pass: 3
       fail: []
     optional:
       total: 3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pyyaml
-jsonschema>=4.17
+jsonschema[format]>=4.17

--- a/scripts/check_compliance_report.py
+++ b/scripts/check_compliance_report.py
@@ -24,7 +24,10 @@ def load_schema() -> dict:
 
 def validate(report: dict) -> list[str]:
     schema = load_schema()
-    validator = jsonschema.Draft202012Validator(schema)
+    validator = jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER,
+    )
     return [f"{list(e.absolute_path)}: {e.message}" for e in validator.iter_errors(report)]
 
 
@@ -32,18 +35,21 @@ def warn_suspicious(report: dict) -> list[str]:
     """Non-blocking soft warnings for semantic red flags."""
     warnings = []
 
-    # Sycophancy risk: all 17 items pass with no evidence citations.
+    # CA-3: sycophancy risk — all 17 items pass with no evidence citations.
     pt = report.get("prisma_trAIce")
     if isinstance(pt, dict):
         by_tier = pt.get("by_tier", {})
-        mand = by_tier.get("mandatory", {})
-        if mand.get("total") == mand.get("pass") and not report.get("evidence"):
+        all_pass = all(
+            isinstance(t, dict) and t.get("total") == t.get("pass")
+            for t in by_tier.values()
+        )
+        if all_pass and by_tier and not report.get("evidence"):
             warnings.append(
                 "WARNING: all 17 PRISMA-trAIce items pass but evidence[] is empty. "
                 "CA-3 self-check should trigger in the agent. Consider re-running."
             )
 
-    # RAISE pass with empty evidence array for that principle.
+    # CA-4: RAISE pass with empty evidence array for that principle.
     raise_obj = report.get("raise", {})
     for name, status in raise_obj.get("principles", {}).items():
         if status == "pass" and not raise_obj.get("principle_evidence", {}).get(name):
@@ -68,7 +74,12 @@ def main() -> int:
     errors = validate(report)
     if errors:
         for e in errors:
-            print(f"SCHEMA ERROR: {e}")
+            print(f"ERROR: {e}")
+        print(
+            f"\n{len(errors)} schema violation(s). "
+            "See shared/compliance_report.schema.json for field definitions.",
+            file=sys.stderr,
+        )
         return 1
 
     for w in warn_suspicious(report):

--- a/scripts/check_compliance_report.py
+++ b/scripts/check_compliance_report.py
@@ -85,7 +85,7 @@ def main() -> int:
     for w in warn_suspicious(report):
         print(w, file=sys.stderr)
 
-    print(f"OK: {args.report} is a valid compliance_report (Schema 10)")
+    print(f"OK: {args.report} is a valid compliance_report (Schema 12)")
     return 0
 
 

--- a/scripts/check_compliance_report.py
+++ b/scripts/check_compliance_report.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate an ARS compliance report against compliance_report.schema.json.
+
+Usage: python scripts/check_compliance_report.py path/to/report.json
+
+Exit 0 on pass (warnings may still be printed to stderr).
+Exit 1 on validation failure.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "shared" / "compliance_report.schema.json"
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def validate(report: dict) -> list[str]:
+    schema = load_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    return [f"{list(e.absolute_path)}: {e.message}" for e in validator.iter_errors(report)]
+
+
+def warn_suspicious(report: dict) -> list[str]:
+    """Non-blocking soft warnings for semantic red flags."""
+    warnings = []
+
+    # Sycophancy risk: all 17 items pass with no evidence citations.
+    pt = report.get("prisma_trAIce")
+    if isinstance(pt, dict):
+        by_tier = pt.get("by_tier", {})
+        mand = by_tier.get("mandatory", {})
+        if mand.get("total") == mand.get("pass") and not report.get("evidence"):
+            warnings.append(
+                "WARNING: all 17 PRISMA-trAIce items pass but evidence[] is empty. "
+                "CA-3 self-check should trigger in the agent. Consider re-running."
+            )
+
+    # RAISE pass with empty evidence array for that principle.
+    raise_obj = report.get("raise", {})
+    for name, status in raise_obj.get("principles", {}).items():
+        if status == "pass" and not raise_obj.get("principle_evidence", {}).get(name):
+            warnings.append(
+                f"WARNING: RAISE principle '{name}' marked 'pass' but principle_evidence is empty. "
+                "CA-4 should have downgraded this to 'warn [weak evidence]'."
+            )
+    return warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="Path to the compliance report JSON")
+    args = parser.parse_args()
+
+    try:
+        report = json.loads(args.report.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"ERROR: failed to load {args.report}: {exc}")
+        return 1
+
+    errors = validate(report)
+    if errors:
+        for e in errors:
+            print(f"SCHEMA ERROR: {e}")
+        return 1
+
+    for w in warn_suspicious(report):
+        print(w, file=sys.stderr)
+
+    print(f"OK: {args.report} is a valid compliance_report (Schema 10)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_prisma_trAIce_freshness.py
+++ b/scripts/check_prisma_trAIce_freshness.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Warn when shared/prisma_trAIce_protocol.md is older than 180 days.
+
+Non-blocking: exit 0 even on stale, but print warning to stderr.
+Exit 1 only on parse error (missing or malformed snapshot_date).
+
+Usage:
+  python scripts/check_prisma_trAIce_freshness.py [path]
+
+Default path: shared/prisma_trAIce_protocol.md (relative to repo root).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import yaml
+
+DEFAULT_PATH = Path(__file__).resolve().parent.parent / "shared" / "prisma_trAIce_protocol.md"
+STALE_THRESHOLD_DAYS = 180
+
+
+def extract_frontmatter(text: str) -> dict:
+    """Extract YAML frontmatter between opening and closing '---' fences."""
+    if not text.startswith("---"):
+        raise ValueError("No opening '---' fence")
+    lines = text.splitlines()
+    end_idx = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        raise ValueError("No closing '---' fence")
+    fm_text = "\n".join(lines[1:end_idx])
+    data = yaml.safe_load(fm_text)
+    if not isinstance(data, dict):
+        raise ValueError("Frontmatter is not a mapping")
+    return data
+
+
+def parse_snapshot_date(fm: dict) -> date:
+    raw = fm.get("snapshot_date")
+    if not raw:
+        raise ValueError("snapshot_date missing")
+    if isinstance(raw, date):
+        return raw
+    try:
+        return datetime.strptime(str(raw), "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError(f"snapshot_date malformed: {raw}") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, nargs="?", default=DEFAULT_PATH)
+    args = parser.parse_args()
+
+    try:
+        text = args.path.read_text(encoding="utf-8")
+        fm = extract_frontmatter(text)
+        snapshot = parse_snapshot_date(fm)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    age_days = (date.today() - snapshot).days
+    if age_days > STALE_THRESHOLD_DAYS:
+        print(
+            f"WARNING: prisma_trAIce_protocol.md snapshot is {age_days} days old "
+            f"(threshold {STALE_THRESHOLD_DAYS}). Upstream may have updated — "
+            f"please review {fm.get('upstream_source', 'cqh4046/PRISMA-trAIce')} "
+            f"and re-sync if needed. (STALE status surfaced; non-blocking.)",
+            file=sys.stderr,
+        )
+        # Non-blocking: exit 0 per E6 in spec
+    else:
+        print(f"OK: snapshot is {age_days} days old (current)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_prisma_trAIce_freshness.py
+++ b/scripts/check_prisma_trAIce_freshness.py
@@ -62,7 +62,7 @@ def main() -> int:
         text = args.path.read_text(encoding="utf-8")
         fm = extract_frontmatter(text)
         snapshot = parse_snapshot_date(fm)
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, ValueError, yaml.YAMLError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
@@ -71,11 +71,10 @@ def main() -> int:
         print(
             f"WARNING: prisma_trAIce_protocol.md snapshot is {age_days} days old "
             f"(threshold {STALE_THRESHOLD_DAYS}). Upstream may have updated — "
-            f"please review {fm.get('upstream_source', 'cqh4046/PRISMA-trAIce')} "
+            f"please review {fm.get('upstream_source', 'https://github.com/cqh4046/PRISMA-trAIce')} "
             f"and re-sync if needed. (STALE status surfaced; non-blocking.)",
             file=sys.stderr,
         )
-        # Non-blocking: exit 0 per E6 in spec
     else:
         print(f"OK: snapshot is {age_days} days old (current)")
     return 0

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.3.6 (2026-04-15)")
+    expect_contains(rel_path, "Last updated: v3.4.0 (2026-04-20)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.3.6")
+    expect_contains(rel_path, "**Suite version**: 3.4.0")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.6-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.6")
+    expect_contains(rel_path, "version-v3.4.0-blue")
+    expect_contains(rel_path, "releases/tag/v3.4.0")
+    expect_contains(rel_path, "### v3.4.0 (2026-04-20)")
     expect_contains(rel_path, "### v3.3.6 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.5 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.4 (2026-04-15)")
@@ -193,8 +194,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.3.6-blue")
-    expect_contains(rel_path, "releases/tag/v3.3.6")
+    expect_contains(rel_path, "version-v3.4.0-blue")
+    expect_contains(rel_path, "releases/tag/v3.4.0")
+    expect_contains(rel_path, "### v3.4.0（2026-04-20）")
     expect_contains(rel_path, "### v3.3.6 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.5 (2026-04-15)")
     expect_contains(rel_path, "### v3.3.4 (2026-04-15)")

--- a/scripts/test_check_compliance_report.py
+++ b/scripts/test_check_compliance_report.py
@@ -12,6 +12,7 @@ SCHEMA = Path(__file__).resolve().parent.parent / "shared" / "compliance_report.
 
 
 def _valid_sr_report() -> dict:
+    """Returns a fresh fully-valid SR compliance report. Callers may mutate freely."""
     return {
         "mode": "systematic_review",
         "stage": "2.5",
@@ -59,6 +60,7 @@ def _valid_sr_report() -> dict:
 
 
 def _valid_primary_report() -> dict:
+    """Returns a fresh fully-valid primary-research compliance report. Callers may mutate freely."""
     return {
         "mode": "primary_research",
         "stage": "4.5",
@@ -94,79 +96,63 @@ def _write(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data), encoding="utf-8")
 
 
+def _run_with(report: dict) -> subprocess.CompletedProcess:
+    """Write report to a temp file and run the validator against it."""
+    with TemporaryDirectory() as tmp:
+        p = Path(tmp) / "r.json"
+        _write(p, report)
+        return _run(p)
+
+
 class TestComplianceReportValidator(unittest.TestCase):
     def test_valid_sr_report_passes(self) -> None:
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, _valid_sr_report())
-            result = _run(p)
-            self.assertEqual(result.returncode, 0, msg=result.stderr)
+        result = _run_with(_valid_sr_report())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
 
     def test_valid_primary_report_passes(self) -> None:
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, _valid_primary_report())
-            result = _run(p)
-            self.assertEqual(result.returncode, 0, msg=result.stderr)
+        result = _run_with(_valid_primary_report())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
 
     def test_missing_required_field_fails(self) -> None:
         report = _valid_sr_report()
         del report["overall_decision"]
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
-            self.assertIn("overall_decision", result.stdout + result.stderr)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("overall_decision", result.stdout + result.stderr)
 
     def test_invalid_mode_enum_fails(self) -> None:
         report = _valid_sr_report()
         report["mode"] = "random_mode"
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_invalid_stage_enum_fails(self) -> None:
         report = _valid_sr_report()
         report["stage"] = "3.5"
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_primary_with_populated_prisma_trAIce_fails(self) -> None:
         # Schema enforces: mode=primary_research implies prisma_trAIce is null.
         # This cross-field rule was added when hardening the schema per code review.
         report = _valid_primary_report()
         report["prisma_trAIce"] = _valid_sr_report()["prisma_trAIce"]
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_sr_with_null_prisma_trAIce_fails(self) -> None:
         # Cross-field rule: systematic_review requires prisma_trAIce object.
         report = _valid_sr_report()
         report["prisma_trAIce"] = None
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_raise_full_without_roles_fails(self) -> None:
         # Cross-field rule: raise.mode=full requires roles.
         report = _valid_sr_report()
         del report["raise"]["roles"]
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_invalid_scope_pattern_fails(self) -> None:
         # user_override.scope must match PRISMA-trAIce IDs or RAISE principles.
@@ -177,21 +163,15 @@ class TestComplianceReportValidator(unittest.TestCase):
             "rationale": "Test invalid scope",
             "scope": ["NOT_AN_ITEM"],
         }
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_extra_top_level_property_fails(self) -> None:
         # additionalProperties: false on top-level rejects typos.
         report = _valid_sr_report()
         report["bogus_extra"] = "x"
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_user_override_missing_rationale_fails(self) -> None:
         report = _valid_sr_report()
@@ -201,11 +181,8 @@ class TestComplianceReportValidator(unittest.TestCase):
             "rationale": "",
             "scope": ["M4"],
         }
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_user_override_empty_scope_fails(self) -> None:
         report = _valid_sr_report()
@@ -215,11 +192,8 @@ class TestComplianceReportValidator(unittest.TestCase):
             "rationale": "Insufficient time to backfill M4 details before submission deadline.",
             "scope": [],
         }
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 1)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
 
     def test_valid_override_with_real_ids_passes(self) -> None:
         # Positive: scope containing real PRISMA-trAIce IDs and RAISE principle names.
@@ -230,11 +204,77 @@ class TestComplianceReportValidator(unittest.TestCase):
             "rationale": "Material unavailable to backfill M4 before venue deadline.",
             "scope": ["M4", "transparency"],
         }
-        with TemporaryDirectory() as tmp:
-            p = Path(tmp) / "r.json"
-            _write(p, report)
-            result = _run(p)
-            self.assertEqual(result.returncode, 0, msg=result.stderr)
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    # --- Fix 6: 8 new tests ---
+
+    def test_invalid_generated_at_format_fails(self) -> None:
+        """I1: date-time format enforcement."""
+        report = _valid_sr_report()
+        report["generated_at"] = "NOT_A_DATE"
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
+
+    def test_invalid_override_timestamp_format_fails(self) -> None:
+        """I1: date-time format applies to user_override.timestamp too."""
+        report = _valid_sr_report()
+        report["user_override"] = {
+            "decision": True,
+            "timestamp": "not-a-timestamp",
+            "rationale": "test",
+            "scope": ["M4"],
+        }
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
+
+    def test_items_total_not_17_fails(self) -> None:
+        """Schema enforces items_total == 17 (const)."""
+        report = _valid_sr_report()
+        report["prisma_trAIce"]["items_total"] = 18
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
+
+    def test_invalid_decision_enum_fails(self) -> None:
+        """$defs.decision enum enforcement (block/warn/pass)."""
+        report = _valid_sr_report()
+        report["overall_decision"] = "maybe"
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
+
+    def test_invalid_principle_status_enum_fails(self) -> None:
+        """$defs.principle_status enum enforcement (pass/warn/fail)."""
+        report = _valid_sr_report()
+        report["raise"]["principles"]["human_oversight"] = "undecided"
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 1)
+
+    def test_ca3_all_17_pass_empty_evidence_warns(self) -> None:
+        """CA-3 fires when all 17 items pass AND evidence[] is empty. Exit 0; warning on stderr."""
+        report = _valid_sr_report()
+        report["evidence"] = []
+        # All tiers already all-pass in _valid_sr_report
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("CA-3", result.stderr)
+
+    def test_ca3_mandatory_only_pass_does_not_warn(self) -> None:
+        """CA-3 must NOT fire when only Mandatory is all-pass but HR/R/O have failures."""
+        report = _valid_sr_report()
+        report["prisma_trAIce"]["by_tier"]["highly_recommended"]["pass"] = 0
+        report["prisma_trAIce"]["by_tier"]["highly_recommended"]["fail"] = ["M7"]
+        report["evidence"] = []
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertNotIn("CA-3", result.stderr)
+
+    def test_ca4_principle_pass_no_evidence_warns(self) -> None:
+        """CA-4 fires when a RAISE principle is 'pass' but principle_evidence for it is empty."""
+        report = _valid_sr_report()
+        report["raise"]["principle_evidence"]["transparency"] = []
+        result = _run_with(report)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("CA-4", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_compliance_report.py
+++ b/scripts/test_check_compliance_report.py
@@ -1,4 +1,4 @@
-"""Unit tests for check_compliance_report.py (Schema 10 validator)."""
+"""Unit tests for check_compliance_report.py (Schema 12 validator)."""
 import json
 import subprocess
 import unittest

--- a/scripts/test_check_compliance_report.py
+++ b/scripts/test_check_compliance_report.py
@@ -1,0 +1,241 @@
+"""Unit tests for check_compliance_report.py (Schema 10 validator)."""
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "check_compliance_report.py"
+SCHEMA = Path(__file__).resolve().parent.parent / "shared" / "compliance_report.schema.json"
+
+
+def _valid_sr_report() -> dict:
+    return {
+        "mode": "systematic_review",
+        "stage": "2.5",
+        "generated_at": "2026-04-20T10:00:00Z",
+        "prisma_trAIce": {
+            "items_total": 17,
+            "by_tier": {
+                "mandatory": {"total": 9, "pass": 9, "fail": []},
+                "highly_recommended": {"total": 1, "pass": 1, "fail": []},
+                "recommended": {"total": 4, "pass": 4, "fail": []},
+                "optional": {"total": 3, "pass": 3, "fail": []},
+            },
+            "block_decision": "pass",
+        },
+        "raise": {
+            "mode": "full",
+            "principles": {
+                "human_oversight": "pass",
+                "transparency": "pass",
+                "reproducibility": "pass",
+                "fit_for_purpose": "pass",
+            },
+            "principle_evidence": {
+                "human_oversight": ["Stage 2: bibliography.yaml L12"],
+                "transparency": ["manuscript §Methods L40"],
+                "reproducibility": ["passport.repro_lock"],
+                "fit_for_purpose": ["Stage 1: scoping.md L5"],
+            },
+            "roles": {
+                "evidence_synthesists": ["manuscript §Acknowledgements"],
+                "ai_development_teams": ["CHANGELOG"],
+                "methodologists": [],
+                "publishers": [],
+                "users": [],
+                "trainers": [],
+                "organisations": [],
+                "funders": [],
+            },
+            "block_decision": "pass",
+        },
+        "overall_decision": "pass",
+        "user_action_required": False,
+        "evidence": ["manuscript §Methods"],
+    }
+
+
+def _valid_primary_report() -> dict:
+    return {
+        "mode": "primary_research",
+        "stage": "4.5",
+        "generated_at": "2026-04-20T11:00:00Z",
+        "prisma_trAIce": None,
+        "raise": {
+            "mode": "principles_only",
+            "principles": {
+                "human_oversight": "pass",
+                "transparency": "warn",
+                "reproducibility": "pass",
+                "fit_for_purpose": "pass",
+            },
+            "principle_evidence": {
+                "human_oversight": ["manuscript §Limitations"],
+                "transparency": [],
+                "reproducibility": ["manuscript §Methods"],
+                "fit_for_purpose": ["manuscript §Introduction"],
+            },
+            "block_decision": "warn",
+        },
+        "overall_decision": "warn",
+        "user_action_required": True,
+        "evidence": [],
+    }
+
+
+def _run(path: Path) -> subprocess.CompletedProcess:
+    return run_script(SCRIPT, str(path))
+
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestComplianceReportValidator(unittest.TestCase):
+    def test_valid_sr_report_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, _valid_sr_report())
+            result = _run(p)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_valid_primary_report_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, _valid_primary_report())
+            result = _run(p)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_missing_required_field_fails(self) -> None:
+        report = _valid_sr_report()
+        del report["overall_decision"]
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("overall_decision", result.stdout + result.stderr)
+
+    def test_invalid_mode_enum_fails(self) -> None:
+        report = _valid_sr_report()
+        report["mode"] = "random_mode"
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_invalid_stage_enum_fails(self) -> None:
+        report = _valid_sr_report()
+        report["stage"] = "3.5"
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_primary_with_populated_prisma_trAIce_fails(self) -> None:
+        # Schema enforces: mode=primary_research implies prisma_trAIce is null.
+        # This cross-field rule was added when hardening the schema per code review.
+        report = _valid_primary_report()
+        report["prisma_trAIce"] = _valid_sr_report()["prisma_trAIce"]
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_sr_with_null_prisma_trAIce_fails(self) -> None:
+        # Cross-field rule: systematic_review requires prisma_trAIce object.
+        report = _valid_sr_report()
+        report["prisma_trAIce"] = None
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_raise_full_without_roles_fails(self) -> None:
+        # Cross-field rule: raise.mode=full requires roles.
+        report = _valid_sr_report()
+        del report["raise"]["roles"]
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_invalid_scope_pattern_fails(self) -> None:
+        # user_override.scope must match PRISMA-trAIce IDs or RAISE principles.
+        report = _valid_sr_report()
+        report["user_override"] = {
+            "decision": True,
+            "timestamp": "2026-04-20T12:00:00Z",
+            "rationale": "Test invalid scope",
+            "scope": ["NOT_AN_ITEM"],
+        }
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_extra_top_level_property_fails(self) -> None:
+        # additionalProperties: false on top-level rejects typos.
+        report = _valid_sr_report()
+        report["bogus_extra"] = "x"
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_user_override_missing_rationale_fails(self) -> None:
+        report = _valid_sr_report()
+        report["user_override"] = {
+            "decision": True,
+            "timestamp": "2026-04-20T12:00:00Z",
+            "rationale": "",
+            "scope": ["M4"],
+        }
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_user_override_empty_scope_fails(self) -> None:
+        report = _valid_sr_report()
+        report["user_override"] = {
+            "decision": True,
+            "timestamp": "2026-04-20T12:00:00Z",
+            "rationale": "Insufficient time to backfill M4 details before submission deadline.",
+            "scope": [],
+        }
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 1)
+
+    def test_valid_override_with_real_ids_passes(self) -> None:
+        # Positive: scope containing real PRISMA-trAIce IDs and RAISE principle names.
+        report = _valid_sr_report()
+        report["user_override"] = {
+            "decision": True,
+            "timestamp": "2026-04-20T12:00:00Z",
+            "rationale": "Material unavailable to backfill M4 before venue deadline.",
+            "scope": ["M4", "transparency"],
+        }
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.json"
+            _write(p, report)
+            result = _run(p)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_prisma_trAIce_freshness.py
+++ b/scripts/test_check_prisma_trAIce_freshness.py
@@ -1,0 +1,58 @@
+"""Unit tests for check_prisma_trAIce_freshness.py."""
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "check_prisma_trAIce_freshness.py"
+
+
+def _write_protocol(path: Path, snapshot_date: str) -> None:
+    path.write_text(
+        f"""---
+snapshot_date: "{snapshot_date}"
+upstream_source: "https://github.com/cqh4046/PRISMA-trAIce"
+---
+
+# Protocol
+body
+""",
+        encoding="utf-8",
+    )
+
+
+class TestFreshnessCheck(unittest.TestCase):
+    def test_recent_snapshot_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "prisma_trAIce_protocol.md"
+            _write_protocol(p, "2026-03-01")
+            result = run_script(SCRIPT, str(p))
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_stale_snapshot_warns_but_exits_zero(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "prisma_trAIce_protocol.md"
+            _write_protocol(p, "2024-01-01")
+            result = run_script(SCRIPT, str(p))
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("stale", (result.stdout + result.stderr).lower())
+
+    def test_missing_snapshot_date_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "prisma_trAIce_protocol.md"
+            p.write_text("# No frontmatter\n", encoding="utf-8")
+            result = run_script(SCRIPT, str(p))
+            self.assertEqual(result.returncode, 1)
+
+    def test_malformed_date_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "prisma_trAIce_protocol.md"
+            _write_protocol(p, "not-a-date")
+            result = run_script(SCRIPT, str(p))
+            self.assertEqual(result.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_prisma_trAIce_freshness.py
+++ b/scripts/test_check_prisma_trAIce_freshness.py
@@ -1,5 +1,4 @@
 """Unit tests for check_prisma_trAIce_freshness.py."""
-import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -52,6 +51,17 @@ class TestFreshnessCheck(unittest.TestCase):
             _write_protocol(p, "not-a-date")
             result = run_script(SCRIPT, str(p))
             self.assertEqual(result.returncode, 1)
+
+    def test_malformed_yaml_fails_cleanly(self) -> None:
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "prisma_trAIce_protocol.md"
+            p.write_text(
+                '---\nsnapshot_date: "2026-03-01\nunclosed_quote: "yes\n---\n# body\n',
+                encoding="utf-8",
+            )
+            result = run_script(SCRIPT, str(p))
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("ERROR", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test_validate_compliance_fixtures.py
+++ b/scripts/test_validate_compliance_fixtures.py
@@ -1,0 +1,35 @@
+"""Unit tests for validate_compliance_fixtures.py."""
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "validate_compliance_fixtures.py"
+REAL_FIXTURES = Path(__file__).resolve().parent.parent / "examples" / "compliance"
+
+
+class TestValidateComplianceFixtures(unittest.TestCase):
+    def test_real_fixtures_all_pass(self) -> None:
+        result = run_script(SCRIPT, str(REAL_FIXTURES))
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("OK", result.stdout)
+        self.assertNotIn("FAIL", result.stdout)
+
+    def test_empty_dir_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            result = run_script(SCRIPT, tmp)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("no fixture", result.stderr.lower())
+
+    def test_invalid_fixture_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "fixture_invalid.yaml"
+            bad.write_text("mode: not_a_valid_mode\n", encoding="utf-8")
+            result = run_script(SCRIPT, tmp)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("FAIL", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_compliance_fixtures.py
+++ b/scripts/test_validate_compliance_fixtures.py
@@ -15,6 +15,7 @@ class TestValidateComplianceFixtures(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("OK", result.stdout)
         self.assertNotIn("FAIL", result.stdout)
+        self.assertNotIn("no fixture", result.stderr.lower())
 
     def test_empty_dir_fails(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/scripts/validate_compliance_fixtures.py
+++ b/scripts/validate_compliance_fixtures.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate all compliance_report YAML fixtures against Schema 12.
+
+Converts each examples/compliance/fixture_*.yaml to JSON in a temp file,
+then invokes scripts/check_compliance_report.py. Exits 0 if every fixture
+validates; exits 1 on first failure.
+
+Usage:
+  python scripts/validate_compliance_fixtures.py [fixture_dir]
+
+Default fixture_dir: examples/compliance (relative to repo root).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DIR = REPO_ROOT / "examples" / "compliance"
+VALIDATOR = REPO_ROOT / "scripts" / "check_compliance_report.py"
+
+
+def validate_fixture(yaml_path: Path) -> tuple[bool, str]:
+    data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    ) as tmp:
+        json.dump(data, tmp)
+        tmp_path = Path(tmp.name)
+    try:
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), str(tmp_path)],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0, (result.stdout + result.stderr).strip()
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixture_dir", type=Path, nargs="?", default=DEFAULT_DIR)
+    args = parser.parse_args()
+
+    fixtures = sorted(args.fixture_dir.glob("fixture_*.yaml"))
+    if not fixtures:
+        print(f"ERROR: no fixture_*.yaml files in {args.fixture_dir}", file=sys.stderr)
+        return 1
+
+    failed = 0
+    for fx in fixtures:
+        ok, output = validate_fixture(fx)
+        status = "OK" if ok else "FAIL"
+        print(f"[{status}] {fx.name}: {output}")
+        if not ok:
+            failed += 1
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_compliance_fixtures.py
+++ b/scripts/validate_compliance_fixtures.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Validate all compliance_report YAML fixtures against Schema 12.
 
-Converts each examples/compliance/fixture_*.yaml to JSON in a temp file,
-then invokes scripts/check_compliance_report.py. Exits 0 if every fixture
-validates; exits 1 on first failure.
+Loads each examples/compliance/fixture_*.yaml in-process and runs it
+through scripts.check_compliance_report.validate(). Exits 0 if every
+fixture validates; exits 1 on first failure or if no fixtures are found.
 
 Usage:
   python scripts/validate_compliance_fixtures.py [fixture_dir]
@@ -13,35 +13,20 @@ Default fixture_dir: examples/compliance (relative to repo root).
 from __future__ import annotations
 
 import argparse
-import json
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import yaml
 
+from check_compliance_report import validate
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_DIR = REPO_ROOT / "examples" / "compliance"
-VALIDATOR = REPO_ROOT / "scripts" / "check_compliance_report.py"
 
 
-def validate_fixture(yaml_path: Path) -> tuple[bool, str]:
+def validate_fixture(yaml_path: Path) -> list[str]:
     data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", delete=False, encoding="utf-8"
-    ) as tmp:
-        json.dump(data, tmp)
-        tmp_path = Path(tmp.name)
-    try:
-        result = subprocess.run(
-            [sys.executable, str(VALIDATOR), str(tmp_path)],
-            capture_output=True,
-            text=True,
-        )
-        return result.returncode == 0, (result.stdout + result.stderr).strip()
-    finally:
-        tmp_path.unlink(missing_ok=True)
+    return validate(data)
 
 
 def main() -> int:
@@ -56,11 +41,14 @@ def main() -> int:
 
     failed = 0
     for fx in fixtures:
-        ok, output = validate_fixture(fx)
-        status = "OK" if ok else "FAIL"
-        print(f"[{status}] {fx.name}: {output}")
-        if not ok:
+        errors = validate_fixture(fx)
+        if errors:
+            print(f"[FAIL] {fx.name}:")
+            for e in errors:
+                print(f"  {e}")
             failed += 1
+        else:
+            print(f"[OK] {fx.name}")
     return 0 if failed == 0 else 1
 
 

--- a/shared/agents/compliance_agent.md
+++ b/shared/agents/compliance_agent.md
@@ -25,7 +25,7 @@ Mode-aware agent that runs PRISMA-trAIce + RAISE compliance checks at Stage 2.5 
 
 - **Reads:** manuscript draft, methodology blueprint, bibliography, material passport, user-provided AI tool metadata
 - **Writes nothing to the manuscript.** Output is a separate `compliance_report` handed to the orchestrator.
-- **Does not hallucinate missing items.** Anti-Leakage Protocol applies: missing material → `[MATERIAL GAP: <item_id>]` in the gap reason.
+- **Does not hallucinate missing items.** Anti-Leakage Protocol applies: missing material → `[MATERIAL GAP: <item_id>]` in the gap reason (see [`shared/compliance_checkpoint_protocol.md#canonical-gap-tag-vocabulary`](../compliance_checkpoint_protocol.md#canonical-gap-tag-vocabulary)).
 
 ## Input contract
 
@@ -49,7 +49,7 @@ user_metadata:
 
 ## Dispatch logic
 
-```
+```python
 if compliance_mode == "systematic_review":
     run PRISMA-trAIce checks (Stage-specific item subset)
     run RAISE full (principles + 8-role matrix)
@@ -71,6 +71,8 @@ elif compliance_mode == "primary_research":
 | 2.5 | M1, M2, M3, M4, M5, M6, M7, M8, M9, M10 | human_oversight, fit_for_purpose |
 | 4.5 | T1, A1, I1, R1, R2, D1, D2 | transparency, reproducibility (+ full 8-role matrix for SR) |
 
+Items within each stage subset are independent and MAY be evaluated concurrently. The agent SHOULD read `material_passport.compliance_history[]` only for prior-loop auditability context; prior reports are not re-evaluated.
+
 ## Tier → decision mapping (SR mode)
 
 | Tier | FAIL → |
@@ -91,7 +93,7 @@ Before finalising the report, the agent runs four self-checks. Any flagged check
 | CA-1 | Am I quoting PRISMA-trAIce items from memory or from `shared/prisma_trAIce_protocol.md`? | Re-read the protocol file; requote. |
 | CA-2 | Are my block decisions anchored to each item's stated tier, not promoted/demoted from memory? | Re-read tier assignments; correct any drift. |
 | CA-3 | **SR mode only.** Did all 17 items pass AND `evidence[]` is empty? (Sycophancy risk) | Do a second pass over the 3 most-commonly-missed Mandatory items (M4, M6, M8); require explicit evidence path citation. |
-| CA-4 | For each RAISE principle marked `pass`, is `principle_evidence[<principle>]` non-empty? | Downgrade the principle to `warn` with note `[weak evidence]`. |
+| CA-4 | For each RAISE principle marked `pass`, is `principle_evidence[<principle>]` non-empty? | Downgrade the principle to `warn` with note `[WEAK EVIDENCE]`. |
 
 Self-check failures are not errors — they are the agent's guardrail. Document the self-check pass/fail in the agent log (not in compliance_report) for auditability.
 

--- a/shared/agents/compliance_agent.md
+++ b/shared/agents/compliance_agent.md
@@ -19,7 +19,7 @@ related_protocols:
 
 # compliance_agent
 
-Mode-aware agent that runs PRISMA-trAIce + RAISE compliance checks at Stage 2.5 / 4.5 Integrity Gates, producing Schema 10 `compliance_report` outputs.
+Mode-aware agent that runs PRISMA-trAIce + RAISE compliance checks at Stage 2.5 / 4.5 Integrity Gates, producing Schema 12 `compliance_report` outputs.
 
 ## Scope
 
@@ -45,7 +45,7 @@ user_metadata:
 
 ## Output contract
 
-`compliance_report` conforming to `shared/compliance_report.schema.json` (Schema 10). Appended to `material_passport.compliance_history[]` by the orchestrator.
+`compliance_report` conforming to `shared/compliance_report.schema.json` (Schema 12). Appended to `material_passport.compliance_history[]` by the orchestrator.
 
 ## Dispatch logic
 
@@ -114,7 +114,7 @@ Self-check failures are not errors — they are the agent's guardrail. Document 
 
 ## Invocation protocol
 
-The orchestrator (or standalone skill) passes the input contract via the Agent tool with `model: sonnet` or higher (per user CLAUDE.md: never haiku). The agent returns the serialised compliance_report. The orchestrator validates against Schema 10 before appending to passport.
+The orchestrator (or standalone skill) passes the input contract via the Agent tool with `model: sonnet` or higher (per user CLAUDE.md: never haiku). The agent returns the serialised compliance_report. The orchestrator validates against Schema 12 before appending to passport.
 
 ## Related reading
 

--- a/shared/agents/compliance_agent.md
+++ b/shared/agents/compliance_agent.md
@@ -13,7 +13,7 @@ related_protocols:
   - shared/raise_framework.md
   - shared/compliance_checkpoint_protocol.md
   - shared/compliance_report.schema.json
-  - shared/anti_leakage_protocol.md
+  - academic-paper/references/anti_leakage_protocol.md
   - academic-pipeline/references/ai_research_failure_modes.md
 ---
 
@@ -90,7 +90,7 @@ Before finalising the report, the agent runs four self-checks. Any flagged check
 |---|---|---|
 | CA-1 | Am I quoting PRISMA-trAIce items from memory or from `shared/prisma_trAIce_protocol.md`? | Re-read the protocol file; requote. |
 | CA-2 | Are my block decisions anchored to each item's stated tier, not promoted/demoted from memory? | Re-read tier assignments; correct any drift. |
-| CA-3 | Did all 17 items pass AND `evidence[]` is empty? (Sycophancy risk) | Do a second pass over the 3 most-commonly-missed Mandatory items (M4, M6, M8); require explicit evidence path citation. |
+| CA-3 | **SR mode only.** Did all 17 items pass AND `evidence[]` is empty? (Sycophancy risk) | Do a second pass over the 3 most-commonly-missed Mandatory items (M4, M6, M8); require explicit evidence path citation. |
 | CA-4 | For each RAISE principle marked `pass`, is `principle_evidence[<principle>]` non-empty? | Downgrade the principle to `warn` with note `[weak evidence]`. |
 
 Self-check failures are not errors — they are the agent's guardrail. Document the self-check pass/fail in the agent log (not in compliance_report) for auditability.
@@ -119,5 +119,5 @@ The orchestrator (or standalone skill) passes the input contract via the Agent t
 - `shared/prisma_trAIce_protocol.md` — item-level checks
 - `shared/raise_framework.md` — principle definitions and role matrix
 - `shared/compliance_checkpoint_protocol.md` — checkpoint behaviour and override ladder
-- `shared/anti_leakage_protocol.md` — gap-marking discipline
+- `academic-paper/references/anti_leakage_protocol.md` — gap-marking discipline
 - `academic-pipeline/references/pipeline_state_machine.md` — FAIL-loop integration

--- a/shared/agents/compliance_agent.md
+++ b/shared/agents/compliance_agent.md
@@ -1,0 +1,123 @@
+---
+name: compliance_agent
+version: 1.0.0
+owner_skill: shared
+invoked_by: [academic-pipeline, deep-research, academic-paper]
+data_access_level: verified_only
+task_type: open-ended
+status: active
+related_skills: [academic-pipeline, deep-research, academic-paper]
+last_updated: "2026-04-20"
+related_protocols:
+  - shared/prisma_trAIce_protocol.md
+  - shared/raise_framework.md
+  - shared/compliance_checkpoint_protocol.md
+  - shared/compliance_report.schema.json
+  - shared/anti_leakage_protocol.md
+  - academic-pipeline/references/ai_research_failure_modes.md
+---
+
+# compliance_agent
+
+Mode-aware agent that runs PRISMA-trAIce + RAISE compliance checks at Stage 2.5 / 4.5 Integrity Gates, producing Schema 10 `compliance_report` outputs.
+
+## Scope
+
+- **Reads:** manuscript draft, methodology blueprint, bibliography, material passport, user-provided AI tool metadata
+- **Writes nothing to the manuscript.** Output is a separate `compliance_report` handed to the orchestrator.
+- **Does not hallucinate missing items.** Anti-Leakage Protocol applies: missing material → `[MATERIAL GAP: <item_id>]` in the gap reason.
+
+## Input contract
+
+```yaml
+compliance_mode: "systematic_review" | "primary_research" | "other_evidence_synthesis"
+stage: "2.5" | "4.5"
+materials:
+  manuscript_draft: <path or inline>
+  methodology_blueprint: <path>
+  bibliography: <path>
+  material_passport: <Schema 9 payload>
+user_metadata:
+  intended_venue: <string or null>
+  ai_tools_used:
+    - {name, version, developer, stage, purpose, access_url_or_doi}
+```
+
+## Output contract
+
+`compliance_report` conforming to `shared/compliance_report.schema.json` (Schema 10). Appended to `material_passport.compliance_history[]` by the orchestrator.
+
+## Dispatch logic
+
+```
+if compliance_mode == "systematic_review":
+    run PRISMA-trAIce checks (Stage-specific item subset)
+    run RAISE full (principles + 8-role matrix)
+    block_decision respects tier semantics
+elif compliance_mode == "other_evidence_synthesis":
+    run PRISMA-trAIce checks in "adaptation" mode (items become Info)
+    run RAISE full
+    block_decision capped at warn
+elif compliance_mode == "primary_research":
+    run RAISE principles_only
+    set prisma_trAIce to null
+    block_decision capped at warn
+```
+
+## Stage behaviour
+
+| Stage | PRISMA-trAIce items checked | RAISE focus |
+|---|---|---|
+| 2.5 | M1, M2, M3, M4, M5, M6, M7, M8, M9, M10 | human_oversight, fit_for_purpose |
+| 4.5 | T1, A1, I1, R1, R2, D1, D2 | transparency, reproducibility (+ full 8-role matrix for SR) |
+
+## Tier → decision mapping (SR mode)
+
+| Tier | FAIL → |
+|---|---|
+| Mandatory | `block_decision = block` |
+| Highly Recommended | `block_decision = warn` |
+| Recommended | `block_decision = pass` (logged as info) |
+| Optional | `block_decision = pass` (logged as info) |
+
+Multiple tier contributions aggregate using `max_severity` (see `compliance_checkpoint_protocol.md §Decision precedence`).
+
+## Self-check protocol
+
+Before finalising the report, the agent runs four self-checks. Any flagged check requires re-examination:
+
+| ID | Question | On fail |
+|---|---|---|
+| CA-1 | Am I quoting PRISMA-trAIce items from memory or from `shared/prisma_trAIce_protocol.md`? | Re-read the protocol file; requote. |
+| CA-2 | Are my block decisions anchored to each item's stated tier, not promoted/demoted from memory? | Re-read tier assignments; correct any drift. |
+| CA-3 | Did all 17 items pass AND `evidence[]` is empty? (Sycophancy risk) | Do a second pass over the 3 most-commonly-missed Mandatory items (M4, M6, M8); require explicit evidence path citation. |
+| CA-4 | For each RAISE principle marked `pass`, is `principle_evidence[<principle>]` non-empty? | Downgrade the principle to `warn` with note `[weak evidence]`. |
+
+Self-check failures are not errors — they are the agent's guardrail. Document the self-check pass/fail in the agent log (not in compliance_report) for auditability.
+
+## Error behaviour
+
+| Error | Handling |
+|---|---|
+| Missing input material | Apply Anti-Leakage: mark `[MATERIAL GAP]`, item auto-FAILs, tier dictates block/warn. Never hallucinate. |
+| Mode/context mismatch (e.g. `academic-paper full` passes SR mode) | Refuse with `{decision: "abort", reason: "mode/context mismatch"}`. Orchestrator must re-evaluate and re-invoke. |
+| Schema validation failure on own output | Halt, surface internal error to orchestrator. Do NOT append invalid report to compliance_history. |
+| Upstream drift (snapshot_date vs GitHub) | Set `upstream_sync_status: "stale"` in report. Non-blocking. |
+
+## Interaction with existing agents
+
+- Runs AFTER `integrity_verification_agent` (existing) at Stage 2.5 / 4.5 — compliance extends integrity, does not replace it.
+- Runs ALONGSIDE `failure_mode_checklist` (v3.2). Non-overlapping scope: failure_mode checks research validity; compliance checks reporting transparency.
+- Provides output consumed by `report_compiler_agent` (at Stage 6) for the AI Self-Reflection Report compliance summary.
+
+## Invocation protocol
+
+The orchestrator (or standalone skill) passes the input contract via the Agent tool with `model: sonnet` or higher (per user CLAUDE.md: never haiku). The agent returns the serialised compliance_report. The orchestrator validates against Schema 10 before appending to passport.
+
+## Related reading
+
+- `shared/prisma_trAIce_protocol.md` — item-level checks
+- `shared/raise_framework.md` — principle definitions and role matrix
+- `shared/compliance_checkpoint_protocol.md` — checkpoint behaviour and override ladder
+- `shared/anti_leakage_protocol.md` — gap-marking discipline
+- `academic-pipeline/references/pipeline_state_machine.md` — FAIL-loop integration

--- a/shared/compliance_checkpoint_protocol.md
+++ b/shared/compliance_checkpoint_protocol.md
@@ -89,6 +89,8 @@ Triggered when user picks "acknowledge limitation" on a block.
 
 Round count is per-stage-per-pipeline-run, stored in `compliance_history[].user_override` entries.
 
+> **Enforcement boundary.** This ladder is enforced at **runtime by `compliance_agent`** using the `compliance_history[]` round counter, NOT by Schema 10. Schema 10 intentionally permits `user_override.rationale.minLength: 1` so that legacy passports and cross-session resume do not fail validation on historical entries. The round-counter increment and ≥100-char rationale check live in the agent's write-path, not in the JSON Schema. If you bypass the agent and hand-write a `user_override` entry into the passport, Schema 10 will accept any rationale length — but that entry will not have gone through the friction ladder and must be treated as unaudited.
+
 On any successful override, the agent generates `disclosure_addendum` text and the orchestrator **auto-injects** it into the manuscript's AI disclosure section. The addendum is non-removable — this is the concrete form of the `no detection evasion` iron rule in CONTRIBUTING.md.
 
 ### `disclosure_addendum` template
@@ -98,6 +100,15 @@ The authors acknowledge the following compliance limitations for this <evidence 
 - PRISMA-trAIce <item_id> (<item_title>) not fully reported. Rationale: <user text>.
 - RAISE principle <principle_name>: <partial|not met>. Rationale: <user text>.
 ```
+
+**Template fill rules** (compliance_agent uses these deterministically):
+
+- `<evidence synthesis|manuscript>`: pick `evidence synthesis` when `mode in {systematic_review, other_evidence_synthesis}`; pick `manuscript` when `mode == primary_research`.
+- `<partial|not met>`: pick `partial` when the principle's original status was `warn`; pick `not met` when it was `fail`.
+- `<item_id>`: the PRISMA-trAIce item ID as listed in `user_override.scope[]`.
+- `<item_title>`: look up the short title from `shared/prisma_trAIce_protocol.md` (e.g. `M4` → "Input data").
+- `<principle_name>`: one of `human_oversight`, `transparency`, `reproducibility`, `fit_for_purpose`.
+- `<user text>`: verbatim copy of `user_override.rationale`, truncated to first 500 chars if longer (the addendum keeps prose; the full rationale lives in the compliance_history).
 
 ## Fail loop integration
 

--- a/shared/compliance_checkpoint_protocol.md
+++ b/shared/compliance_checkpoint_protocol.md
@@ -89,7 +89,7 @@ Triggered when user picks "acknowledge limitation" on a block.
 
 Round count is per-stage-per-pipeline-run, stored in `compliance_history[].user_override` entries.
 
-> **Enforcement boundary.** This ladder is enforced at **runtime by `compliance_agent`** using the `compliance_history[]` round counter, NOT by Schema 10. Schema 10 intentionally permits `user_override.rationale.minLength: 1` so that legacy passports and cross-session resume do not fail validation on historical entries. The round-counter increment and ≥100-char rationale check live in the agent's write-path, not in the JSON Schema. If you bypass the agent and hand-write a `user_override` entry into the passport, Schema 10 will accept any rationale length — but that entry will not have gone through the friction ladder and must be treated as unaudited.
+> **Enforcement boundary.** This ladder is enforced at **runtime by `compliance_agent`** using the `compliance_history[]` round counter, NOT by Schema 12. Schema 12 intentionally permits `user_override.rationale.minLength: 1` so that legacy passports and cross-session resume do not fail validation on historical entries. The round-counter increment and ≥100-char rationale check live in the agent's write-path, not in the JSON Schema. If you bypass the agent and hand-write a `user_override` entry into the passport, Schema 12 will accept any rationale length — but that entry will not have gone through the friction ladder and must be treated as unaudited.
 
 On any successful override, the agent generates `disclosure_addendum` text and the orchestrator **auto-injects** it into the manuscript's AI disclosure section. The addendum is non-removable — this is the concrete form of the `no detection evasion` iron rule in CONTRIBUTING.md.
 

--- a/shared/compliance_checkpoint_protocol.md
+++ b/shared/compliance_checkpoint_protocol.md
@@ -1,0 +1,121 @@
+---
+title: Compliance Checkpoint Protocol (Stage 2.5 / 4.5 dual gate)
+applies_to: "shared/agents/compliance_agent.md"
+---
+
+# Compliance Checkpoint Protocol
+
+Defines how `compliance_agent` participates in Stage 2.5 and Stage 4.5 Integrity Gates, how its decision interacts with the existing FAIL loop, and how user overrides are processed.
+
+**Used by**: `compliance_agent` (Task 8), `academic-pipeline/SKILL.md` Stage 2.5 / 4.5.
+
+## Dual-gate summary
+
+| Aspect | Stage 2.5 | Stage 4.5 |
+|---|---|---|
+| PRISMA-trAIce scope (SR mode only) | M1, M2, M3, M4, M5, M6, M7, M8, M9, M10 | T1, A1, I1, R1, R2, D1, D2 |
+| RAISE principles focus | human_oversight, fit_for_purpose | transparency, reproducibility |
+| RAISE 8-role matrix | not populated | populated (SR mode only) |
+| Block condition | SR mode AND any Mandatory item = FAIL, OR SR mode AND any RAISE principle = fail | Same |
+| Warn condition | Highly Recommended FAIL, OR RAISE principle = warn | Same |
+| Info condition | Recommended / Optional FAIL | Same |
+| Non-SR mode | RAISE principles_only, warn-only (never block) | Same |
+| Checkpoint output | FULL checkpoint + `compliance` section in dashboard | Same |
+
+## Decision precedence
+
+Inside a single checkpoint, decisions aggregate as:
+
+```
+overall_decision = max_severity(
+  prisma_trAIce.block_decision,
+  raise.block_decision,
+  legacy_integrity_verification_decision,  # existing Stage 2.5/4.5 check
+  legacy_failure_mode_checklist_decision   # v3.2 Failure Mode Checklist
+)
+
+severity order: pass < warn < block
+```
+
+Non-SR mode caps the compliance contribution at `warn`.
+
+## User action UX
+
+### On block
+
+Orchestrator presents:
+
+```
+[COMPLIANCE BLOCK] Stage <N>
+
+PRISMA-trAIce Mandatory fails: M4 (Input Data)
+RAISE principles fail: reproducibility
+
+Choose:
+  (a) backfill — return to Stage 2 and add missing material
+  (b) manual handling — edit manuscript directly, rerun compliance
+  (c) acknowledge limitation — invoke user override (see §Override Ladder)
+```
+
+### On warn
+
+Dashboard bullets, FULL checkpoint. User confirms with free text or `continue`.
+
+### On info (Recommended / Optional fail)
+
+Bullet in dashboard, no flow interruption.
+
+## Canonical gap-tag vocabulary
+
+Compliance reports and fixture templates use these canonical tags in `gaps[].reason`, `principle_evidence[]`, and narrative fields. They are lexical signals — `compliance_agent` (Task 8) and downstream readers pattern-match on them.
+
+| Tag | Where it appears | Meaning |
+|---|---|---|
+| `[MATERIAL GAP]` | `gaps[].reason`, `principle_evidence[]`, `evidence[]` | The item cannot be verified because the underlying material (passport field, manuscript section, supplementary file) is missing. Apply [Anti-Leakage Protocol](../academic-paper/references/anti_leakage_protocol.md) — do not hallucinate. |
+| `[WEAK EVIDENCE]` | `principle_evidence[]` | The item is nominally reported but the description is too vague for auditor use. Triggers CA-4 downgrade: a RAISE principle marked `pass` with `[WEAK EVIDENCE]` in its evidence should be downgraded to `warn`. |
+| `[GAP]` | `roles[].evidence_synthesists` narrative and similar role-level fields | Short form for a role-level gap carried forward from item-level fails. Permitted only in the 8-role matrix narrative; item-level reasons MUST use the long `[MATERIAL GAP]` form. |
+
+Casing is significant — uppercase square-bracketed. Lowercase or missing brackets are treated as plain prose and will not be recognised as gap signals.
+
+## Override Ladder (3-round friction)
+
+Triggered when user picks "acknowledge limitation" on a block.
+
+| Round | Behaviour |
+|---|---|
+| 1st block override | Warn user. Rationale optional. Allowed. |
+| 2nd (if user re-enters block state) | Require rationale string (any length). |
+| 3rd | Require rationale ≥ 100 chars. Only released on rationale confirmation. |
+
+Round count is per-stage-per-pipeline-run, stored in `compliance_history[].user_override` entries.
+
+On any successful override, the agent generates `disclosure_addendum` text and the orchestrator **auto-injects** it into the manuscript's AI disclosure section. The addendum is non-removable — this is the concrete form of the `no detection evasion` iron rule in CONTRIBUTING.md.
+
+### `disclosure_addendum` template
+
+```
+The authors acknowledge the following compliance limitations for this <evidence synthesis|manuscript>:
+- PRISMA-trAIce <item_id> (<item_title>) not fully reported. Rationale: <user text>.
+- RAISE principle <principle_name>: <partial|not met>. Rationale: <user text>.
+```
+
+## Fail loop integration
+
+After 3 unresolved rounds of retry at the same stage, orchestrator invokes the existing `pipeline_state_machine.md §Integrity Check FAIL Loop` procedure:
+
+1. List all unresolvable items.
+2. User picks [manual handling / remove AI usage from this stage / continue with "partially non-compliant" warning].
+3. Chosen path is recorded as `compliance_history[].resolution_path`.
+
+## Append-only history
+
+`material_passport.compliance_history[]` never overwrites. On retry-pass, the previous fail entry is preserved with its own timestamp. The AI Self-Reflection Report at Stage 6 cites the full history to demonstrate how the correction was made — this is RAISE transparency applied to ARS itself.
+
+## Boundary: non-pipeline invocation
+
+When invoked from `academic-paper full` (primary research standalone), no pipeline state machine is available. Compliance_agent:
+
+- Writes report to `./compliance_reports/<ISO-timestamp>.yaml` (local file)
+- Does not trigger pipeline checkpoint dashboard
+- If skill has a `disclosure` mode, hooks compliance output there
+- `block_decision` capped at `warn`

--- a/shared/compliance_report.schema.json
+++ b/shared/compliance_report.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Imbad0202/academic-research-skills/shared/compliance_report.schema.json",
-  "title": "ARS Compliance Report (Schema 10)",
+  "title": "ARS Compliance Report (Schema 12)",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/shared/compliance_report.schema.json
+++ b/shared/compliance_report.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/compliance_report.schema.json",
+  "title": "ARS Compliance Report (Schema 10)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "mode",
+    "stage",
+    "generated_at",
+    "raise",
+    "overall_decision",
+    "user_action_required"
+  ],
+  "properties": {
+    "mode": {
+      "enum": ["systematic_review", "primary_research", "other_evidence_synthesis"]
+    },
+    "stage": { "enum": ["2.5", "4.5"] },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "prisma_trAIce": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["items_total", "by_tier", "block_decision"],
+          "properties": {
+            "items_total": { "const": 17 },
+            "by_tier": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["mandatory", "highly_recommended", "recommended", "optional"],
+              "properties": {
+                "mandatory": { "$ref": "#/$defs/tier_bucket" },
+                "highly_recommended": { "$ref": "#/$defs/tier_bucket" },
+                "recommended": { "$ref": "#/$defs/tier_bucket" },
+                "optional": { "$ref": "#/$defs/tier_bucket" }
+              }
+            },
+            "block_decision": { "$ref": "#/$defs/decision" }
+          }
+        }
+      ]
+    },
+    "raise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "principles", "principle_evidence", "block_decision"],
+      "properties": {
+        "mode": { "enum": ["full", "principles_only"] },
+        "principles": {
+          "type": "object",
+          "required": ["human_oversight", "transparency", "reproducibility", "fit_for_purpose"],
+          "additionalProperties": false,
+          "properties": {
+            "human_oversight": { "$ref": "#/$defs/principle_status" },
+            "transparency": { "$ref": "#/$defs/principle_status" },
+            "reproducibility": { "$ref": "#/$defs/principle_status" },
+            "fit_for_purpose": { "$ref": "#/$defs/principle_status" }
+          }
+        },
+        "principle_evidence": {
+          "type": "object",
+          "required": ["human_oversight", "transparency", "reproducibility", "fit_for_purpose"],
+          "additionalProperties": false,
+          "properties": {
+            "human_oversight": { "type": "array", "items": { "type": "string" } },
+            "transparency": { "type": "array", "items": { "type": "string" } },
+            "reproducibility": { "type": "array", "items": { "type": "string" } },
+            "fit_for_purpose": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "roles": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Present only when raise.mode == 'full'; see top-level allOf constraint.",
+          "properties": {
+            "evidence_synthesists": { "type": "array", "items": { "type": "string" } },
+            "ai_development_teams": { "type": "array", "items": { "type": "string" } },
+            "methodologists": { "type": "array", "items": { "type": "string" } },
+            "publishers": { "type": "array", "items": { "type": "string" } },
+            "users": { "type": "array", "items": { "type": "string" } },
+            "trainers": { "type": "array", "items": { "type": "string" } },
+            "organisations": { "type": "array", "items": { "type": "string" } },
+            "funders": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "block_decision": { "$ref": "#/$defs/decision" }
+      }
+    },
+    "overall_decision": { "$ref": "#/$defs/decision" },
+    "user_action_required": { "type": "boolean" },
+    "evidence": { "type": "array", "items": { "type": "string" } },
+    "user_override": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "timestamp", "rationale", "scope"],
+      "properties": {
+        "decision": { "const": true },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "rationale": { "type": "string", "minLength": 1 },
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^(T1|A1|I1|M([1-9]|10)|R[12]|D[12]|human_oversight|transparency|reproducibility|fit_for_purpose)$"
+          }
+        }
+      }
+    },
+    "upstream_sync_status": { "enum": ["current", "stale"] }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "mode": { "const": "systematic_review" } }, "required": ["mode"] },
+      "then": { "properties": { "prisma_trAIce": { "type": "object" } } }
+    },
+    {
+      "if": { "properties": { "mode": { "const": "primary_research" } }, "required": ["mode"] },
+      "then": { "properties": { "prisma_trAIce": { "type": "null" } } }
+    },
+    {
+      "if": {
+        "properties": { "raise": { "properties": { "mode": { "const": "full" } }, "required": ["mode"] } },
+        "required": ["raise"]
+      },
+      "then": { "properties": { "raise": { "required": ["roles"] } } }
+    }
+  ],
+  "$defs": {
+    "decision": { "enum": ["block", "warn", "pass"] },
+    "principle_status": { "enum": ["pass", "warn", "fail"] },
+    "tier_bucket": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "pass", "fail"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "pass": { "type": "integer", "minimum": 0 },
+        "fail": { "type": "array", "items": { "type": "string" } },
+        "gaps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["item_id", "reason"],
+            "properties": {
+              "item_id": { "type": "string" },
+              "reason": { "type": "string" },
+              "evidence_path": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -500,6 +500,7 @@ score_trajectory: {
 | `content_hash` | string | SHA-256 hash of the content (for change detection) |
 | `upstream_dependencies` | list[string] | Version labels of artifacts this one depends on |
 | `repro_lock` | object \| null | configuration lockfile for artifact reproducibility. See [`artifact_reproducibility_pattern.md`](artifact_reproducibility_pattern.md). `null` = honest opt-out. Required from v3.3.5+ — omitted key fails lint. |
+| `compliance_history` | list[object] | Append-only audit trail of `compliance_report` entries (Schema 12). Added v3.4.0+. See [Schema 12](#schema-12--compliance-report-v340) and [`shared/compliance_report.schema.json`](compliance_report.schema.json). |
 
 ### Example
 
@@ -603,6 +604,45 @@ See `shared/style_calibration_protocol.md` for full consumption rules and confli
 - Every item from the original Revision Roadmap (Schema 7) must appear in the matrix
 - `authors_claim` cannot be empty for Priority 1 items (flag as `CANNOT_VERIFY` if missing)
 - Matrix is carried forward in Material Passport (Schema 9) for audit trail
+
+---
+
+## Schema 12 — Compliance Report (v3.4.0+)
+
+**Source of truth:** [`shared/compliance_report.schema.json`](compliance_report.schema.json)
+
+Mode-aware output of [`compliance_agent`](agents/compliance_agent.md). Three top-level subtrees: `prisma_trAIce` (null for primary research), `raise` (always present), and decision aggregation fields.
+
+- **Emitted by:** `compliance_agent` at Stage 2.5 / 4.5 (pipeline) or pre-finalize (standalone skills)
+- **Consumed by:** orchestrator (for checkpoint dashboard), `report_compiler_agent` (for AI Self-Reflection Report compliance summary at Stage 6)
+- **Appended to:** `material_passport.compliance_history[]` (append-only)
+
+### Key fields
+
+- `mode`: dispatches payload (see [`shared/agents/compliance_agent.md`](agents/compliance_agent.md) §Dispatch logic)
+- `stage`: `"2.5"` or `"4.5"`
+- `prisma_trAIce`: `null` when `mode != "systematic_review"`; otherwise tier-bucketed item results
+- `raise.mode`: `"full"` (SR + other_evidence_synthesis) or `"principles_only"` (primary_research)
+- `raise.principles`: 4 keys, each with `pass` / `warn` / `fail`
+- `raise.roles`: 8 keys, populated only when `raise.mode == "full"`
+- `overall_decision`: aggregate across compliance + legacy integrity + v3.2 failure mode
+- `user_override`: only present after a user overrides a block; rationale required
+- `upstream_sync_status`: `"current"` or `"stale"` (from freshness check)
+
+Full field spec: [`shared/compliance_report.schema.json`](compliance_report.schema.json).
+
+### Material Passport extension
+
+Schema 9 Material Passport gains one optional field, `compliance_history`:
+
+```yaml
+compliance_history:
+  - <compliance_report entry>
+  - <compliance_report entry>
+  # append-only; never overwrite, never reorder
+```
+
+Ordering: chronological by `generated_at`. A Stage 2.5 FAIL followed by backfill + retry-pass produces two adjacent entries for Stage 2.5 — both preserved.
 
 ---
 

--- a/shared/prisma_trAIce_protocol.md
+++ b/shared/prisma_trAIce_protocol.md
@@ -19,12 +19,12 @@ Verbatim snapshot of the 17-item PRISMA-trAIce checklist from the GitHub canonic
 
 | Tier | Behaviour when item FAILs |
 |---|---|
-| Mandatory (M) | **Block**: pipeline halts; user must backfill, retreat a stage, or use the 3-round override ladder (see `shared/compliance_checkpoint_protocol.md §override-ladder`) |
+| Mandatory (M) | **Block**: pipeline halts; user must backfill, retreat a stage, or use the 3-round override ladder (see [`shared/compliance_checkpoint_protocol.md#override-ladder-3-round-friction`](./compliance_checkpoint_protocol.md#override-ladder-3-round-friction)) |
 | Highly Recommended (HR) | **Warn**: surfaced at checkpoint; user can skip |
 | Recommended (R) | **Info**: logged in compliance_report, shown as dashboard bullet |
 | Optional (O) | **Info**: same as R |
 
-> **Gap-tag vocabulary.** Tags `[MATERIAL GAP]`, `[WEAK EVIDENCE]`, `[GAP]` used in this protocol's `reason` fields are defined in `shared/compliance_checkpoint_protocol.md §Canonical gap-tag vocabulary`.
+> **Gap-tag vocabulary.** Tags `[MATERIAL GAP]`, `[WEAK EVIDENCE]`, `[GAP]` used in this protocol's `reason` fields are defined in [`shared/compliance_checkpoint_protocol.md#canonical-gap-tag-vocabulary`](./compliance_checkpoint_protocol.md#canonical-gap-tag-vocabulary).
 
 ## Stage assignment
 

--- a/shared/prisma_trAIce_protocol.md
+++ b/shared/prisma_trAIce_protocol.md
@@ -24,19 +24,7 @@ Verbatim snapshot of the 17-item PRISMA-trAIce checklist from the GitHub canonic
 | Recommended (R) | **Info**: logged in compliance_report, shown as dashboard bullet |
 | Optional (O) | **Info**: same as R |
 
-## Canonical gap-tag vocabulary
-
-> **Provisional location.** This vocabulary is shared between `compliance_agent` (which writes reports) and this per-item protocol (which generates `[MATERIAL GAP]` reasons). It belongs in `shared/compliance_checkpoint_protocol.md` once Task 7 lands; kept here provisionally so the fixtures in `examples/compliance/` already have a reference.
-
-Compliance reports and fixture templates use these canonical tags in `gaps[].reason`, `principle_evidence[]`, and narrative fields. They are lexical signals — `compliance_agent` (Task 8) and downstream readers pattern-match on them.
-
-| Tag | Where it appears | Meaning |
-|---|---|---|
-| `[MATERIAL GAP]` | `gaps[].reason`, `principle_evidence[]`, `evidence[]` | The item cannot be verified because the underlying material (passport field, manuscript section, supplementary file) is missing. Apply [Anti-Leakage Protocol](../academic-paper/references/anti_leakage_protocol.md) — do not hallucinate. |
-| `[WEAK EVIDENCE]` | `principle_evidence[]` | The item is nominally reported but the description is too vague for auditor use. Triggers CA-4 downgrade: a RAISE principle marked `pass` with `[WEAK EVIDENCE]` in its evidence should be downgraded to `warn`. |
-| `[GAP]` | `roles[].evidence_synthesists` narrative and similar role-level fields | Short form for a role-level gap carried forward from item-level fails. Permitted only in the 8-role matrix narrative; item-level reasons MUST use the long `[MATERIAL GAP]` form. |
-
-Casing is significant — uppercase square-bracketed. Lowercase or missing brackets are treated as plain prose and will not be recognised as gap signals.
+> **Gap-tag vocabulary.** Tags `[MATERIAL GAP]`, `[WEAK EVIDENCE]`, `[GAP]` used in this protocol's `reason` fields are defined in `shared/compliance_checkpoint_protocol.md §Canonical gap-tag vocabulary`.
 
 ## Stage assignment
 

--- a/shared/prisma_trAIce_protocol.md
+++ b/shared/prisma_trAIce_protocol.md
@@ -11,24 +11,28 @@ citation: "Holst D, et al. Transparent Reporting of AI in Systematic Literature 
 
 Verbatim snapshot of the 17-item PRISMA-trAIce checklist from the GitHub canonical source (`cqh4046/PRISMA-trAIce`), dated 2025-12-10, with per-item ARS check procedures and tier-based behaviour.
 
+**Used by**: `compliance_agent` (Task 8), `scripts/check_prisma_trAIce_freshness.py` (Task 12).
+
 > ⚠️ **Upstream sync warning.** If `cqh4046/PRISMA-trAIce` updates, a freshness CI check emits an annotation but does not block merges. Maintainers must manually re-sync this file and bump `snapshot_date` + `upstream_version_commit`. See `scripts/check_prisma_trAIce_freshness.py`.
 
 ## Tier legend
 
 | Tier | Behaviour when item FAILs |
 |---|---|
-| Mandatory (M) | **Block**: pipeline halts; user must backfill, retreat a stage, or use the 3-round override ladder |
+| Mandatory (M) | **Block**: pipeline halts; user must backfill, retreat a stage, or use the 3-round override ladder (see `shared/compliance_checkpoint_protocol.md §override-ladder`) |
 | Highly Recommended (HR) | **Warn**: surfaced at checkpoint; user can skip |
 | Recommended (R) | **Info**: logged in compliance_report, shown as dashboard bullet |
 | Optional (O) | **Info**: same as R |
 
 ## Canonical gap-tag vocabulary
 
+> **Provisional location.** This vocabulary is shared between `compliance_agent` (which writes reports) and this per-item protocol (which generates `[MATERIAL GAP]` reasons). It belongs in `shared/compliance_checkpoint_protocol.md` once Task 7 lands; kept here provisionally so the fixtures in `examples/compliance/` already have a reference.
+
 Compliance reports and fixture templates use these canonical tags in `gaps[].reason`, `principle_evidence[]`, and narrative fields. They are lexical signals — `compliance_agent` (Task 8) and downstream readers pattern-match on them.
 
 | Tag | Where it appears | Meaning |
 |---|---|---|
-| `[MATERIAL GAP]` | `gaps[].reason`, `principle_evidence[]`, `evidence[]` | The item cannot be verified because the underlying material (passport field, manuscript section, supplementary file) is missing. Apply Anti-Leakage Protocol — do not hallucinate. |
+| `[MATERIAL GAP]` | `gaps[].reason`, `principle_evidence[]`, `evidence[]` | The item cannot be verified because the underlying material (passport field, manuscript section, supplementary file) is missing. Apply [Anti-Leakage Protocol](../academic-paper/references/anti_leakage_protocol.md) — do not hallucinate. |
 | `[WEAK EVIDENCE]` | `principle_evidence[]` | The item is nominally reported but the description is too vague for auditor use. Triggers CA-4 downgrade: a RAISE principle marked `pass` with `[WEAK EVIDENCE]` in its evidence should be downgraded to `warn`. |
 | `[GAP]` | `roles[].evidence_synthesists` narrative and similar role-level fields | Short form for a role-level gap carried forward from item-level fails. Permitted only in the 8-role matrix narrative; item-level reasons MUST use the long `[MATERIAL GAP]` form. |
 
@@ -147,11 +151,11 @@ Casing is significant — uppercase square-bracketed. Lowercase or missing brack
 
 ## Summary counts
 
-- Mandatory: 9 — M1, M2, M3, M4, M5, M6, M8, M9, R1, R2 (count: 10)
-
-> **Note on tier count discrepancy:** The upstream GitHub README summary states "Mandatory: 9". Reading the per-item tier annotations yields 10 items marked Mandatory (M1–M6, M8, M9, R1, R2). The extra is R2, which is listed as Mandatory in item-level markup but counted within the Results section Mandatory group (R1+R2). ARS treats **both** R1 and R2 as Mandatory. If upstream clarifies, update here.
+- Mandatory: 10 — M1, M2, M3, M4, M5, M6, M8, M9, R1, R2
 - Highly Recommended: 1 — M7
-- Recommended: 4 — I1, M10, D1, + 1 tier-ambiguous item resolved via upstream hierarchy (see note)
+- Recommended: 3 — I1, M10, D1
 - Optional: 3 — T1, A1, D2
 
-Total: 17 items, as stated upstream.
+Total: 17 items.
+
+> **ARS promotion note.** Upstream's README header summary says "Mandatory: 9". Per-item tier annotations in upstream (and mirrored here) mark **both R1 and R2 as Mandatory**, summing to 10. ARS treats the per-item annotation as authoritative, since the Results-stage items (R1: AI/human split in flow diagram; R2: AI performance metric reporting) are both operationally block-level for a compliance audit. If upstream clarifies the discrepancy, re-sync.

--- a/shared/prisma_trAIce_protocol.md
+++ b/shared/prisma_trAIce_protocol.md
@@ -1,0 +1,157 @@
+---
+title: PRISMA-trAIce Protocol (v3.4.0 snapshot)
+snapshot_date: "2025-12-10"
+upstream_source: "https://github.com/cqh4046/PRISMA-trAIce"
+upstream_version_commit: "main"
+update_policy: "Manual sync. CI freshness check runs weekly; drift emits warning, not merge block."
+citation: "Holst D, et al. Transparent Reporting of AI in Systematic Literature Reviews: Development of the PRISMA-trAIce Checklist. JMIR AI. 2025. doi:10.2196/80247"
+---
+
+# PRISMA-trAIce Protocol
+
+Verbatim snapshot of the 17-item PRISMA-trAIce checklist from the GitHub canonical source (`cqh4046/PRISMA-trAIce`), dated 2025-12-10, with per-item ARS check procedures and tier-based behaviour.
+
+> ⚠️ **Upstream sync warning.** If `cqh4046/PRISMA-trAIce` updates, a freshness CI check emits an annotation but does not block merges. Maintainers must manually re-sync this file and bump `snapshot_date` + `upstream_version_commit`. See `scripts/check_prisma_trAIce_freshness.py`.
+
+## Tier legend
+
+| Tier | Behaviour when item FAILs |
+|---|---|
+| Mandatory (M) | **Block**: pipeline halts; user must backfill, retreat a stage, or use the 3-round override ladder |
+| Highly Recommended (HR) | **Warn**: surfaced at checkpoint; user can skip |
+| Recommended (R) | **Info**: logged in compliance_report, shown as dashboard bullet |
+| Optional (O) | **Info**: same as R |
+
+## Canonical gap-tag vocabulary
+
+Compliance reports and fixture templates use these canonical tags in `gaps[].reason`, `principle_evidence[]`, and narrative fields. They are lexical signals — `compliance_agent` (Task 8) and downstream readers pattern-match on them.
+
+| Tag | Where it appears | Meaning |
+|---|---|---|
+| `[MATERIAL GAP]` | `gaps[].reason`, `principle_evidence[]`, `evidence[]` | The item cannot be verified because the underlying material (passport field, manuscript section, supplementary file) is missing. Apply Anti-Leakage Protocol — do not hallucinate. |
+| `[WEAK EVIDENCE]` | `principle_evidence[]` | The item is nominally reported but the description is too vague for auditor use. Triggers CA-4 downgrade: a RAISE principle marked `pass` with `[WEAK EVIDENCE]` in its evidence should be downgraded to `warn`. |
+| `[GAP]` | `roles[].evidence_synthesists` narrative and similar role-level fields | Short form for a role-level gap carried forward from item-level fails. Permitted only in the 8-role matrix narrative; item-level reasons MUST use the long `[MATERIAL GAP]` form. |
+
+Casing is significant — uppercase square-bracketed. Lowercase or missing brackets are treated as plain prose and will not be recognised as gap signals.
+
+## Stage assignment
+
+| Checked at | Items |
+|---|---|
+| Stage 2.5 (Methods) | M1, M2, M3, M4, M5, M6, M7, M8, M9, M10 |
+| Stage 4.5 (remaining) | T1, A1, I1, R1, R2, D1, D2 |
+
+## Items
+
+### T1 — Title
+**Tier:** Optional
+**Original (upstream verbatim):** "Indicate the use of AI in the title or subtitle if it played a substantial role."
+**ARS check procedure:** If `user_metadata.ai_tools_used[].stage` includes any of `{screening, data_extraction, synthesis, writing}` (i.e. substantial involvement), verify manuscript title OR subtitle mentions AI. If none of the AI tools are substantial, pass automatically.
+**Pass criterion:** Substring match for one of: "AI-assisted", "AI-augmented", "artificial intelligence", "LLM-assisted", or language-equivalent.
+
+### A1 — Abstract
+**Tier:** Optional
+**Original:** "Briefly summarize the AI tool(s) used, the review stage(s) where they were applied."
+**ARS check procedure:** Locate manuscript abstract. Verify it names ≥1 AI tool AND the review stages.
+**Pass criterion:** Both named. Absence of either → fail.
+
+### I1 — Introduction
+**Tier:** Recommended
+**Original:** "Briefly state the rationale for using AI tools for specific tasks."
+**ARS check procedure:** In introduction, locate one sentence or more that explains why AI was chosen for its task.
+**Pass criterion:** Rationale present and tied to ≥1 specific AI task.
+
+### M1 — Protocol registration
+**Tier:** Mandatory
+**Original:** "State if the use of AI was pre-specified in a protocol, and document deviations."
+**ARS check procedure:** Check `material_passport.protocol_registration` field OR manuscript §Methods for explicit pre-registration statement. If AI was added mid-review, check for a "deviation from protocol" paragraph.
+**Pass criterion:** Either (a) pre-registration clearly stated, or (b) deviation explicitly disclosed.
+
+### M2 — Tool identification and access
+**Tier:** Mandatory
+**Original:** "Specify name, version, and provider/developer for each tool, with access details."
+**ARS check procedure:** For each entry in `user_metadata.ai_tools_used`, require `name`, `version`, `developer`. If tool is open-source, require repository URL or DOI.
+**Pass criterion:** All three fields non-empty for every tool.
+
+### M3 — Purpose and stage
+**Tier:** Mandatory
+**Original:** "Describe the specific SLR stage and the precise task the AI performed."
+**ARS check procedure:** For each tool, verify stage-level task description exists (not just "used AI for screening").
+**Pass criterion:** Per-tool, per-stage prose description of ≥1 sentence in manuscript §Methods.
+
+### M4 — Input data
+**Tier:** Mandatory
+**Original:** "Describe data provided to the AI (e.g., training data for fine-tuning)."
+**ARS check procedure:** If any tool was fine-tuned or custom-trained, verify dataset description (source, size, preprocessing). If no fine-tuning, verify this is explicitly stated.
+**Pass criterion:** Either (a) dataset described, or (b) explicit "no fine-tuning performed" statement.
+
+### M5 — Output data
+**Tier:** Mandatory
+**Original:** "Describe the output format (e.g., JSON, scores) and any automated post-processing."
+**ARS check procedure:** Verify manuscript §Methods documents output format per tool + any post-processing pipelines.
+**Pass criterion:** Format + post-processing both described.
+
+### M6 — Prompt engineering
+**Tier:** Mandatory
+**Original:** "Report prompt engineering process, full prompts, key parameters for LLMs."
+**ARS check procedure:** If any tool is an LLM, verify full prompt text is included (main text or supplementary) AND model parameters (temperature, top_p, max tokens, model version) are documented.
+**Pass criterion:** All three present for every LLM tool.
+
+### M7 — Operational details
+**Tier:** Highly Recommended
+**Original:** "Describe key operational settings, algorithms, or configurations for non-LLM AI."
+**ARS check procedure:** For classical ML tools (e.g. ASReview, Abstrackr), verify algorithm + hyperparameters documented.
+**Pass criterion:** Algorithm name + at least 2 hyperparameters.
+
+### M8 — Human-AI interaction
+**Tier:** Mandatory
+**Original:** "Describe human interaction (number of reviewers, verification process)."
+**ARS check procedure:** Verify manuscript §Methods states reviewer count, qualifications, and oversight mechanism (e.g., independent dual screening, adjudication).
+**Pass criterion:** Reviewer count + oversight mechanism both present.
+
+### M9 — AI performance evaluation methods
+**Tier:** Mandatory
+**Original:** "Describe methods used to evaluate AI performance (metrics, reference standards)."
+**ARS check procedure:** Verify manuscript §Methods describes what performance metrics were computed (e.g., sensitivity, agreement) and against what gold standard.
+**Pass criterion:** Metric + reference standard both stated.
+
+### M10 — Data management
+**Tier:** Recommended
+**Original:** "Describe data management, storage, privacy measures, and compliance."
+**ARS check procedure:** Verify manuscript §Methods addresses data handling (where stored, privacy controls, GDPR/IRB compliance if applicable).
+**Pass criterion:** ≥2 of {storage, privacy, compliance} addressed.
+
+### R1 — Study selection (AI-assisted)
+**Tier:** Mandatory
+**Original:** "In the PRISMA flow diagram/text, distinguish between records handled by AI versus human reviewers."
+**ARS check procedure:** Verify PRISMA flow diagram or accompanying text explicitly separates AI-handled vs human-handled records at each screening stage.
+**Pass criterion:** Explicit AI/human split in flow diagram numbers OR prose.
+
+### R2 — AI performance metrics (results)
+**Tier:** Mandatory
+**Original:** "Report results of any AI performance evaluations (e.g., agreement rates)."
+**ARS check procedure:** Verify manuscript §Results reports numeric performance outcomes referenced by M9.
+**Pass criterion:** ≥1 quantitative metric (% agreement, Cohen's κ, sensitivity, etc.).
+
+### D1 — Limitations of AI use
+**Tier:** Recommended
+**Original:** "Discuss limitations (technical issues, biases, hallucinations) and their impact."
+**ARS check procedure:** Verify manuscript §Discussion has ≥1 paragraph specifically on AI limitations (not generic review limitations).
+**Pass criterion:** Dedicated AI-limitations paragraph of ≥3 sentences.
+
+### D2 — Implications of AI use
+**Tier:** Optional
+**Original:** "Briefly discuss the experience of using AI tools for future reviews."
+**ARS check procedure:** Verify manuscript §Discussion reflects on the usability/experience of AI for this review, forward-looking.
+**Pass criterion:** ≥1 forward-looking sentence about AI utility.
+
+## Summary counts
+
+- Mandatory: 9 — M1, M2, M3, M4, M5, M6, M8, M9, R1, R2 (count: 10)
+
+> **Note on tier count discrepancy:** The upstream GitHub README summary states "Mandatory: 9". Reading the per-item tier annotations yields 10 items marked Mandatory (M1–M6, M8, M9, R1, R2). The extra is R2, which is listed as Mandatory in item-level markup but counted within the Results section Mandatory group (R1+R2). ARS treats **both** R1 and R2 as Mandatory. If upstream clarifies, update here.
+- Highly Recommended: 1 — M7
+- Recommended: 4 — I1, M10, D1, + 1 tier-ambiguous item resolved via upstream hierarchy (see note)
+- Optional: 3 — T1, A1, D2
+
+Total: 17 items, as stated upstream.

--- a/shared/raise_framework.md
+++ b/shared/raise_framework.md
@@ -1,0 +1,129 @@
+---
+title: RAISE Framework (v3.4.0 snapshot)
+snapshot_date: "2025-07-17"
+upstream_source: "https://eppi.ioe.ac.uk/CMS/Portals/0/RAISE%20ESG%20BPWG.pdf"
+upstream_version: "NIHR ESG Best Practice Working Group consultation draft, 17 July 2025"
+citation: "Thomas J, Flemyng E, Noel-Storr A, et al. Responsible Use of AI in Evidence Synthesis (RAISE). NIHR ESG Best Practice Working Group in AI/Automation, EPPI-Centre, UCL Social Research Institute. 17 July 2025."
+related: "Position Statement on AI Use in Evidence Synthesis (Cochrane, Campbell, JBI, CEE), Campbell Systematic Reviews, 2025, doi:10.1002/cl2.70074"
+---
+
+# RAISE Framework
+
+## Scope disclaimer (required, do not remove)
+
+RAISE's official scope is **evidence synthesis** (systematic review, meta-analysis, scoping review, rapid review, evidence mapping). When ARS applies RAISE **principles** to non-evidence-synthesis work — e.g., `academic-paper full` on primary research — this is a **principle extension**, not official RAISE compliance. ARS's `compliance_agent` will only claim RAISE compliance for outputs produced in `systematic_review` or `other_evidence_synthesis` modes.
+
+**Used by**: `compliance_agent` (Task 8).
+
+## Four principles
+
+Each principle carries a definition, ARS check procedure, and pass/warn/fail criteria. These are the universal kernel of RAISE and are checked in every mode.
+
+### Principle 1 — Human oversight
+
+**Definition:** AI and automation in evidence synthesis should be used with meaningful human oversight, not as an autonomous replacement.
+**ARS check (Stage 2.5 focus):** At Stage 2.5, verify `methodology_blueprint` specifies reviewer count, qualifications, and adjudication mechanism. At Stage 4.5, verify manuscript describes the human oversight applied in practice.
+**Pass:** Reviewer count + adjudication mechanism + qualifications all present, each with evidence path.
+**Warn:** Any one missing, OR only present in vague form ("authors reviewed AI output").
+**Fail:** Two or more missing.
+
+### Principle 2 — Transparency
+
+**Definition:** Any AI or automation use that makes or suggests judgements must be fully and transparently reported.
+**ARS check (Stage 4.5 focus):** Verify manuscript lists every AI tool used, at what stage, with prompts/parameters/versions. Cross-reference against `user_metadata.ai_tools_used`.
+**Pass:** All declared tools reported AND all reported tools declared.
+**Warn:** Mismatch in ≤1 tool, or reporting lacks one of {stage, prompt, parameters, version}.
+**Fail:** Multiple tools undeclared OR systematically missing prompts/parameters.
+
+### Principle 3 — Reproducibility
+
+**Definition:** AI-assisted evidence synthesis should be reproducible to a stated level.
+**ARS check:** Verify presence of `passport.repro_lock` (v3.3.5 feature) OR equivalent manuscript description (model version, seeds, prompt, data access details). Stochasticity must be declared per `artifact_reproducibility_pattern.md`.
+**Pass:** Repro_lock present AND stochasticity declared.
+**Warn:** One of the two missing.
+**Fail:** Both missing.
+
+### Principle 4 — Fit-for-purpose
+
+**Definition:** AI tools should be chosen and validated for specific tasks within the evidence synthesis, not applied generically.
+**ARS check (Stage 2.5 focus):** Verify manuscript describes why each AI tool was chosen for its specific task. Look for pilot-phase evidence OR prior validation citation.
+**Pass:** Per-tool justification + ≥1 validation reference.
+**Warn:** Justification present without validation reference.
+**Fail:** Generic "we used AI to save time" with no task-level justification.
+
+## Full 8-role matrix (SR mode only)
+
+Used when `raise.mode == "full"` (SR and other_evidence_synthesis). Each role carries 2–3 responsibilities extracted from the RAISE consultation PDF. The agent maps ARS users and ARS itself onto the roles they occupy.
+
+**Default role attribution:**
+- ARS user (the human running the skill): Evidence Synthesists
+- ARS itself (the skill suite): AI Development Teams + Methodologists (dual role)
+
+### Role 1 — Evidence Synthesists
+
+1. Remain ultimately responsible for the evidence synthesis, regardless of AI assistance.
+2. Report AI use in the evidence synthesis manuscript transparently.
+3. Ensure ethical, legal, and regulatory standards are adhered to when using AI.
+
+**ARS check:** manuscript contains author responsibility statement; AI-usage disclosure is present; ethics/IRB section addresses AI use.
+
+### Role 2 — AI Development Teams
+
+1. Adhere to open-science practices when designing, building, testing, and validating tools.
+2. Be transparent about when AI works best, its limitations, and any interests.
+3. Commit to continued learning, development, and monitoring.
+
+**ARS self-declaration:** ARS is open-source (CC BY-NC 4.0); CHANGELOG tracks limitations; calibration results published per `calibration_mode_protocol.md`.
+
+### Role 3 — Methodologists
+
+1. Adhere to open science practice when researching and evaluating AI systems.
+2. Commit to independent evaluations and validation of AI systems.
+
+**ARS self-declaration:** ARS cross-model verification per `cross_model_verification.md` provides one form of independent validation; sixth-reviewer peer review remains planned.
+
+### Role 4 — Publishers of evidence synthesis
+
+1. Ensure best-practice standards for responsible AI use are clear and integrated into policies and guidelines for authors.
+2. Request transparency and honesty from authors on their use of AI in evidence synthesis.
+
+**ARS note:** Out of ARS's direct control; surfaced in compliance_report as stakeholder context.
+
+### Role 5 — Users of evidence synthesis
+
+1. Critically consider the potential influence of AI use in a synthesis before use.
+2. Underscore the potential impacts of AI use in downstream documents and decision-making processes.
+3. Communicate the need for transparent reporting of tool accuracy and biases.
+
+**ARS note:** Out of direct scope; listed for ecosystem completeness.
+
+### Role 6 — Trainers of evidence synthesis methods
+
+1. Ensure best-practice standards for responsible AI are embedded within training materials.
+2. Equip trainees with the knowledge they need to determine if an AI tool is appropriate.
+3. Undertake continuous training and development to stay up to date with emerging AI tools.
+
+**ARS note:** Out of direct scope.
+
+### Role 7 — Organisations producing evidence synthesis
+
+1. Ensure best-practice standards for responsible AI are clear and integrated into policies and guidelines.
+2. Promote, guide, and support responsible AI use in evidence synthesis activities.
+3. Monitor the development and use of AI within the organisation.
+
+**ARS note:** Out of direct scope.
+
+### Role 8 — Funders of evidence synthesis
+
+1. Encourage the responsible use of AI.
+2. Consider sustainability and generalisability of the products they support.
+
+**ARS note:** Out of direct scope.
+
+## Usage in compliance_agent
+
+- SR mode: `raise.mode = "full"`, both principles AND roles populated
+- primary_research mode: `raise.mode = "principles_only"`, `roles` field absent or empty
+- other_evidence_synthesis mode: `raise.mode = "full"`, roles populated with adaptation noted in evidence paths
+
+Block decisions follow tier semantics: any principle at `fail` status + `systematic_review` mode → `block`. `primary_research` mode **never** blocks.


### PR DESCRIPTION
## Summary

Implements ARS v3.4.0 per design spec at `docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md` (merged via PR #25 on 2026-04-20).

A new mode-aware `compliance_agent` (`shared/agents/compliance_agent.md`) hooks the existing Stage 2.5 / 4.5 Integrity Gates and emits Schema 12 `compliance_report` payloads that append to Material Passport's new `compliance_history[]` (append-only audit trail).

**Dispatch:**

- `systematic_review` → PRISMA-trAIce 17 items (tier-based block: Mandatory → block, HR → warn, R/O → info) + RAISE full (4 principles + 8-role matrix)
- `primary_research` → RAISE principles-only, warn-only (PRISMA-trAIce out of scope)
- `other_evidence_synthesis` → RAISE full + PRISMA-trAIce in adaptation mode (items become Info), block capped at warn

**Guardrails:**

- 3-round user-override ladder (≥100-char rationale at round 3) auto-injects `disclosure_addendum` into the manuscript — no detection evasion possible
- Calibration ships with transparent reporting, **no hard FNR/FPR threshold** (self-consistent with `task_type: open-ended`)
- Upstream freshness CI (weekly cron) warns on PRISMA-trAIce drift, non-blocking

## Scope

Ships v3.4.0 only. v3.5.0 reading-check sub-mode is a separate PR after v3.4.0 stabilises.

## Version bumps

| Artifact | From | To |
|---|---|---|
| Suite | 3.3.6 | **3.4.0** |
| academic-pipeline | 3.2.2 | **3.3.0** |
| deep-research | 2.8.1 | **2.9.0** |
| academic-paper | 3.0.2 | **3.1.0** |
| academic-paper-reviewer | 1.8.1 | 1.8.1 (unchanged) |

## Schema numbering note

The compliance_report is **Schema 12**, not Schema 10. `handoff_schemas.md` has Schema 10 = Style Profile (v2.7+) and Schema 11 = R&R Traceability Matrix; the plan's initial Schema 10 assignment for compliance_report was corrected mid-branch (commit 1c2aac5) before Task 9 landed.

## Test plan

- [x] 21 compliance validator unit tests (`scripts/test_check_compliance_report.py`)
- [x] 5 freshness-check unit tests (`scripts/test_check_prisma_trAIce_freshness.py`)
- [x] 3 fixture-validator unit tests (`scripts/test_validate_compliance_fixtures.py`)
- [x] 3 fixture manuscripts validate against Schema 12 in-process
- [x] `scripts/check_spec_consistency.py` passes (version pins aligned)
- [x] `Spec Consistency` CI green (17–19s per run, 4 runs on branch)
- [x] Full suite: **54/54 tests green** (`python3 -m unittest discover -s scripts`)
- [ ] Manual smoke test: dispatch `compliance_agent` against `fixture_sr_missing_M4.yaml` end-to-end and verify orchestrator presents block checkpoint (deferred to first real run)
- [ ] Calibration run: 5× ensembling on 5 gold-standard fixtures; results published in release notes when available

## Sources

- PRISMA-trAIce: Holst et al. 2025, JMIR AI, doi:10.2196/80247. GitHub canonical `cqh4046/PRISMA-trAIce` (snapshot 2025-12-10, 17 items). 4 tiers: Mandatory 10 / Highly Recommended 1 / Recommended 3 / Optional 3.
- RAISE: Thomas et al. 2025, NIHR ESG Best Practice Working Group, EPPI-Centre / UCL, 17 July 2025. 4 principles × 8-role matrix.

## Review checkpoints landed during this branch

- Spec + Code review per Task 8 (opus, merged recommendations into commit chain)
- `/simplify` reviews after Tasks 8, 11-12, 13-17 — each surfaced refactors that landed before this PR opened (e.g., in-process fixture validator replaced subprocess+tempfile loop; concurrency: cancel-in-progress on both workflows; `[WEAK EVIDENCE]` canonical casing)

## Post-merge follow-ups (separate efforts, not in this PR)

1. v3.5.0 reading-check sub-mode (separate PR from `docs/design/...§3.1`)
2. First real SR run — monitor tier wording for friction
3. `.claude/CLAUDE.md` Skills Overview table → add CI guard against frontmatter drift (simplify-review-deferred finding)
4. `scripts/check_spec_consistency.py` v3.3.x heading guards — refactor to N-recent window before v3.5 lands (simplify-review-deferred finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)