### PR TITLE
chore(prompts): harness retirement pass — negative → positive framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Harness retirement pass (Task A per `project_ars_v3.6_execution_order.md`): rewrote 7 negative-framing blocks to positive / split form across 7 files. No behaviour change, no schema change — voice alignment with v3.4/v3.5-era agents. Audit report: `/tmp/harness-retirement-ars-2026-04-22.md` (findings F-001 through F-007).
+  - `academic-paper/agents/socratic_mentor_agent.md` — Core Principles items 1, 6 (F-001)
+  - `deep-research/agents/socratic_mentor_agent.md` — Quality Standards items 2, 3, 4 (F-002)
+  - `academic-paper/agents/draft_writer_agent.md` — quick style check, paragraph variation, colloquialisms, transition-word usage (F-003, 4 spots)
+  - `academic-pipeline/agents/pipeline_orchestrator_agent.md` — **split** "Prohibited Actions" (9 items, all negative) into "Scope (delegate, don't perform)" (items 1-6, positive delegation) + "Hard boundaries (never violate)" (items 7-9, kept negative as intentional safety directives for silent-failure modes: fabrication, skipped checkpoints, skipped integrity gates) (F-004)
+  - `academic-pipeline/agents/collaboration_depth_agent.md` — Agent-specific boundaries 4 bullets (F-005)
+  - `academic-pipeline/SKILL.md` — single-line UX guidance (F-006)
+  - `academic-paper/references/academic_writing_style.md` — §4 Formality 3 items (F-007, discovered during apply)
+
+### Notes
+- Version labels unchanged this round; retirement is wording-only and will be folded into the next minor release. Audit itself referenced upstream as v3.6.3 retirement checklist (shared skill, not a suite release).
+- Kept-as-debt: ~50 anti-hallucination references across `deep-research/`, `academic-paper/references/anti_leakage_protocol.md`, `academic-pipeline/references/ai_research_failure_modes.md`, `shared/agents/compliance_agent.md`, `shared/compliance_checkpoint_protocol.md` — load-bearing integrity architecture (Lu 2026 7-mode; S2 API Tier-0; `[MATERIAL GAP]` taxonomy). Not retired under the iron rule clause for silent-failure domains.
+- All 73 script-suite tests green after the rewrites (version_consistency, spec_consistency, collaboration_depth_rubric, prisma_trAIce_freshness, compliance_report, benchmark_report, data_access_level, repro_lock, task_type, validate_compliance_fixtures).
+
 ## [3.5.0] - 2026-04-21
 
 ### Added

--- a/academic-paper/agents/draft_writer_agent.md
+++ b/academic-paper/agents/draft_writer_agent.md
@@ -41,7 +41,7 @@ For each section in the outline:
 4. **Write transitions** connecting to the next section
 5. **Check word count** against allocation
 6. **Self-review** for clarity, logic, and completeness
-7. **Quick style check** — while writing, avoid AI-typical patterns: no throat-clearing openers, vary sentence lengths, use precise vocabulary. If Style Profile is non-null: verify section voice aligns with profile traits (within discipline constraints per `shared/style_calibration_protocol.md` priority system)
+7. **Quick style check** — while writing, target academic prose: open paragraphs with the actual claim, vary sentence lengths to match argument rhythm, and choose precise vocabulary. `references/writing_quality_check.md` is the style diagnostic after drafting. If Style Profile is non-null: verify section voice aligns with profile traits (within discipline constraints per `shared/style_calibration_protocol.md` priority system)
 
 ### Step 3: Full Draft Assembly
 Combine all sections into a coherent document with:
@@ -55,7 +55,7 @@ Combine all sections into a coherent document with:
   - Check semicolon density (≤2 per 1000 words)
   - Remove all throat-clearing openers
   - Verify sentence length variation (burstiness) — flag 5+ consecutive same-length sentences
-  - Verify paragraph length variation — avoid uniform blocks
+  - Vary paragraph length by function — short paragraphs mark emphasis, longer ones carry argument
   - Check binary contrast usage (≤2 per paper)
   - Fix all violations before handoff to citation_compliance_agent
 
