### PR TITLE
docs(v3.5.0): reconcile charts + version labels with Collaboration Depth Observer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 | `deep-research` v2.9.0 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
 | `academic-paper` v3.1.0 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.8.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.4.0 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.5.0 | Full pipeline orchestrator | (coordinates all above) |
 
 ## v3.5 Key Additions
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ Per-agent responsibilities and per-stage artifacts now live in [`docs/ARCHITECTU
 
 7-agent multi-perspective review with **0-100 quality rubrics**. Modes: full, re-review, quick, methodology-focus, guided, calibration. **Decision mapping:** ≥80 Accept, 65-79 Minor Revision, 50-64 Major Revision, <50 Reject. First-round review team vs. narrow re-review team boundary: see ARCHITECTURE.md §3 Stage 3 / Stage 3'.
 
-### Academic Pipeline (v3.4)
+### Academic Pipeline (v3.5)
 
-10-stage orchestrator with integrity verification, two-stage review, Socratic coaching, and collaboration evaluation. Pipeline guarantees: every stage requires user confirmation checkpoint; integrity verification (Stage 2.5 + 4.5) cannot be skipped; R&R Traceability Matrix (Schema 11) independently verifies author revision claims. v3.3 added the Compliance Agent (PRISMA-trAIce + RAISE) at Stage 2.5 / 4.5. v3.4 adds the **Collaboration Depth Observer** (`collaboration_depth_agent`, advisory only — never blocks) at FULL/SLIM checkpoints. Stage-by-stage matrix with agents, artifacts, and gates: see ARCHITECTURE.md §3.
+10-stage orchestrator with integrity verification, two-stage review, Socratic coaching, and collaboration evaluation. Pipeline guarantees: every stage requires user confirmation checkpoint; integrity verification (Stage 2.5 + 4.5) cannot be skipped; R&R Traceability Matrix (Schema 11) independently verifies author revision claims. v3.4 added the Compliance Agent (PRISMA-trAIce + RAISE) at Stage 2.5 / 4.5. v3.5 adds the **Collaboration Depth Observer** (`collaboration_depth_agent`, advisory only — never blocks) at every FULL/SLIM checkpoint and at pipeline completion. MANDATORY integrity gates (2.5 / 4.5) explicitly skip the observer so compliance checks are not diluted. Based on Wang & Zhang (2026), IJETHE 23:11. Stage-by-stage matrix with agents, artifacts, and gates: see ARCHITECTURE.md §3.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -210,9 +210,9 @@ ARS Stage 2 寫作      →  用驗證過的實驗結果撰寫論文
 
 7 個 Agent 的多視角審查，搭配 **0-100 品質量表**。模式：full、re-review、quick、methodology-focus、guided、calibration。**決策對照：** ≥80 接受、65-79 小修、50-64 大修、<50 退稿。第一輪審查團隊 vs. 精簡再審團隊的分界：見 ARCHITECTURE.md §3 Stage 3 / Stage 3'。
 
-### Academic Pipeline (v3.4)
+### Academic Pipeline (v3.5)
 
-10 階段調度器，含誠信驗證、兩階段審查、蘇格拉底指導、協作品質評估。Pipeline 保證：每個階段都需使用者確認 checkpoint；誠信驗證（Stage 2.5 + 4.5）不可跳過；R&R 追溯矩陣（Schema 11）獨立驗證作者修訂宣稱。v3.3 新增 Compliance Agent（PRISMA-trAIce + RAISE）於 Stage 2.5 / 4.5。v3.4 新增 **協作深度觀察員**（`collaboration_depth_agent`，純觀察，永不阻擋流程）於 FULL/SLIM checkpoint。逐階段矩陣（agent、產出物、閘門）：見 ARCHITECTURE.md §3。
+10 階段調度器，含誠信驗證、兩階段審查、蘇格拉底指導、協作品質評估。Pipeline 保證：每個階段都需使用者確認 checkpoint；誠信驗證（Stage 2.5 + 4.5）不可跳過；R&R 追溯矩陣（Schema 11）獨立驗證作者修訂宣稱。v3.4 新增 Compliance Agent（PRISMA-trAIce + RAISE）於 Stage 2.5 / 4.5。v3.5 新增 **協作深度觀察員**（`collaboration_depth_agent`，僅諮詢性質、永不阻擋流程）於每一次 FULL/SLIM checkpoint 與 pipeline 完成時。MANDATORY 誠信閘門（2.5 / 4.5）明確跳過觀察員，避免稀釋合規檢查。理論基礎：Wang & Zhang (2026), IJETHE 23:11。逐階段矩陣（agent、產出物、閘門）：見 ARCHITECTURE.md §3。
 
 ---
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,7 +2,7 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.4.0"
+  version: "3.5.0"
   last_updated: "2026-04-21"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
@@ -14,7 +14,7 @@ metadata:
     - academic-paper-reviewer
 ---
 
-# Academic Pipeline v3.4.0 — Full Academic Research Workflow Orchestrator
+# Academic Pipeline v3.5.0 — Full Academic Research Workflow Orchestrator
 
 A lightweight orchestrator that manages the complete academic pipeline from research exploration to final manuscript. It does not perform substantive work — it only detects stages, recommends modes, dispatches skills, manages transitions, and tracks state.
 
@@ -378,7 +378,7 @@ Produces the final process record: paper creation journey, collaboration quality
 
 ---
 
-## Collaboration Depth Observer (v3.4.0, advisory only — never blocks)
+## Collaboration Depth Observer (v3.5.0, advisory only — never blocks)
 
 The `collaboration_depth_agent` observes the user's collaboration pattern with the pipeline. It is **advisory only** and **never blocks** progression at any checkpoint. It is `non-blocking` by design and carries `blocking: false` in its frontmatter as a structural guarantee.
 
@@ -566,7 +566,7 @@ Stage 5: academic-paper (format-convert mode)
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.4.0 |
+| Skill Version | 3.5.0 |
 | Last Updated | 2026-04-21 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v2.0+, academic-paper v2.0+, academic-paper-reviewer v1.1+ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,20 +44,20 @@ The pipeline has **two classes of user checkpoint**. Both require the user to co
 ```mermaid
 flowchart TD
     Start([User input])
-    S1[1. RESEARCH<br/>🧑 deep-research]
-    S2[2. WRITE<br/>🧑 academic-paper]
-    G25{{2.5 INTEGRITY<br/>✓ 7-mode checklist<br/>then user ack}}
-    S3[3. REVIEW<br/>🧑 academic-paper-reviewer]
+    S1[1. RESEARCH<br/>🧑 deep-research<br/>👁 observer]
+    S2[2. WRITE<br/>🧑 academic-paper<br/>👁 observer]
+    G25{{2.5 INTEGRITY<br/>✓ 7-mode checklist<br/>then user ack<br/>— observer SKIPPED}}
+    S3[3. REVIEW<br/>🧑 academic-paper-reviewer<br/>👁 observer]
     D3{Decision}
     RC[🧑 3→4 Revision<br/>Coaching<br/>max 8 rounds]
-    S4[4. REVISE<br/>🧑 academic-paper]
-    S3p[3'. RE-REVIEW<br/>🧑]
+    S4[4. REVISE<br/>🧑 academic-paper<br/>👁 observer]
+    S3p[3'. RE-REVIEW<br/>🧑<br/>👁 observer]
     D3p{Decision}
     RS[🧑 3'→4' Residual<br/>Coaching<br/>max 5 rounds]
-    S4p[4'. RE-REVISE<br/>🧑 content frozen]
-    G45{{4.5 FINAL INTEGRITY<br/>✓ Mode 2 deep check<br/>then user ack}}
+    S4p[4'. RE-REVISE<br/>🧑 content frozen<br/>👁 observer]
+    G45{{4.5 FINAL INTEGRITY<br/>✓ Mode 2 deep check<br/>then user ack<br/>— observer SKIPPED}}
     S5[5. FINALIZE<br/>🧑 format selection]
-    S6[6. PROCESS SUMMARY<br/>🧑]
+    S6[6. PROCESS SUMMARY<br/>🧑<br/>👁 observer<br/>pipeline-completion dispatch]
     End([Done])
 
     Start --> S1 --> S2 --> G25
@@ -89,23 +89,24 @@ flowchart TD
 - **Solid red (🧑)** = decision-heavy human gate — the user chooses a branch or approves a material decision.
 - **Solid orange (✓)** = integrity gate — machine verification runs first, user then acknowledges the report. Not skipped.
 - **Green** = Socratic coaching sub-stage. User may engage or say "just fix it" to skip the dialogue.
+- **👁 observer** (v3.5.0) = `collaboration_depth_agent` dispatches at every FULL/SLIM checkpoint + pipeline completion. **Never blocks.** Advisory only. MANDATORY integrity gates (2.5 / 4.5) explicitly skip the observer so compliance checks are not diluted.
 
 ## 3. Stage × Dimension Matrix
 
 | Stage | Skill / Mode | Data level | Artifact produced | Core agents | Gate / Checkpoint |
 |---|---|---|---|---|---|
-| **1. RESEARCH** | `deep-research` v2.9.0 (full / socratic / lit-review / systematic-review / fact-check / review / quick) | RAW | RQ Brief; Methodology Blueprint; Annotated Bibliography (S2-verified); Synthesis Report; INSIGHT Collection | research_question_agent; research_architect_agent; bibliography_agent; source_verification_agent; synthesis_agent; meta_analysis_agent; editor_in_chief_agent; devils_advocate_agent; risk_of_bias_agent; ethics_review_agent; socratic_mentor_agent; report_compiler_agent; monitoring_agent (13 agents) | 🧑 **Decision-heavy checkpoint:** user confirms RQ brief + methodology. Machine checks: S2 API Tier-0 verification (Levenshtein ≥ 0.70); evidence hierarchy graded; anti-sycophancy on DA (score 1-5, concede only ≥ 4) |
-| **2. WRITE** | `academic-paper` v3.1.0 (full / plan / outline-only / lit-review / revision-coach / abstract-only / citation-check / disclosure / format-convert / revision) | REDACTED | Paper Configuration Record; Outline; Argument Map; Draft Text; Bilingual Abstract; Figures + Captions; Citation List | 12-agent pipeline: intake_agent; literature_strategist_agent; structure_architect_agent; argument_builder_agent; draft_writer_agent; citation_compliance_agent; abstract_bilingual_agent; peer_reviewer_agent; formatter_agent; socratic_mentor_agent; visualization_agent; revision_coach_agent | 🧑 **Decision-heavy checkpoint:** outline approved before drafting. Machine checks: anti-leakage protocol (unsupported fill → `[MATERIAL GAP]`); VLM figure verification (10-pt APA checklist, max 2 refinements); style calibration vs user voice; Stage 2 parallelization (Phase 1 + visualization after outline) |
-| **2.5 INTEGRITY** | `academic-pipeline` v3.4.0 (gate) | VERIFIED_ONLY | Material Passport (Schema 9, required) + `repro_lock` (v3.3.5, declared — populated or `null`); Claim Verification Report (pre-review sampling: 30% of claims, min 10 — per `claim_verification_protocol.md`); Data Provenance Audit | integrity_verification_agent; state_tracker_agent; pipeline_orchestrator_agent | ✓ **Integrity gate** + user ack. 7-mode AI failure checklist (Lu 2026, canonical order per `ai_research_failure_modes.md`): **M1** implementation bug passing AI self-review; **M2** hallucinated citation; **M3** hallucinated experimental result; **M4** shortcut reliance; **M5** implementation bug reframed as novel insight; **M6** methodology fabrication; **M7** frame-lock at early pipeline stage. Pre-review claim sampling mode. FAIL → fix + re-verify (max 3 rounds) |
-| **3. REVIEW** | `academic-paper-reviewer` v1.8.1 (full / guided / quick / methodology-focus / calibration) | VERIFIED_ONLY | **First-round review package** (per `academic-paper-reviewer/SKILL.md`): 5 review reports (EIC + R1 methodology + R2 domain + R3 interdisciplinary + Devil's Advocate) + Editorial Decision (Accept / Minor / Major / Reject) + Revision Roadmap | field_analyst_agent (auto-detects domain, configures 3 field-adaptive reviewers); eic_agent; methodology_reviewer_agent; domain_reviewer_agent; perspective_reviewer_agent; devils_advocate_reviewer_agent; editorial_synthesizer_agent (7 agents) | 🧑 **Decision-heavy checkpoint:** user reviews editorial decision. Machine checks: concession threshold protocol (DA rebuttal scored 1-5, no concede below 4); attack intensity preserved through revisions; cross-model DA critique (optional, `ARS_CROSS_MODEL` env); read-only constraint (no new claims) |
+| **1. RESEARCH** | `deep-research` v2.9.0 (full / socratic / lit-review / systematic-review / fact-check / review / quick) | RAW | RQ Brief; Methodology Blueprint; Annotated Bibliography (S2-verified); Synthesis Report; INSIGHT Collection | research_question_agent; research_architect_agent; bibliography_agent; source_verification_agent; synthesis_agent; meta_analysis_agent; editor_in_chief_agent; devils_advocate_agent; risk_of_bias_agent; ethics_review_agent; socratic_mentor_agent; report_compiler_agent; monitoring_agent (13 agents); **👁 collaboration_depth_agent (v3.5.0, advisory)** | 🧑 **Decision-heavy checkpoint:** user confirms RQ brief + methodology. Machine checks: S2 API Tier-0 verification (Levenshtein ≥ 0.70); evidence hierarchy graded; anti-sycophancy on DA (score 1-5, concede only ≥ 4). 👁 Observer runs post-checkpoint; never blocks |
+| **2. WRITE** | `academic-paper` v3.1.0 (full / plan / outline-only / lit-review / revision-coach / abstract-only / citation-check / disclosure / format-convert / revision) | REDACTED | Paper Configuration Record; Outline; Argument Map; Draft Text; Bilingual Abstract; Figures + Captions; Citation List | 12-agent pipeline: intake_agent; literature_strategist_agent; structure_architect_agent; argument_builder_agent; draft_writer_agent; citation_compliance_agent; abstract_bilingual_agent; peer_reviewer_agent; formatter_agent; socratic_mentor_agent; visualization_agent; revision_coach_agent; **👁 collaboration_depth_agent (v3.5.0, advisory)** | 🧑 **Decision-heavy checkpoint:** outline approved before drafting. Machine checks: anti-leakage protocol (unsupported fill → `[MATERIAL GAP]`); VLM figure verification (10-pt APA checklist, max 2 refinements); style calibration vs user voice; Stage 2 parallelization (Phase 1 + visualization after outline). 👁 Observer runs post-checkpoint; never blocks |
+| **2.5 INTEGRITY** | `academic-pipeline` v3.5.0 (gate) | VERIFIED_ONLY | Material Passport (Schema 9, required) + `repro_lock` (v3.3.5, declared — populated or `null`); Claim Verification Report (pre-review sampling: 30% of claims, min 10 — per `claim_verification_protocol.md`); Data Provenance Audit | integrity_verification_agent; state_tracker_agent; pipeline_orchestrator_agent. **👁 collaboration_depth_agent: SKIPPED (MANDATORY gate — observer dilution explicitly prevented)** | ✓ **Integrity gate** + user ack. 7-mode AI failure checklist (Lu 2026, canonical order per `ai_research_failure_modes.md`): **M1** implementation bug passing AI self-review; **M2** hallucinated citation; **M3** hallucinated experimental result; **M4** shortcut reliance; **M5** implementation bug reframed as novel insight; **M6** methodology fabrication; **M7** frame-lock at early pipeline stage. Pre-review claim sampling mode. FAIL → fix + re-verify (max 3 rounds) |
+| **3. REVIEW** | `academic-paper-reviewer` v1.8.1 (full / guided / quick / methodology-focus / calibration) | VERIFIED_ONLY | **First-round review package** (per `academic-paper-reviewer/SKILL.md`): 5 review reports (EIC + R1 methodology + R2 domain + R3 interdisciplinary + Devil's Advocate) + Editorial Decision (Accept / Minor / Major / Reject) + Revision Roadmap | field_analyst_agent (auto-detects domain, configures 3 field-adaptive reviewers); eic_agent; methodology_reviewer_agent; domain_reviewer_agent; perspective_reviewer_agent; devils_advocate_reviewer_agent; editorial_synthesizer_agent (7 agents); **👁 collaboration_depth_agent (v3.5.0, advisory)** | 🧑 **Decision-heavy checkpoint:** user reviews editorial decision. Machine checks: concession threshold protocol (DA rebuttal scored 1-5, no concede below 4); attack intensity preserved through revisions; cross-model DA critique (optional, `ARS_CROSS_MODEL` env); read-only constraint (no new claims). 👁 Observer runs post-checkpoint; never blocks |
 | **3 → 4 Revision Coaching** | `academic-paper-reviewer` (EIC Socratic sub-stage) | VERIFIED_ONLY | Revision strategy dialogue (not an artifact handed forward; feeds Stage 4 revision plan) | eic_agent | 🧑 **Decision-heavy checkpoint:** Socratic dialogue with EIC (max 8 rounds). User may say "just fix it for me" to skip. Source: `two_stage_review_protocol.md` |
-| **4. REVISE** | `academic-paper` v3.1.0 (revision / revision-coach) | REDACTED | Point-by-Point Response; Revised Draft; Delta Report (what changed + why) | revision_coach_agent (v3.3 Socratic mode); draft_writer_agent (re-entry); argument_builder_agent (if structural) | 🧑 **Decision-heavy checkpoint:** user confirms changes. Machine checks: score trajectory tracked per rubric dimension (v3.3) — revisions that regress a dimension are flagged |
-| **3'. RE-REVIEW** | `academic-paper-reviewer` v1.8.1 (re-review) | VERIFIED_ONLY | **Verification package** (per re-review mode spec in `academic-paper-reviewer/SKILL.md`): Revision response checklist + residual issues list + new Decision (Accept / Minor / Major) + **R&R Traceability Matrix (Schema 11)** with Author's Claim + Verified? columns | **Narrow re-review team**: field_analyst_agent + eic_agent + editorial_synthesizer_agent (3 agents — not the full Stage 3 panel) | 🧑 **Decision-heavy checkpoint:** user reviews verification decision. Hard cap: **max 1 RE-REVISE round; 2 revision loops total** across Stages 4 + 4'. Major outcome at 3' → Residual Coaching → Stage 4' |
+| **4. REVISE** | `academic-paper` v3.1.0 (revision / revision-coach) | REDACTED | Point-by-Point Response; Revised Draft; Delta Report (what changed + why) | revision_coach_agent (v3.3 Socratic mode); draft_writer_agent (re-entry); argument_builder_agent (if structural); **👁 collaboration_depth_agent (v3.5.0, advisory)** | 🧑 **Decision-heavy checkpoint:** user confirms changes. Machine checks: score trajectory tracked per rubric dimension (v3.3) — revisions that regress a dimension are flagged. 👁 Observer runs post-checkpoint; never blocks |
+| **3'. RE-REVIEW** | `academic-paper-reviewer` v1.8.1 (re-review) | VERIFIED_ONLY | **Verification package** (per re-review mode spec in `academic-paper-reviewer/SKILL.md`): Revision response checklist + residual issues list + new Decision (Accept / Minor / Major) + **R&R Traceability Matrix (Schema 11)** with Author's Claim + Verified? columns | **Narrow re-review team**: field_analyst_agent + eic_agent + editorial_synthesizer_agent (3 agents — not the full Stage 3 panel); **👁 collaboration_depth_agent (v3.5.0, advisory)** | 🧑 **Decision-heavy checkpoint:** user reviews verification decision. Hard cap: **max 1 RE-REVISE round; 2 revision loops total** across Stages 4 + 4'. Major outcome at 3' → Residual Coaching → Stage 4'. 👁 Observer runs post-checkpoint; never blocks |
 | **3' → 4' Residual Coaching** | `academic-paper-reviewer` (EIC Socratic sub-stage) | VERIFIED_ONLY | Residual-issue dialogue | eic_agent | 🧑 **Decision-heavy checkpoint:** Socratic dialogue on trade-offs for residual issues (max 5 rounds). User may skip. Source: `two_stage_review_protocol.md` |
-| **4'. RE-REVISE** | `academic-paper` v3.1.0 (revision) | REDACTED | Final Revised Draft (terminal; advances to 4.5) | draft_writer_agent; revision_coach_agent | 🧑 **Decision-heavy checkpoint:** user confirms content frozen. No further review loop permitted |
-| **4.5 FINAL INTEGRITY** | `academic-pipeline` v3.4.0 (gate) | VERIFIED_ONLY | Updated Material Passport (`verification_status: VERIFIED`) + `repro_lock` declared — populated or explicit `null` (honest opt-out); Claim Verification Report (**final-check mode: 100% of claims** per `claim_verification_protocol.md`) | integrity_verification_agent (deeper re-run of 7 modes); state_tracker_agent | ✓ **Integrity gate** + user ack. **Zero-tolerance on the 7-mode re-run; no skip permitted.** Any mode SUSPECTED at 2.5 must be CLEAR or user-Overridden by 4.5. `repro_lock` is **not** read by the integrity gate at runtime (per `artifact_reproducibility_pattern.md`); if populated, `stochasticity_declaration` must be verbatim and is validated by the standalone `check_repro_lock.py` — this is post-hoc documentation, not a runtime block |
+| **4'. RE-REVISE** | `academic-paper` v3.1.0 (revision) | REDACTED | Final Revised Draft (terminal; advances to 4.5) | draft_writer_agent; revision_coach_agent; **👁 collaboration_depth_agent (v3.5.0, advisory)** | 🧑 **Decision-heavy checkpoint:** user confirms content frozen. No further review loop permitted. 👁 Observer runs post-checkpoint; never blocks |
+| **4.5 FINAL INTEGRITY** | `academic-pipeline` v3.5.0 (gate) | VERIFIED_ONLY | Updated Material Passport (`verification_status: VERIFIED`) + `repro_lock` declared — populated or explicit `null` (honest opt-out); Claim Verification Report (**final-check mode: 100% of claims** per `claim_verification_protocol.md`) | integrity_verification_agent (deeper re-run of 7 modes); state_tracker_agent. **👁 collaboration_depth_agent: SKIPPED (MANDATORY gate — observer dilution explicitly prevented)** | ✓ **Integrity gate** + user ack. **Zero-tolerance on the 7-mode re-run; no skip permitted.** Any mode SUSPECTED at 2.5 must be CLEAR or user-Overridden by 4.5. `repro_lock` is **not** read by the integrity gate at runtime (per `artifact_reproducibility_pattern.md`); if populated, `stochasticity_declaration` must be verbatim and is validated by the standalone `check_repro_lock.py` — this is post-hoc documentation, not a runtime block |
 | **5. FINALIZE** | `academic-paper` v3.1.0 (format-convert / disclosure) | VERIFIED_ONLY | Publication-ready MD; DOCX (Pandoc, if available); LaTeX (user confirms); PDF (tectonic); AI Disclosure Statement (venue-specific) | formatter_agent | 🧑 **Decision-heavy checkpoint:** user selects format before render. Disclosure statement must match venue (ICLR / NeurIPS / Nature / Science / ACL / EMNLP) |
-| **6. PROCESS SUMMARY** | `academic-pipeline` v3.4.0 | VERIFIED_ONLY | Paper Creation Process Record (MD + PDF); AI Self-Reflection Report (concession rate, sycophancy risk, health alerts, Failure Mode Audit Log); Score trajectory visualization | state_tracker_agent; pipeline_orchestrator_agent | 🧑 **Decision-heavy checkpoint:** language confirmed with user. Collaboration quality evaluated. Post-publication audit report (if peer-review published) |
+| **6. PROCESS SUMMARY** | `academic-pipeline` v3.5.0 | VERIFIED_ONLY | Paper Creation Process Record (MD + PDF); AI Self-Reflection Report (concession rate, sycophancy risk, health alerts, Failure Mode Audit Log); Score trajectory visualization; **Collaboration Depth Chapter (v3.5.0)** summarising the per-checkpoint observer reports from `collaboration_depth_history[]` | state_tracker_agent; pipeline_orchestrator_agent; **👁 collaboration_depth_agent (v3.5.0, pipeline-completion dispatch — final advisory report)** | 🧑 **Decision-heavy checkpoint:** language confirmed with user. Collaboration quality evaluated. Post-publication audit report (if peer-review published). 👁 Observer runs final pipeline-completion dispatch; never blocks |
 
 ## 4. Data Access Level Flow (v3.3.2+)
 
@@ -146,15 +147,17 @@ Rules (per `shared/ground_truth_isolation_pattern.md`):
 
 ```mermaid
 graph TD
-    Pipeline[academic-pipeline<br/>orchestrator<br/>v3.4.0]
+    Pipeline[academic-pipeline<br/>orchestrator<br/>v3.5.0<br/>Agent Team: 4]
+    Observer[collaboration_depth_agent<br/>observer · advisory only<br/>blocking: false]
     DR[deep-research<br/>13 agents<br/>v2.9.0]
     AP[academic-paper<br/>12 agents<br/>v3.1.0]
     APR[academic-paper-reviewer<br/>7 agents<br/>v1.8.1]
-    Shared[shared/<br/>handoff_schemas.md<br/>ground_truth_isolation<br/>benchmark_report<br/>artifact_reproducibility<br/>cross_model_verification<br/>mode_spectrum<br/>style_calibration]
+    Shared[shared/<br/>handoff_schemas.md<br/>ground_truth_isolation<br/>benchmark_report<br/>artifact_reproducibility<br/>cross_model_verification<br/>mode_spectrum<br/>style_calibration<br/>collaboration_depth_rubric]
 
     Pipeline --> DR
     Pipeline --> AP
     Pipeline --> APR
+    Pipeline -. "FULL/SLIM ckpt + pipeline completion<br/>MANDATORY gates skip" .-> Observer
     DR -. "RQ Brief + Bibliography + Synthesis" .-> AP
     AP -. "Complete manuscript" .-> APR
     APR -. "Revision Roadmap" .-> AP
@@ -162,13 +165,16 @@ graph TD
     AP --- Shared
     APR --- Shared
     Pipeline --- Shared
+    Observer --- Shared
 
     classDef orch fill:#f0f5ff,stroke:#2f54eb,stroke-width:2px
     classDef skill fill:#e6f4ff,stroke:#1677ff
     classDef shared fill:#f5f5f5,stroke:#595959,stroke-dasharray:5 5
+    classDef observer fill:#f6ffed,stroke:#52c41a,stroke-dasharray:3 3
     class Pipeline orch
     class DR,AP,APR skill
     class Shared shared
+    class Observer observer
 ```
 
 ## 6. Quality Gates
@@ -237,4 +243,4 @@ timeline
 | `deep-research` v2.9.0 | full, quick, socratic, review, lit-review, fact-check, systematic-review (7) |
 | `academic-paper` v3.1.0 | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure (10) |
 | `academic-paper-reviewer` v1.8.1 | full, re-review, quick, methodology-focus, guided, calibration (6) |
-| `academic-pipeline` v3.4.0 | (orchestrator — delegates to sub-skill modes; no standalone modes) |
+| `academic-pipeline` v3.5.0 | (orchestrator — delegates to sub-skill modes; no standalone modes) |

--- a/scripts/check_collaboration_depth_rubric.py
+++ b/scripts/check_collaboration_depth_rubric.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the Collaboration Depth Observer artifacts (ARS v3.4).
+"""Validate the Collaboration Depth Observer artifacts (ARS v3.5).
 
 Usage: python scripts/check_collaboration_depth_rubric.py [--path REPO_ROOT]
 Exit codes: 0 all checks pass; 1 at least one check failed.

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -152,7 +152,7 @@ def check_readme_sections() -> None:
         "### Deep Research (v2.8)",
         "### Academic Paper (v3.0)",
         "### Academic Paper Reviewer (v1.8)",
-        "### Academic Pipeline (v3.4)",
+        "### Academic Pipeline (v3.5)",
     ):
         if heading not in text:
             fail(f"{rel_path}: missing heading {heading!r}")
@@ -211,7 +211,7 @@ def check_readme_zh_sections() -> None:
         "### Deep Research (v2.8)",
         "### Academic Paper (v3.0)",
         "### Academic Paper Reviewer (v1.8)",
-        "### Academic Pipeline (v3.4)",
+        "### Academic Pipeline (v3.5)",
     ):
         if heading not in text:
             fail(f"{rel_path}: missing heading {heading!r}")

--- a/scripts/test_check_collaboration_depth_rubric.py
+++ b/scripts/test_check_collaboration_depth_rubric.py
@@ -1,4 +1,4 @@
-"""Unit tests for check_collaboration_depth_rubric.py (ARS v3.4)."""
+"""Unit tests for check_collaboration_depth_rubric.py (ARS v3.5)."""
 from __future__ import annotations
 
 import textwrap

--- a/shared/collaboration_depth_rubric.md
+++ b/shared/collaboration_depth_rubric.md
@@ -6,7 +6,7 @@ license: CC-BY-NC 4.0
 
 # Collaboration Depth Rubric
 
-**Status**: v1.0 (introduced ARS v3.4, 2026-04-21)
+**Status**: v1.0 (introduced ARS v3.5, 2026-04-21)
 **Source**: Wang, S., & Zhang, H. (2026). *IJETHE* 23:11. DOI [10.1186/s41239-026-00585-x](https://doi.org/10.1186/s41239-026-00585-x). Open Access, CC BY 4.0.
 **Canonical location**: `shared/collaboration_depth_rubric.md` in `Imbad0202/academic-research-skills`. External consumers should reference by stable URL; do not vendor (bump the `rubric_version` field on any modification).
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #27. The v3.5.0 PR bumped the suite version and the Quality Gates table, but left three mermaid charts and several per-file version labels still pointing at v3.4.0 without the observer annotated.

### Mermaid charts — now reflect the observer

- **§2 Pipeline Flow**: every FULL/SLIM stage (1 / 2 / 3 / 3' / 4 / 4' / 6) marked **👁 observer**. MANDATORY integrity gates (2.5 / 4.5) marked **"observer SKIPPED"** so readers see the non-dilution contract at a glance. Legend updated.
- **§5 Skill Dependency Graph**: new `collaboration_depth_agent` node, dashed green edge from Pipeline labelled with dispatch conditions (`FULL/SLIM ckpt + pipeline completion, MANDATORY gates skip`). `collaboration_depth_rubric` added to `shared/`. Pipeline node version 3.4.0 → 3.5.0.
- **§3 Stage × Dimension Matrix**: observer added to "Core agents" for stages 1 / 2 / 3 / 3' / 4 / 4' / 6, and explicitly marked **SKIPPED** at 2.5 / 4.5 with rationale. Stage 6 now also lists the **Collaboration Depth Chapter** artifact (pipeline-completion dispatch).
- **§8 Modes**: `academic-pipeline` row v3.4.0 → v3.5.0.

### Version labels caught

| File | Drift |
|---|---|
| `academic-pipeline/SKILL.md` | frontmatter `version: 3.4.0` → `3.5.0`; H1 title; Observer section header; Version Info footer |
| `README.md` + `README.zh-TW.md` | heading `Academic Pipeline (v3.4)` → `(v3.5)`; body corrected (Compliance Agent is v3.4.0, not v3.3; observer is v3.5.0, not v3.4) |
| `scripts/check_spec_consistency.py` | pinned heading expectations bumped to `v3.5` to match README |
| `.claude/CLAUDE.md` | Skills Overview: pipeline v3.4.0 → v3.5.0 |
| `shared/collaboration_depth_rubric.md` | Status line "introduced ARS v3.4" → v3.5 |
| `scripts/check_collaboration_depth_rubric.py` + test | docstring "ARS v3.4" → v3.5 |

## Why this slipped through

The PR #27 lint (`check_spec_consistency.py`) pinned `### Academic Pipeline (v3.4)` as an expected heading, so bumping the README heading to v3.5 would have broken CI. Lint and source-of-truth drifted together and neither flagged the other. Fixed both in lockstep here.

## Test plan

- [x] `python3 scripts/check_spec_consistency.py` — OK
- [x] `PYTHONPATH=scripts python3 scripts/check_collaboration_depth_rubric.py` — OK
- [x] `python3 -m unittest scripts.test_check_collaboration_depth_rubric -v` — 12/12 pass
- [ ] CI `Spec Consistency` workflow passes on this PR

## Files

9 files, +41 / -35. Docs + lint + rubric/test metadata only; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)