### PR TITLE
fix: add missing description to pre-existing agent frontmatter

### DIFF
--- a/academic-pipeline/agents/collaboration_depth_agent.md
+++ b/academic-pipeline/agents/collaboration_depth_agent.md
@@ -1,5 +1,6 @@
 ---
 name: collaboration_depth_agent
+description: "Post-hoc observer scoring user-AI collaboration depth against the canonical rubric; advisory-only, never blocks pipeline progression"
 role: observer
 blocking: false
 measures: collaboration_depth

--- a/shared/agents/compliance_agent.md
+++ b/shared/agents/compliance_agent.md
@@ -1,5 +1,6 @@
 ---
 name: compliance_agent
+description: "Runs PRISMA-trAIce + RAISE compliance checks at Stage 2.5 / 4.5 integrity gates and emits Schema 12 compliance_report"
 version: 1.0.0
 owner_skill: shared
 invoked_by: [academic-pipeline, deep-research, academic-paper]


### PR DESCRIPTION
## Summary

Follow-up to #31. Two agents (`compliance_agent`, `collaboration_depth_agent`) already carried YAML frontmatter before #31, so #31 left them untouched — but both were missing a `description` field.

Claude Code's plugin registry (per NLPM's audit that triggered #30) requires both `name` and `description` for every indexed agent file. With this PR, every agent in the repo has a complete registry entry.

## Diff

- 2 files changed, +2 / -0 (pure additions)
- `shared/agents/compliance_agent.md` — adds one-line description of PRISMA-trAIce + RAISE scope
- `academic-pipeline/agents/collaboration_depth_agent.md` — adds one-line description of the observer role

## Test plan

- [x] Pure metadata addition; no agent behavior / orchestrator / SKILL.md change
- [x] Both descriptions derived from the agent files' own existing content
- [x] All 37 agent files in the repo now have complete name + description frontmatter

Ref: #30, #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)