@@ -68,7 +68,7 @@ Reference: `references/academic_writing_style.md`
 - **Active voice** preferred over passive (except when emphasizing the action over the actor)
 - **Hedging language** for uncertain claims: "suggests," "indicates," "may," "appears to"
 - **Strong language** for well-supported claims: "demonstrates," "establishes," "confirms"
-- **No colloquialisms** — avoid casual language, contractions, or slang
+- **Register**: formal academic prose — use full forms ("do not" over "don't") and domain-precise vocabulary
 
 ### Discipline-Specific Adjustments
 
@@ -286,8 +286,8 @@ Decision tree for choosing citation method:
 | Concession | Although, Despite, Notwithstanding | Although, Despite, Even though |
 
 **Usage rules**:
-- Not every paragraph opening requires a transition word (avoid mechanical feel)
-- Do not repeat the same transition word on the same page
+- Let topic sentences carry paragraph-to-paragraph flow; reach for a transition word only when the relationship is non-obvious
+- Vary transition word choice within a page; repeating the same one flattens argument rhythm
 - Use complete sentences for inter-section transitions, not single words
 
 ### Word Count Monitoring Mechanism

--- a/academic-paper/agents/socratic_mentor_agent.md
+++ b/academic-paper/agents/socratic_mentor_agent.md
@@ -16,12 +16,12 @@ You are the Socratic Mentor Agent for academic paper writing. You act as a senio
 
 ## Core Principles
 
-1. **Do not write directly** — guide users to think clearly through questions
+1. **Guide, don't draft** — help users think clearly through questions; the writing is theirs
 2. **Chapter-specific questioning** — different questioning strategies for each paper chapter
 3. **5 mandatory questions mechanism** — users must answer 5 core questions before each chapter begins
 4. **Writing direction hints** — when users have thought things through, provide "here's how you could start..." guidance
 5. **INSIGHT extraction** — extract key insights after each dialogue round, accumulate into INSIGHT Collection
-6. **Patient probing** — at least 2 rounds of dialogue per chapter, do not rush to advance
+6. **Patient probing** — at least 2 rounds of dialogue per chapter; let understanding settle before advancing
 
 ## SCR Protocol (Internal Mechanism — Never Mention "SCR" to Users)
 

--- a/academic-paper/references/academic_writing_style.md
+++ b/academic-paper/references/academic_writing_style.md
@@ -20,9 +20,9 @@ Used by `draft_writer_agent` and `peer_reviewer_agent`.
 - Acknowledge limitations and alternative interpretations
 
 ### 4. Formality
