### PR TITLE
fix: add YAML frontmatter to all 35 agent files (close #30)

### DIFF
--- a/academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_devils_advocate_reviewer_agent
+description: "Challenges core arguments and logical coherence as the devils advocate reviewer in the editorial panel"
+---
+
 # Devil's Advocate Reviewer Agent — Paper Review Devil's Advocate
 
 ## Role Definition

--- a/academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_devils_advocate_reviewer_agent
+name: devils_advocate_reviewer_agent
 description: "Challenges core arguments and logical coherence as the devils advocate reviewer in the editorial panel"
 ---
 

--- a/academic-paper-reviewer/agents/domain_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/domain_reviewer_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_domain_reviewer_agent
+description: "Peer Reviewer 2; assesses domain expertise, substantive accuracy, and field-specific adequacy"
+---
+
 # Domain Reviewer Agent (Peer Reviewer 2)
 
 ## Role & Identity

--- a/academic-paper-reviewer/agents/domain_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/domain_reviewer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_domain_reviewer_agent
+name: domain_reviewer_agent
 description: "Peer Reviewer 2; assesses domain expertise, substantive accuracy, and field-specific adequacy"
 ---
 

--- a/academic-paper-reviewer/agents/editorial_synthesizer_agent.md
+++ b/academic-paper-reviewer/agents/editorial_synthesizer_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_editorial_synthesizer_agent
+description: "Synthesizes all reviewer reports into a unified editorial decision letter and revision roadmap"
+---
+
 # Editorial Synthesizer Agent
 
 ## Role & Identity

--- a/academic-paper-reviewer/agents/editorial_synthesizer_agent.md
+++ b/academic-paper-reviewer/agents/editorial_synthesizer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_editorial_synthesizer_agent
+name: editorial_synthesizer_agent
 description: "Synthesizes all reviewer reports into a unified editorial decision letter and revision roadmap"
 ---
 

--- a/academic-paper-reviewer/agents/eic_agent.md
+++ b/academic-paper-reviewer/agents/eic_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_eic_agent
+description: "Editor-in-Chief; orchestrates the review panel and delivers the final editorial decision"
+---
+
 # EIC Agent (Editor-in-Chief)
 
 ## Role & Identity

--- a/academic-paper-reviewer/agents/eic_agent.md
+++ b/academic-paper-reviewer/agents/eic_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_eic_agent
+name: eic_agent
 description: "Editor-in-Chief; orchestrates the review panel and delivers the final editorial decision"
 ---
 

--- a/academic-paper-reviewer/agents/field_analyst_agent.md
+++ b/academic-paper-reviewer/agents/field_analyst_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_field_analyst_agent
+description: "Identifies the papers field and dynamically configures the reviewer teams identities and expertise"
+---
+
 # Field Analyst Agent
 
 ## Role & Identity

--- a/academic-paper-reviewer/agents/field_analyst_agent.md
+++ b/academic-paper-reviewer/agents/field_analyst_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_field_analyst_agent
+name: field_analyst_agent
 description: "Identifies the papers field and dynamically configures the reviewer teams identities and expertise"
 ---
 

--- a/academic-paper-reviewer/agents/methodology_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/methodology_reviewer_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_methodology_reviewer_agent
+description: "Peer Reviewer 1; assesses methodological soundness, research design validity, and statistical rigor"
+---
+
 # Methodology Reviewer Agent (Peer Reviewer 1)
 
 ## Role & Identity

--- a/academic-paper-reviewer/agents/methodology_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/methodology_reviewer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_methodology_reviewer_agent
+name: methodology_reviewer_agent
 description: "Peer Reviewer 1; assesses methodological soundness, research design validity, and statistical rigor"
 ---
 

--- a/academic-paper-reviewer/agents/perspective_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/perspective_reviewer_agent.md
@@ -1,3 +1,8 @@
+---
+name: paperreviewer_perspective_reviewer_agent
+description: "Peer Reviewer 3; evaluates cross-disciplinary relevance, broader impact, and alternative interpretations"
+---
+
 # Perspective Reviewer Agent (Peer Reviewer 3)
 
 ## Role & Identity

--- a/academic-paper-reviewer/agents/perspective_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/perspective_reviewer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: paperreviewer_perspective_reviewer_agent
+name: perspective_reviewer_agent
 description: "Peer Reviewer 3; evaluates cross-disciplinary relevance, broader impact, and alternative interpretations"
 ---
 

--- a/academic-paper/agents/abstract_bilingual_agent.md
+++ b/academic-paper/agents/abstract_bilingual_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_abstract_bilingual_agent
+description: "Writes and translates abstracts in English and the target language to journal format standards"
+---
+
 # Abstract Bilingual Agent — Bilingual Abstract
 
 ## Role Definition

--- a/academic-paper/agents/abstract_bilingual_agent.md
+++ b/academic-paper/agents/abstract_bilingual_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_abstract_bilingual_agent
+name: abstract_bilingual_agent
 description: "Writes and translates abstracts in English and the target language to journal format standards"
 ---
 

--- a/academic-paper/agents/argument_builder_agent.md
+++ b/academic-paper/agents/argument_builder_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_argument_builder_agent
+description: "Constructs the papers core argument and logical reasoning structure"
+---
+
 # Argument Builder Agent — Argumentation Construction
 
 ## Role Definition

--- a/academic-paper/agents/argument_builder_agent.md
+++ b/academic-paper/agents/argument_builder_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_argument_builder_agent
+name: argument_builder_agent
 description: "Constructs the papers core argument and logical reasoning structure"
 ---
 

--- a/academic-paper/agents/citation_compliance_agent.md
+++ b/academic-paper/agents/citation_compliance_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_citation_compliance_agent
+description: "Verifies citations against the target journals format requirements and flags non-compliant entries"
+---
+
 # Citation Compliance Agent — Citation Format Compliance
 
 ## Role Definition

--- a/academic-paper/agents/citation_compliance_agent.md
+++ b/academic-paper/agents/citation_compliance_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_citation_compliance_agent
+name: citation_compliance_agent
 description: "Verifies citations against the target journals format requirements and flags non-compliant entries"
 ---
 

--- a/academic-paper/agents/draft_writer_agent.md
+++ b/academic-paper/agents/draft_writer_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_draft_writer_agent
+description: "Writes the full paper draft section by section from the structured outline and Paper Configuration Record"
+---
+
 # Draft Writer Agent — Full-Text Drafting
 
 ## Role Definition

--- a/academic-paper/agents/draft_writer_agent.md
+++ b/academic-paper/agents/draft_writer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_draft_writer_agent
+name: draft_writer_agent
 description: "Writes the full paper draft section by section from the structured outline and Paper Configuration Record"
 ---
 

--- a/academic-paper/agents/formatter_agent.md
+++ b/academic-paper/agents/formatter_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_formatter_agent
+description: "Formats the final manuscript output to target journal style requirements"
+---
+
 # Formatter Agent — Output Formatting
 
 ## Role Definition

--- a/academic-paper/agents/formatter_agent.md
+++ b/academic-paper/agents/formatter_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_formatter_agent
+name: formatter_agent
 description: "Formats the final manuscript output to target journal style requirements"
 ---
 

--- a/academic-paper/agents/intake_agent.md
+++ b/academic-paper/agents/intake_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_intake_agent
+description: "Conducts the paper configuration interview and produces the Paper Configuration Record for downstream agents"
+---
+
 # Intake Agent — Paper Configuration Interview
 
 ## Role Definition

--- a/academic-paper/agents/intake_agent.md
+++ b/academic-paper/agents/intake_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_intake_agent
+name: intake_agent
 description: "Conducts the paper configuration interview and produces the Paper Configuration Record for downstream agents"
 ---
 

--- a/academic-paper/agents/literature_strategist_agent.md
+++ b/academic-paper/agents/literature_strategist_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_literature_strategist_agent
+description: "Designs the literature search strategy and manages source selection for the paper"
+---
+
 # Literature Strategist Agent — Literature Search Strategy
 
 ## Role Definition

--- a/academic-paper/agents/literature_strategist_agent.md
+++ b/academic-paper/agents/literature_strategist_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_literature_strategist_agent
+name: literature_strategist_agent
 description: "Designs the literature search strategy and manages source selection for the paper"
 ---
 

--- a/academic-paper/agents/peer_reviewer_agent.md
+++ b/academic-paper/agents/peer_reviewer_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_peer_reviewer_agent
+description: "Simulates peer review to identify weaknesses and suggest improvements before submission"
+---
+
 # Peer Reviewer Agent — Simulated Peer Review
 
 ## Role Definition

--- a/academic-paper/agents/peer_reviewer_agent.md
+++ b/academic-paper/agents/peer_reviewer_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_peer_reviewer_agent
+name: peer_reviewer_agent
 description: "Simulates peer review to identify weaknesses and suggest improvements before submission"
 ---
 

--- a/academic-paper/agents/revision_coach_agent.md
+++ b/academic-paper/agents/revision_coach_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_revision_coach_agent
+description: "Parses reviewer comments and builds the structured revision plan for the author"
+---
+
 # Revision Coach Agent — Reviewer Comment Parser and Revision Planner
 
 ## Role Definition

--- a/academic-paper/agents/revision_coach_agent.md
+++ b/academic-paper/agents/revision_coach_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_revision_coach_agent
+name: revision_coach_agent
 description: "Parses reviewer comments and builds the structured revision plan for the author"
 ---
 

--- a/academic-paper/agents/socratic_mentor_agent.md
+++ b/academic-paper/agents/socratic_mentor_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_socratic_mentor_agent
+name: socratic_mentor_agent
 description: "Guides paper authors through Socratic questions to sharpen arguments and surface unstated assumptions"
 ---
 

--- a/academic-paper/agents/socratic_mentor_agent.md
+++ b/academic-paper/agents/socratic_mentor_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_socratic_mentor_agent
+description: "Guides paper authors through Socratic questions to sharpen arguments and surface unstated assumptions"
+---
+
 # Socratic Mentor Agent — Socratic Paper Advisor
 
 ## Role Definition

--- a/academic-paper/agents/structure_architect_agent.md
+++ b/academic-paper/agents/structure_architect_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_structure_architect_agent
+description: "Designs the papers section architecture and detailed outline before drafting begins"
+---
+
 # Structure Architect Agent — Paper Architecture Design
 
 ## Role Definition

--- a/academic-paper/agents/structure_architect_agent.md
+++ b/academic-paper/agents/structure_architect_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_structure_architect_agent
+name: structure_architect_agent
 description: "Designs the papers section architecture and detailed outline before drafting begins"
 ---
 

--- a/academic-paper/agents/visualization_agent.md
+++ b/academic-paper/agents/visualization_agent.md
@@ -1,3 +1,8 @@
+---
+name: academicpaper_visualization_agent
+description: "Generates publication-quality figure specifications and chart descriptions for inclusion in the paper"
+---
+
 # Visualization Agent — Publication-Quality Figure Generation
 
 ## Role Definition

--- a/academic-paper/agents/visualization_agent.md
+++ b/academic-paper/agents/visualization_agent.md
@@ -1,5 +1,5 @@
 ---
-name: academicpaper_visualization_agent
+name: visualization_agent
 description: "Generates publication-quality figure specifications and chart descriptions for inclusion in the paper"
 ---
 

--- a/academic-pipeline/agents/integrity_verification_agent.md
+++ b/academic-pipeline/agents/integrity_verification_agent.md
@@ -1,3 +1,8 @@
+---
+name: pipeline_integrity_verification_agent
+description: "Verifies all references, citations, and data for factual accuracy before submission and after revision"
+---
+
 # Integrity Verification Agent — Academic Integrity Verification Gatekeeper
 
 ## Role Definition

--- a/academic-pipeline/agents/integrity_verification_agent.md
+++ b/academic-pipeline/agents/integrity_verification_agent.md
@@ -1,5 +1,5 @@
 ---
-name: pipeline_integrity_verification_agent
+name: integrity_verification_agent
 description: "Verifies all references, citations, and data for factual accuracy before submission and after revision"
 ---
 

--- a/academic-pipeline/agents/pipeline_orchestrator_agent.md
+++ b/academic-pipeline/agents/pipeline_orchestrator_agent.md
@@ -1,3 +1,8 @@
+---
+name: pipeline_orchestrator_agent
+description: "Orchestrates the full multi-skill academic research pipeline and manages agent handoffs across phases"
+---
+
 # Pipeline Orchestrator Agent v2.0
 
 ## Role Definition

--- a/academic-pipeline/agents/state_tracker_agent.md
+++ b/academic-pipeline/agents/state_tracker_agent.md
@@ -1,3 +1,8 @@
+---
+name: pipeline_state_tracker_agent
+description: "Tracks pipeline state and maintains the research session history across multi-phase workflows"
+---
+
 # State Tracker Agent v2.0
 
 ## Role Definition

--- a/academic-pipeline/agents/state_tracker_agent.md
+++ b/academic-pipeline/agents/state_tracker_agent.md
@@ -1,5 +1,5 @@
 ---
-name: pipeline_state_tracker_agent
+name: state_tracker_agent
 description: "Tracks pipeline state and maintains the research session history across multi-phase workflows"
 ---
 

--- a/deep-research/agents/bibliography_agent.md
+++ b/deep-research/agents/bibliography_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_bibliography_agent
+description: "Systematic literature search and curation; identifies, annotates, and formats sources in APA 7.0"
+---
+
 # Bibliography Agent — Systematic Literature Search & Curation
 
 ## Role Definition

--- a/deep-research/agents/bibliography_agent.md
+++ b/deep-research/agents/bibliography_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_bibliography_agent
+name: bibliography_agent
 description: "Systematic literature search and curation; identifies, annotates, and formats sources in APA 7.0"
 ---
 

--- a/deep-research/agents/devils_advocate_agent.md
+++ b/deep-research/agents/devils_advocate_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_devils_advocate_agent
+description: "Challenges assumptions, tests logical chains, and stress-tests research arguments at mandatory checkpoints"
+---
+
 # Devil's Advocate Agent — Assumption Challenger & Bias Hunter
 
 ## Role Definition

--- a/deep-research/agents/devils_advocate_agent.md
+++ b/deep-research/agents/devils_advocate_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_devils_advocate_agent
+name: devils_advocate_agent
 description: "Challenges assumptions, tests logical chains, and stress-tests research arguments at mandatory checkpoints"
 ---
 

--- a/deep-research/agents/editor_in_chief_agent.md
+++ b/deep-research/agents/editor_in_chief_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_editor_in_chief_agent
+description: "Q1 journal editorial review; delivers Accept/Reject verdict with actionable feedback on research reports"
+---
+
 # Editor-in-Chief Agent — Q1 Journal Editorial Review
 
 ## Role Definition

--- a/deep-research/agents/editor_in_chief_agent.md
+++ b/deep-research/agents/editor_in_chief_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_editor_in_chief_agent
+name: editor_in_chief_agent
 description: "Q1 journal editorial review; delivers Accept/Reject verdict with actionable feedback on research reports"
 ---
 

--- a/deep-research/agents/ethics_review_agent.md
+++ b/deep-research/agents/ethics_review_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_ethics_review_agent
+description: "Research ethics gate; ensures AI-assisted research meets attribution, disclosure, and integrity standards before delivery"
+---
+
 # Ethics Review Agent — Research Integrity & AI Ethics Guardian
 
 ## Role Definition

--- a/deep-research/agents/ethics_review_agent.md
+++ b/deep-research/agents/ethics_review_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_ethics_review_agent
+name: ethics_review_agent
 description: "Research ethics gate; ensures AI-assisted research meets attribution, disclosure, and integrity standards before delivery"
 ---
 

--- a/deep-research/agents/meta_analysis_agent.md
+++ b/deep-research/agents/meta_analysis_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_meta_analysis_agent
+description: "Quantitative synthesis of included studies; computes effect sizes, assesses heterogeneity, and applies GRADE framework"
+---
+
 # Meta-Analysis Agent — Quantitative Synthesis & Effect Size Computation
 
 ## Role Definition

--- a/deep-research/agents/meta_analysis_agent.md
+++ b/deep-research/agents/meta_analysis_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_meta_analysis_agent
+name: meta_analysis_agent
 description: "Quantitative synthesis of included studies; computes effect sizes, assesses heterogeneity, and applies GRADE framework"
 ---
 

--- a/deep-research/agents/monitoring_agent.md
+++ b/deep-research/agents/monitoring_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_monitoring_agent
+description: "Post-research literature monitoring; helps users track new publications and developments after a research project is complete"
+---
+
 # Monitoring Agent — Post-Research Literature Monitoring
 
 ## Role Definition

--- a/deep-research/agents/monitoring_agent.md
+++ b/deep-research/agents/monitoring_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_monitoring_agent
+name: monitoring_agent
 description: "Post-research literature monitoring; helps users track new publications and developments after a research project is complete"
 ---
 

--- a/deep-research/agents/report_compiler_agent.md
+++ b/deep-research/agents/report_compiler_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_report_compiler_agent
+description: "Transforms research findings into polished APA 7.0 academic reports; activated in Phase 4 and Phase 6"
+---
+
 # Report Compiler Agent — APA 7.0 Academic Report Writer
 
 ## Role Definition

--- a/deep-research/agents/report_compiler_agent.md
+++ b/deep-research/agents/report_compiler_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_report_compiler_agent
+name: report_compiler_agent
 description: "Transforms research findings into polished APA 7.0 academic reports; activated in Phase 4 and Phase 6"
 ---
 

--- a/deep-research/agents/research_architect_agent.md
+++ b/deep-research/agents/research_architect_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_research_architect_agent
+description: "Designs the methodological blueprint; selects research paradigm, method, data strategy, and analytical framework"
+---
+
 # Research Architect Agent — Methodology Blueprint Designer
 
 ## Role Definition

--- a/deep-research/agents/research_architect_agent.md
+++ b/deep-research/agents/research_architect_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_research_architect_agent
+name: research_architect_agent
 description: "Designs the methodological blueprint; selects research paradigm, method, data strategy, and analytical framework"
 ---
 

--- a/deep-research/agents/research_question_agent.md
+++ b/deep-research/agents/research_question_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_research_question_agent
+description: "Transforms vague topics into precise, FINER-evaluated researchable questions through iterative refinement"
+---
+
 # Research Question Agent — Precision Question Engineering
 
 ## Role Definition

--- a/deep-research/agents/research_question_agent.md
+++ b/deep-research/agents/research_question_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_research_question_agent
+name: research_question_agent
 description: "Transforms vague topics into precise, FINER-evaluated researchable questions through iterative refinement"
 ---
 

--- a/deep-research/agents/risk_of_bias_agent.md
+++ b/deep-research/agents/risk_of_bias_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_risk_of_bias_agent
+description: "Assesses risk of bias in included studies using RoB 2 (RCTs) and ROBINS-I (non-randomized studies)"
+---
+
 # Risk of Bias Agent — Systematic Bias Assessment for Included Studies
 
 ## Role Definition

--- a/deep-research/agents/risk_of_bias_agent.md
+++ b/deep-research/agents/risk_of_bias_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_risk_of_bias_agent
+name: risk_of_bias_agent
 description: "Assesses risk of bias in included studies using RoB 2 (RCTs) and ROBINS-I (non-randomized studies)"
 ---
 

--- a/deep-research/agents/socratic_mentor_agent.md
+++ b/deep-research/agents/socratic_mentor_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_socratic_mentor_agent
+name: socratic_mentor_agent
 description: "Guides researchers through Socratic questioning to clarify and sharpen their research thinking"
 ---
 

--- a/deep-research/agents/socratic_mentor_agent.md
+++ b/deep-research/agents/socratic_mentor_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_socratic_mentor_agent
+description: "Guides researchers through Socratic questioning to clarify and sharpen their research thinking"
+---
+
 # Socratic Mentor Agent — Socratic Research Guide
 
 ## Role Definition

--- a/deep-research/agents/source_verification_agent.md
+++ b/deep-research/agents/source_verification_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_source_verification_agent
+description: "Grades evidence, detects predatory publications, and fact-checks claims entering the research pipeline"
+---
+
 # Source Verification Agent — Evidence Grading & Fact-Checking
 
 ## Role Definition

--- a/deep-research/agents/source_verification_agent.md
+++ b/deep-research/agents/source_verification_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_source_verification_agent
+name: source_verification_agent
 description: "Grades evidence, detects predatory publications, and fact-checks claims entering the research pipeline"
 ---
 

--- a/deep-research/agents/synthesis_agent.md
+++ b/deep-research/agents/synthesis_agent.md
@@ -1,3 +1,8 @@
+---
+name: deepresearch_synthesis_agent
+description: "Integrates findings across sources, resolves evidence conflicts, and maps knowledge gaps"
+---
+
 # Synthesis Agent — Cross-Source Integration & Gap Analysis
 
 ## Role Definition

--- a/deep-research/agents/synthesis_agent.md
+++ b/deep-research/agents/synthesis_agent.md
@@ -1,5 +1,5 @@
 ---
-name: deepresearch_synthesis_agent
+name: synthesis_agent
 description: "Integrates findings across sources, resolves evidence conflicts, and maps knowledge gaps"
 ---
 


### PR DESCRIPTION
## Summary

Adds the missing YAML frontmatter (`name`, `description`) to all 35 agent `.md` files flagged by the NLPM audit in #30. Pure metadata addition — no agent prompt content, SKILL.md, orchestrator, or template was modified.

Closes #30.

## What Changed

- 35 files changed, +175 / -0 (pure additions against main)
- Each agent file now starts with:
  ```yaml
  ---
  name: <filename_stem>
  description: "<one-line summary from Role Definition>"
  ---
  ```
- The two agents that already had frontmatter (`shared/agents/compliance_agent.md`, `academic-pipeline/agents/collaboration_depth_agent.md`) are untouched.

## Naming Convention

`name` matches the filename stem for every file. This keeps frontmatter consistent with every dispatch site across SKILL.md orchestrators, handoff references inside sibling agents, templates, and examples.

Two distinct agents share the name `socratic_mentor_agent` (one under `deep-research/agents/`, one under `academic-paper/agents/`) because that's the identifier their respective skills already use. Registry collision at a future plugin-marketplace layer is noted; no current code path dispatches agents by frontmatter name.

## Review History

Three codex review passes shaped this PR:

1. **Initial approach** used `{skill}_{stem}` prefixes (e.g. `paperreviewer_eic_agent`) to pre-empt plugin-registry collisions → codex flagged 4 [P1] findings: the prefixes broke every existing SKILL.md / orchestrator reference, since those still dispatch by unprefixed stems.
2. **Reverted to stems** with prefixes kept only for the two colliding `socratic_mentor_agent` files → codex flagged 2 [P2] findings: same drift problem, just narrower — SKILL.md and sibling agents in both skills still reference `socratic_mentor_agent` without a prefix.
3. **Final pass** aligns all 35 names with filename stems, accepting the socratic_mentor collision as a documented tradeoff.

## Version Impact

**No version bump in this PR.** Pure metadata addition with zero behavior change — no agent prompt, SKILL.md, orchestrator, or template is modified.

Suggested CHANGELOG entry for the next release (v3.5.1 or v3.6.0):

> - **Agent registry metadata**: Added `name` and `description` YAML frontmatter to all 35 agent files so Claude Code's plugin registry can index them. Filename stems remain the canonical identifier used throughout SKILL.md dispatch. (#30, #31)

## Credit

Bug reported by @xiaolai via [NLPM](https://github.com/xiaolai/nlpm-for-claude) automated audit (#30), with a fix branch prepared at [xiaolai/academic-research-skills#1](https://github.com/xiaolai/academic-research-skills/pull/1). This PR reimplements the fix locally so it passes through this repo's CI/review gate. Descriptions are carried over from the NLPM-generated versions after spot-checking against each agent's Role Definition.

## Test plan

- [x] codex review GATE: PASS (no [P1], [P2] scoped to socratic_mentor collision accepted by design)
- [x] Diff contains zero deletions / zero non-frontmatter additions
- [x] All 35 `name` fields equal their filename stem
- [x] Every agent file opens with YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)