### PR TITLE
chore(tests): simplify test_check_version_consistency per review

### DIFF
--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -1,4 +1,4 @@
-"""Unit tests for check_version_consistency.py (ARS v3.6 CI guard E)."""
+"""Unit tests for check_version_consistency.py."""
 from __future__ import annotations
 
 import subprocess
@@ -134,16 +134,21 @@ class TestVersionConsistency(unittest.TestCase):
         """academic-pipeline version in table must equal suite version."""
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            skills = [
-                ("deep-research", "2.9.0"),
-                ("academic-paper", "3.1.0"),
-                ("academic-paper-reviewer", "1.8.1"),
-                ("academic-pipeline", "3.4.0"),
-            ]
-            for name, ver in skills:
-                _write_skill(root, name, ver)
-            _write_claude_md(root, suite_version="3.5.0", table_rows=skills)
-            _write_changelog(root, latest_version="3.5.0")
+            _write_aligned_fixture(root)
+            # Drop pipeline to 3.4.0 in both table and SKILL.md, keep suite at 3.5.0.
+            # This isolates invariant 3 (pipeline tracks suite) from invariant 1
+            # (SKILL.md == table).
+            _write_skill(root, "academic-pipeline", "3.4.0")
+            _write_claude_md(
+                root,
+                suite_version="3.5.0",
+                table_rows=[
+                    ("deep-research", "2.9.0"),
+                    ("academic-paper", "3.1.0"),
+                    ("academic-paper-reviewer", "1.8.1"),
+                    ("academic-pipeline", "3.4.0"),
+                ],
+            )
             result = _run(root)
             self.assertEqual(result.returncode, 1)
             self.assertIn("academic-pipeline", result.stdout)
@@ -197,18 +202,6 @@ class TestVersionConsistency(unittest.TestCase):
             result = _run(root)
             self.assertEqual(result.returncode, 1)
             self.assertIn("Suite version", result.stdout)
-
-
-class TestRealRepo(unittest.TestCase):
-    """Smoke test: the script must pass against the real repo right now."""
-
-    def test_real_repo_passes(self) -> None:
-        repo_root = Path(__file__).resolve().parents[1]
-        result = run_script(SCRIPT, "--path", str(repo_root))
-        self.assertEqual(
-            result.returncode, 0,
-            msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to PR #33. Three cleanups surfaced by post-merge review.

## Changes

- **Drop `TestRealRepo` smoke class**: `spec-consistency.yml` already runs the standalone `check_version_consistency.py` step immediately before the unit-test step. `TestRealRepo.test_real_repo_passes` was re-running the same check as a subprocess inside unittest — same files, same outcome, zero additional signal.
- **Simplify `test_pipeline_version_vs_suite_drift_fails`**: now starts from `_write_aligned_fixture()` and overrides only the pipeline version. Keeps the test scoped to invariant 3 (pipeline tracks suite) without duplicating the four-skill setup.
- **Clean module docstring**: remove `(ARS v3.6 CI guard E)` task-tracker reference.

## Test plan

- [x] `PYTHONPATH=. python3 -m unittest scripts.test_check_version_consistency` → 7/7 OK
- [x] `python3 scripts/check_version_consistency.py` → passes on real repo
- [x] Full `scripts/` test suite → 73/73 OK (was 74/74, now one fewer because TestRealRepo removed — the coverage it provided stays in CI via the standalone step)
- [ ] CI on this PR mirrors the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)