### PR TITLE
ci: version consistency guard (CLAUDE.md / SKILL.md / CHANGELOG)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -52,3 +52,14 @@ jobs:
         env:
           PYTHONPATH: .
         run: python3 -m unittest scripts.test_check_collaboration_depth_rubric -v
+
+      - name: Check version consistency (CLAUDE.md / SKILL.md / CHANGELOG)
+        env:
+          PYTHONPATH: scripts
+        run: python3 scripts/check_version_consistency.py
+
+      - name: Run version consistency unit tests
+        env:
+          PYTHONPATH: .
+        run: python3 -m unittest scripts.test_check_version_consistency -v
+

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Lint: version labels stay aligned across .claude/CLAUDE.md, SKILL.md frontmatter, and CHANGELOG.md.
+
+Invariants enforced:
+  1. Every skill listed in .claude/CLAUDE.md Skills Overview table has a version
+     equal to its own SKILL.md metadata.version.
+  2. .claude/CLAUDE.md "**Suite version**: X.Y.Z" equals the most recent
+     "## [X.Y.Z]" entry in CHANGELOG.md.
+  3. academic-pipeline version in the table equals the suite version (pipeline
+     = orchestrator, by convention tracks the suite release).
+
+Runs from repo root by default; `--path` lets tests point at a fake tree.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from _skill_lint import parse_frontmatter, FrontmatterError
+
+
+TABLE_ROW_RE = re.compile(r"^\|\s*`([a-z0-9-]+)`\s+v(\d+\.\d+\.\d+)\s*\|", re.MULTILINE)
+SUITE_VERSION_RE = re.compile(
+    r"^\s*-\s*\*\*Suite version\*\*:\s*(\d+\.\d+\.\d+)", re.MULTILINE
+)
+CHANGELOG_ENTRY_RE = re.compile(r"^##\s*\[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+
+PIPELINE_SKILL_NAME = "academic-pipeline"
+
+
+def _parse_table_versions(claude_md_text: str) -> dict[str, str]:
+    """Return mapping skill_name -> version from the Skills Overview table."""
+    return dict(TABLE_ROW_RE.findall(claude_md_text))
+
+
+def _parse_suite_version(claude_md_text: str) -> str | None:
+    m = SUITE_VERSION_RE.search(claude_md_text)
+    return m.group(1) if m else None
+
+
+def _parse_changelog_latest(changelog_text: str) -> str | None:
+    m = CHANGELOG_ENTRY_RE.search(changelog_text)
+    return m.group(1) if m else None
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+
+    claude_md = root / ".claude" / "CLAUDE.md"
+    if not claude_md.is_file():
+        errors.append(f"{claude_md}: not found")
+        return errors
+    claude_text = claude_md.read_text(encoding="utf-8")
+
+    table_versions = _parse_table_versions(claude_text)
+    if not table_versions:
+        errors.append(
+            f"{claude_md}: Skills Overview table has no parseable "
+            "`<skill>` vX.Y.Z rows"
+        )
+
+    suite_version = _parse_suite_version(claude_text)
+    if suite_version is None:
+        errors.append(
+            f"{claude_md}: missing '**Suite version**: X.Y.Z' line"
+        )
+
+    changelog = root / "CHANGELOG.md"
+    if not changelog.is_file():
+        errors.append(f"{changelog}: not found")
+    else:
+        latest = _parse_changelog_latest(changelog.read_text(encoding="utf-8"))
+        if latest is None:
+            errors.append(f"{changelog}: no '## [X.Y.Z]' entry found")
+        elif suite_version is not None and latest != suite_version:
+            errors.append(
+                f"{claude_md}: Suite version {suite_version!r} does not match "
+                f"CHANGELOG latest entry {latest!r}"
+            )
+
+    for skill_name, table_version in sorted(table_versions.items()):
+        skill_md = root / skill_name / "SKILL.md"
+        if not skill_md.is_file():
+            errors.append(
+                f"{claude_md}: table lists {skill_name!r} v{table_version} "
+                f"but {skill_md} does not exist"
+            )
+            continue
+        try:
+            fm = parse_frontmatter(skill_md)
+        except FrontmatterError as exc:
+            errors.append(str(exc))
+            continue
+        if fm is None:
+            errors.append(f"{skill_md}: missing YAML frontmatter")
+            continue
+        metadata = fm.get("metadata") or {}
+        declared = metadata.get("version")
+        if declared is None:
+            errors.append(f"{skill_md}: metadata.version is missing")
+            continue
+        declared_str = str(declared)
+        if declared_str != table_version:
+            errors.append(
+                f"{claude_md}: {skill_name!r} listed as v{table_version} but "
+                f"{skill_md} metadata.version is {declared_str!r}"
+            )
+
+    if suite_version is not None:
+        pipeline_in_table = table_versions.get(PIPELINE_SKILL_NAME)
+        if pipeline_in_table is not None and pipeline_in_table != suite_version:
+            errors.append(
+                f"{claude_md}: {PIPELINE_SKILL_NAME} listed as "
+                f"v{pipeline_in_table} but suite version is {suite_version!r} "
+                "(pipeline tracks the suite release)"
+            )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    args = parser.parse_args()
+
+    errors = check(args.path)
+    if errors:
+        print("Version consistency check failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+    print("Version consistency check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -1,0 +1,215 @@
+"""Unit tests for check_version_consistency.py (ARS v3.6 CI guard E)."""
+from __future__ import annotations
+
+import subprocess
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "check_version_consistency.py"
+
+
+def _run(root: Path) -> subprocess.CompletedProcess:
+    return run_script(SCRIPT, "--path", str(root))
+
+
+def _write_skill(root: Path, name: str, version: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            name: {name}
+            description: "fixture"
+            metadata:
+              version: "{version}"
+              last_updated: "2026-04-22"
+              status: active
+              data_access_level: raw
+              task_type: open-ended
+            ---
+
+            # {name}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_claude_md(
+    root: Path,
+    suite_version: str,
+    table_rows: list[tuple[str, str]],
+) -> None:
+    claude_dir = root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    rows = "\n".join(
+        f"| `{name}` v{ver} | purpose | modes |" for name, ver in table_rows
+    )
+    text = (
+        "# Academic Research Skills\n"
+        "\n"
+        "## Skills Overview\n"
+        "\n"
+        "| Skill | Purpose | Key Modes |\n"
+        "|-------|---------|-----------|\n"
+        f"{rows}\n"
+        "\n"
+        "## Version Info\n"
+        f"- **Suite version**: {suite_version} (per CHANGELOG.md)\n"
+    )
+    (claude_dir / "CLAUDE.md").write_text(text, encoding="utf-8")
+
+
+def _write_changelog(root: Path, latest_version: str) -> None:
+    (root / "CHANGELOG.md").write_text(
+        textwrap.dedent(
+            f"""\
+            # Changelog
+
+            ## [{latest_version}] - 2026-04-22
+
+            ### Added
+            - fixture entry
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_aligned_fixture(root: Path) -> None:
+    """Everything lines up — baseline for PASS cases and drift mutations."""
+    skills = [
+        ("deep-research", "2.9.0"),
+        ("academic-paper", "3.1.0"),
+        ("academic-paper-reviewer", "1.8.1"),
+        ("academic-pipeline", "3.5.0"),
+    ]
+    for name, ver in skills:
+        _write_skill(root, name, ver)
+    _write_claude_md(root, suite_version="3.5.0", table_rows=skills)
+    _write_changelog(root, latest_version="3.5.0")
+
+
+class TestVersionConsistency(unittest.TestCase):
+    def test_all_aligned_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+
+    def test_table_version_drift_fails(self) -> None:
+        """Table lists deep-research v2.9.0 but SKILL.md says 2.8.0 — must fail."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            _write_skill(root, "deep-research", "2.8.0")
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("deep-research", result.stdout)
+            self.assertIn("2.9.0", result.stdout)
+            self.assertIn("2.8.0", result.stdout)
+
+    def test_suite_version_vs_changelog_drift_fails(self) -> None:
+        """CLAUDE.md suite version != CHANGELOG latest entry — must fail."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            _write_changelog(root, latest_version="3.4.0")
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("3.5.0", result.stdout)
+            self.assertIn("3.4.0", result.stdout)
+            self.assertIn("CHANGELOG", result.stdout)
+
+    def test_pipeline_version_vs_suite_drift_fails(self) -> None:
+        """academic-pipeline version in table must equal suite version."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skills = [
+                ("deep-research", "2.9.0"),
+                ("academic-paper", "3.1.0"),
+                ("academic-paper-reviewer", "1.8.1"),
+                ("academic-pipeline", "3.4.0"),
+            ]
+            for name, ver in skills:
+                _write_skill(root, name, ver)
+            _write_claude_md(root, suite_version="3.5.0", table_rows=skills)
+            _write_changelog(root, latest_version="3.5.0")
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("academic-pipeline", result.stdout)
+
+    def test_skill_missing_frontmatter_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            (root / "deep-research" / "SKILL.md").write_text(
+                "# deep-research\n\nNo frontmatter here.\n",
+                encoding="utf-8",
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("deep-research", result.stdout)
+
+    def test_skill_listed_in_table_but_missing_on_disk_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            import shutil
+            shutil.rmtree(root / "academic-paper-reviewer")
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("academic-paper-reviewer", result.stdout)
+
+    def test_missing_suite_version_in_claude_md_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            (root / ".claude" / "CLAUDE.md").write_text(
+                textwrap.dedent(
+                    """\
+                    # Academic Research Skills
+
+                    ## Skills Overview
+
+                    | Skill | Purpose | Key Modes |
+                    |-------|---------|-----------|
+                    | `deep-research` v2.9.0 | x | y |
+                    | `academic-paper` v3.1.0 | x | y |
+                    | `academic-paper-reviewer` v1.8.1 | x | y |
+                    | `academic-pipeline` v3.5.0 | x | y |
+
+                    ## Version Info
+                    - No suite version line here.
+                    """
+                ),
+                encoding="utf-8",
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Suite version", result.stdout)
+
+
+class TestRealRepo(unittest.TestCase):
+    """Smoke test: the script must pass against the real repo right now."""
+
+    def test_real_repo_passes(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        result = run_script(SCRIPT, "--path", str(repo_root))
+        self.assertEqual(
+            result.returncode, 0,
+            msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Enforces version-label alignment across `.claude/CLAUDE.md`, each `SKILL.md` frontmatter, and `CHANGELOG.md` — the drift that PR #28 had to sweep manually
- New `scripts/check_version_consistency.py` + 8 unit tests, wired into `spec-consistency.yml`
- Real repo passes on the current `main` (no label changes needed — just puts a guard on what's already aligned)

## Invariants enforced

1. Each skill's version in the `.claude/CLAUDE.md` Skills Overview table equals the corresponding `{skill}/SKILL.md` `metadata.version`
2. `.claude/CLAUDE.md` `**Suite version**: X.Y.Z` equals the most recent `## [X.Y.Z]` entry in `CHANGELOG.md`
3. `academic-pipeline` version in the table equals the suite version (pipeline = orchestrator, tracks the suite release)

## Regression coverage

- Aligned fixture → PASS
- Per-skill table drift → FAIL, reports both versions
- Suite-vs-CHANGELOG drift → FAIL
- Pipeline-vs-suite drift → FAIL
- Skill missing frontmatter → FAIL
- Skill listed but dir missing → FAIL
- `**Suite version**` line missing → FAIL

## Motivation

v3.4 / v3.5 releases repeatedly shipped with version labels out of sync (fast-follow PR #28 cleaned one such sweep). Adding this as a hard CI gate prevents the next drift from needing a human sweep.

Part of ARS v3.6 CI-guard work item (E in execution order).

## Test plan

- [x] `python3 scripts/check_version_consistency.py` passes on real repo
- [x] `python3 -m unittest scripts.test_check_version_consistency` → 8/8 OK locally
- [x] Full `scripts/` test suite still 74/74 OK
- [x] `python3 scripts/check_spec_consistency.py` still passes (no overlap broken)
- [ ] CI on this PR reflects the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)