-- No contractions (don't → do not)
-- No colloquialisms or slang
-- No first person unless discipline conventions allow it
+- Use full forms ("do not" over "don't")
+- Use formal academic vocabulary; reserve colloquialisms and slang for informal writing
+- Use third person unless discipline conventions allow first person
 
 ## Register Adjustment by Discipline
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -74,7 +74,7 @@ I received reviewer comments, help me revise
 ### Trigger Exclusions
 
 - If the user only needs a single function (just search materials, just check citations), no pipeline is needed — directly trigger the corresponding skill
-- If the user is already using a specific mode of a skill, do not force them into the pipeline
+- If the user is already using a specific mode of a skill, respect that entry point; the pipeline is opt-in
 - The pipeline is optional, not mandatory
 
 ---

--- a/academic-pipeline/agents/collaboration_depth_agent.md
+++ b/academic-pipeline/agents/collaboration_depth_agent.md
@@ -149,10 +149,10 @@ Note: divergence > 2 points; no silent averaging performed. Original evidence:
 
 These are scope clarifications beyond the rubric's discipline (the rubric owns scoring rules; these are about what this agent refuses to do in the pipeline):
 
-- Do not score the paper, the research, or the AI's work — you score the collaboration pattern.
-- Do not accumulate a cross-session leaderboard. The rubric is per-pipeline only; no global scoreboard is produced.
-- Do not speak in the first person about the user's character or ability. Describe the observable pattern, not the person.
-- Next-stage suggestions must be phrased as options ("you could try X"), never as duties ("you should X") — the rubric is descriptive.
+- **Scope**: score the collaboration *pattern*; the paper, research, and AI output belong to other agents.
+- **Session-bounded**: the rubric is per-pipeline; produce no cross-session leaderboard or global scoreboard.
+- **Describe, don't judge**: speak about the observable pattern, not the person's character or ability.
+- **Offer, don't prescribe**: phrase next-stage suggestions as options ("you could try X") rather than duties ("you should X"). The rubric is descriptive.
 
 ---
 

--- a/academic-pipeline/agents/pipeline_orchestrator_agent.md
+++ b/academic-pipeline/agents/pipeline_orchestrator_agent.md
@@ -322,17 +322,20 @@ The cost is multiplicative: a 10-stage pipeline with cross-model enabled produce
 
 ---
 
-## Prohibited Actions (Strictly Forbidden)
+## Scope (delegate, don't perform)
 
-1. **Do not write papers** — Paper writing is handled by academic-paper
-2. **Do not conduct research** — Research work is handled by deep-research
-3. **Do not review papers** — Review is handled by academic-paper-reviewer
-4. **Do not verify citations** — Verification is handled by integrity_verification_agent
-5. **Do not make decisions for the user** — Only provide suggestions and options; decision authority belongs to the user
-6. **Do not modify skill outputs** — Each skill's quality is guaranteed by that skill itself
-7. **Do not fabricate materials** — If a stage's output does not exist, do not pretend it does
-8. **Do not skip checkpoints** — User confirmation is required after each stage completion
-9. **Do not skip integrity checks** — Stage 2.5 and 4.5 are mandatory
+1. **Paper writing** — delegate to `academic-paper`
+2. **Research** — delegate to `deep-research`
+3. **Review** — delegate to `academic-paper-reviewer`
+4. **Citation verification** — delegate to `integrity_verification_agent`
+5. **Decisions** — offer suggestions and options; final decisions are the user's
+6. **Skill outputs** — treat as authoritative; quality is owned by each skill
+
+## Hard boundaries (never violate)
+
+7. **Do not fabricate materials** — if a stage's output does not exist, surface the gap; do not invent
+8. **Do not skip checkpoints** — explicit user confirmation is required after each stage
+9. **Do not skip integrity checks** — Stage 2.5 and 4.5 are mandatory, no override
 
 ---
 

--- a/deep-research/agents/socratic_mentor_agent.md
+++ b/deep-research/agents/socratic_mentor_agent.md
@@ -413,9 +413,9 @@ The check is invisible to the user because making it visible would change the di
 ## Quality Standards
 
 1. **Every response must contain at least one question** — a response without a question violates the Socratic principle
-2. **Responses must not exceed 400 words** — exceeding that means lecturing, not guiding
-3. **Do not evaluate whether the user's ideas are good or bad** — only ask "why" and "then what"
-4. **Do not list literature references** — may hint at directions, but specific references are left to bibliography_agent
+2. **Keep responses under 400 words** — past that, you're lecturing; stay terse and leave thinking space
+3. **Withhold evaluation** — ask "why" and "then what" instead of judging ideas as good or bad
+4. **Hint at directions without listing references** — specific citations are bibliography_agent's job
 5. **INSIGHT tagging must be precise** — not everything the user says is an INSIGHT; only tag mature ideas
 6. **Maintain curiosity** — even if you disagree with the user's direction, genuinely ask "why do you think that"
 7. **Know when to end** — in **goal-oriented mode**, once the dialogue converges, end it. In **exploratory mode**, the user decides when to end — do not force convergence


### PR DESCRIPTION
## Summary

- First application of the cross-repo **harness-retirement** shared skill (Task A per `花花 memory: project_ars_v3.6_execution_order.md`, v3.6.3 retirement checklist).
- 7 negative-framing blocks rewritten to positive / split form across 7 prompt files. **Wording-only** — no behaviour change, no schema change, no version bump.
- F-004 (pipeline_orchestrator) uses a **split** approach: 6 scope items turned positive, 3 hard safety boundaries kept negative — see rationale below.

## Scope

Audit report: `/tmp/harness-retirement-ars-2026-04-22.md` (local; can be promoted to `audits/` if desired).

| Finding | File | Change |
|---|---|---|
| F-001 | `academic-paper/agents/socratic_mentor_agent.md` | Core Principles items 1, 6 |
| F-002 | `deep-research/agents/socratic_mentor_agent.md` | Quality Standards items 2, 3, 4 |
| F-003 | `academic-paper/agents/draft_writer_agent.md` | 4 style-guidance spots (L44, L58, L71, L289) |
| F-004 | `academic-pipeline/agents/pipeline_orchestrator_agent.md` | **Split** ""Prohibited Actions"" (9 items, all negative) into two sections |
| F-005 | `academic-pipeline/agents/collaboration_depth_agent.md` | Agent-specific boundaries 4 bullets |
| F-006 | `academic-pipeline/SKILL.md` | Single-line UX guidance |
| F-007 | `academic-paper/references/academic_writing_style.md` | §4 Formality 3 items (discovered during apply) |

## F-004 split rationale

Original: 9 consecutive ""Do not …"" items. Items 1-6 are scope separation (""do not write papers"" etc.) where positive delegation voice (""delegate to academic-paper"") is clearer. Items 7-9 are hard safety boundaries — fabrication, skipped checkpoints, skipped integrity gates — where the failure mode is **silent** and closed-form negative wording is load-bearing per `debt_patterns.md` §6 ""do not retire when"" clause.

New structure:
- **## Scope (delegate, don't perform)** — items 1-6, positive voice
- **## Hard boundaries (never violate)** — items 7-9, kept negative, annotated

## Kept as debt (iron rule filtered out)

~50 anti-hallucination references across `deep-research/`, `academic-paper/references/anti_leakage_protocol.md`, `academic-pipeline/references/ai_research_failure_modes.md`, `shared/agents/compliance_agent.md`, `shared/compliance_checkpoint_protocol.md`. These are **architectural integrity design** (Lu 2026 Nature 7-mode checklist, S2 API Tier-0 verification, `[MATERIAL GAP]` taxonomy, cross-model verification), not prompt scaffolds on top of a weak model. Academic-writing is a silent-failure domain per `debt_patterns.md` §2. Do not mistake the feature for debt.

Cat 1 (model IDs) and Cat 7 (magic words: ultrathink / think hard / etc.) scanned cleanly — PR #22 (2026-04-18 Opus 4.7 alignment) pre-cleaned these.

## Version strategy

No version bump this round. Wording-only retirement is folded into the next minor release — avoids a 30+ touchpoint drift sweep (README badges, `releases/tag/vX.Y.Z` links, `scripts/check_spec_consistency.py` hardcoded pins, `MODE_REGISTRY.md`, `docs/ARCHITECTURE.md`). CHANGELOG has an `[Unreleased]` entry.

The retirement audit itself is labelled v3.6.3 in the ARS roadmap as a **process milestone** (shared skill shipped), distinct from a suite release.

## Test plan

- [x] `python3 scripts/check_version_consistency.py` — passes
- [x] `python3 scripts/check_spec_consistency.py` — passes
- [x] `python3 -m scripts.test_check_version_consistency` — 7/7
- [x] `python3 -m scripts.test_check_collaboration_depth_rubric` — 12/12
- [x] `python3 -m scripts.test_check_prisma_trAIce_freshness` — 5/5
- [x] `python3 -m scripts.test_check_compliance_report` — 21/21
- [x] `python3 -m scripts.test_check_benchmark_report` — 7/7
- [x] `python3 -m scripts.test_check_data_access_level` — 6/6
- [x] `python3 -m scripts.test_check_repro_lock` — 6/6
- [x] `python3 -m scripts.test_check_task_type` — 6/6
- [x] `python3 -m scripts.test_validate_compliance_fixtures` — 3/3
- [x] Cross-reference scan: `grep ""Prohibited Actions""` — zero external references to the renamed heading (F-004 split does not break any link)

## Next audit

After v3.6.x lands, or when next Opus version ships. Re-audit scope: same file set + any new agent files. Carry-forward: if `anti_leakage_protocol.md:50` is refactored for other reasons, re-evaluate its wording (kept-as-debt marginal case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)