### PR TITLE
feat(v3.6.5): release sweep — literature_corpus[] consumer integration (PR-B)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,7 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 - **Three reference Python adapters**: `scripts/adapters/{folder_scan,zotero,obsidian}.py` with tests and fixtures. Starting points only; users are expected to write their own adapters for non-reference corpus sources.
 - **Rejection log contract**: `shared/contracts/passport/rejection_log.schema.json`. Always emitted, empty when no rejections; closed enum of categorical reason values.
 - **CI lint + pytest job**: `scripts/check_literature_corpus_schema.py` validates schemas + examples; `scripts/sync_adapter_docs.py --check` prevents schema→docs drift; new `pytest.yml` workflow runs `scripts/adapters/tests/` on path-filtered triggers.
-- **Input-port-only at v3.6.4**: v3.6.4 shipped the schema and adapter contract without consumer integration. `bibliography_agent` and `literature_strategist_agent` were wired in v3.6.5 (see above).
+- **Input-port-only at v3.6.4**: v3.6.4 shipped the schema and adapter contract; consumer integration landed in v3.6.5.
 
 ## v3.6.3 Key Additions
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,10 +6,19 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 
 | Skill | Purpose | Key Modes |
 |-------|---------|-----------|
-| `deep-research` v2.9.1 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
-| `academic-paper` v3.1.0 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
+| `deep-research` v2.9.2 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
+| `academic-paper` v3.1.1 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.9.0 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.6.4 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.6.5 | Full pipeline orchestrator | (coordinates all above) |
+
+## v3.6.5 Key Additions
+
+- **Material Passport `literature_corpus[]` consumer integration in Phase 1**: `deep-research/agents/bibliography_agent.md` and `academic-paper/agents/literature_strategist_agent.md` now read `literature_corpus[]` via the **corpus-first, search-fills-gap** flow when the passport carries a non-empty corpus. Both consumers follow the same five-step shared flow (Step 0 presence detection → Step 1 pre-screen → Step 2 search-fills-gap → Step 3 merge → Step 4 emit Search Strategy report) and the same four Iron Rules (Same criteria / No silent skip / No corpus mutation / Graceful fallback on parse failure).
+- **PRE-SCREENED reproducibility block**: Search Strategy reports gain a PRE-SCREENED FROM USER CORPUS block enumerating included / excluded / skipped corpus entries, with F3 zero-hit note and F4a–F4f provenance reporting that compose around partial declaration of `obtained_via` / `obtained_at`. `final_included = pre_screened_included[] ∪ external_included[]` stays neutral — no provenance tags on bibliography entries or literature matrix rows.
+- **Consumer protocol reference**: `academic-pipeline/references/literature_corpus_consumers.md` carries the canonical PRE-SCREENED template, BAD/GOOD examples, four Iron Rules, and per-consumer reading instructions. Both consumer agents backpoint to this reference.
+- **CI lint** `scripts/check_corpus_consumer_protocol.py` enforcing nine protocol invariants with manifest-driven consumer list (`scripts/corpus_consumer_manifest.json`).
+- **Schema 9 caveat retired**: `shared/handoff_schemas.md` retired the v3.6.4 "Consumer-side integration deferred to v3.6.5+" caveat; replaced with backpointer to the consumer protocol.
+- **No schema change**: existing user adapters work without modification. Consumer integration is presence-based: auto-engages when passport carries a non-empty `literature_corpus[]` and parses cleanly. Parse failures fall back to external-DB-only flow with a `[CORPUS PARSE FAILURE]` surface. No new env flag introduced. `citation_compliance_agent` corpus integration deferred to v3.6.6+.
 
 ## v3.6.4 Key Additions
 
@@ -18,7 +27,7 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 - **Three reference Python adapters**: `scripts/adapters/{folder_scan,zotero,obsidian}.py` with tests and fixtures. Starting points only; users are expected to write their own adapters for non-reference corpus sources.
 - **Rejection log contract**: `shared/contracts/passport/rejection_log.schema.json`. Always emitted, empty when no rejections; closed enum of categorical reason values.
 - **CI lint + pytest job**: `scripts/check_literature_corpus_schema.py` validates schemas + examples; `scripts/sync_adapter_docs.py --check` prevents schema→docs drift; new `pytest.yml` workflow runs `scripts/adapters/tests/` on path-filtered triggers.
-- **Not yet shipped**: no ARS agent reads `literature_corpus[]` yet. Consumer-side integration deferred to v3.6.5+. v3.6.4 defines the input port only.
+- **Input-port-only at v3.6.4**: v3.6.4 shipped the schema and adapter contract without consumer integration. `bibliography_agent` and `literature_strategist_agent` were wired in v3.6.5 (see above).
 
 ## v3.6.3 Key Additions
 
@@ -115,7 +124,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.6.4 (per CHANGELOG.md)
-- **Last Updated**: 2026-04-25
+- **Suite version**: 3.6.5 (per CHANGELOG.md)
+- **Last Updated**: 2026-04-27
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.6.5] - 2026-04-27
+
+### Added
+
+- Material Passport `literature_corpus[]` consumer integration in Phase 1
+  (deep-research/bibliography_agent + academic-paper/literature_strategist_agent).
+  Corpus-first, search-fills-gap flow with PRE-SCREENED reproducibility block.
+  Reproducibility for systematic-review use is preserved through Iron Rule 1
+  same-criteria parity plus Step 2 case C (standard external search runs even
+  when corpus fully covers RQ subtopics).
+- `academic-pipeline/references/literature_corpus_consumers.md` — consumer protocol
+  reference with four Iron Rules (Same criteria / No silent skip / No corpus mutation /
+  Graceful fallback on parse failure) and per-consumer reading instructions.
+- `scripts/check_corpus_consumer_protocol.py` — CI lint enforcing nine protocol invariants
+  with manifest-driven consumer list and stub-block opt-out.
+- `scripts/corpus_consumer_manifest.json` — supported-consumer manifest.
+
+### Changed
+
+- `shared/handoff_schemas.md` Schema 9 — retired the v3.6.4 "Consumer-side integration
+  deferred to v3.6.5+" caveat; replaced with backpointer to the consumer protocol.
+- `deep-research/SKILL.md` 2.9.1 → 2.9.2 — bibliography_agent corpus-first flow (also
+  syncs Version Info footer that lagged at 2.9.0).
+- `academic-paper/SKILL.md` 3.1.0 → 3.1.1 — literature_strategist_agent corpus-first flow.
+- `academic-pipeline/SKILL.md` 3.6.4 → 3.6.5 — suite version invariant.
+- `.claude/CLAUDE.md`, `MODE_REGISTRY.md`, `README.md`, `README.zh-TW.md`,
+  `scripts/check_spec_consistency.py` updated for the version bump (suite version,
+  badge, tag, changelog heading).
+
+### Notes
+
+- Consumer integration is presence-based: auto-engages when passport carries a
+  non-empty `literature_corpus[]` and parses cleanly. Parse failures fall back
+  to external-DB-only flow with a `[CORPUS PARSE FAILURE]` surface. No new env
+  flag introduced.
+- Schema is unchanged from v3.6.4. Existing user adapters work without modification.
+- `citation_compliance_agent` corpus integration deferred to v3.6.6+.
+- `source_pointer` is not dereferenced by consumers; URI resolution remains a future
+  `source_verification_agent` concern.
+
 ## [3.6.4] - 2026-04-25
 
 ### Added

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.6.4 (2026-04-25)
+Last updated: v3.6.5 (2026-04-27)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.6.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.4)
+[![Version](https://img.shields.io/badge/version-v3.6.5-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.5)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -289,6 +289,16 @@ https://github.com/Imbad0202/academic-research-skills
 
 ## Changelog
 
+### v3.6.5 (2026-04-27) — Material Passport `literature_corpus[]` Consumer Integration
+
+- **Two Phase 1 literature consumers** wired: `deep-research/agents/bibliography_agent.md` and `academic-paper/agents/literature_strategist_agent.md`. Both follow the same five-step **corpus-first, search-fills-gap** flow when the passport carries a non-empty `literature_corpus[]` and the same four Iron Rules (Same criteria / No silent skip / No corpus mutation / Graceful fallback on parse failure).
+- **PRE-SCREENED reproducibility block** in Search Strategy reports: enumerates included / excluded / skipped corpus entries, with F3 zero-hit note and F4a–F4f provenance reporting that compose around partial declaration of `obtained_via` / `obtained_at`. `final_included = pre_screened_included[] ∪ external_included[]` stays neutral — no provenance tags on bibliography entries or literature matrix rows.
+- **Consumer protocol reference** at `academic-pipeline/references/literature_corpus_consumers.md` with the canonical PRE-SCREENED template, BAD/GOOD examples, four Iron Rules, and per-consumer reading instructions.
+- **CI lint** `scripts/check_corpus_consumer_protocol.py` enforcing nine protocol invariants with manifest-driven consumer list (`scripts/corpus_consumer_manifest.json`).
+- **Schema 9 caveat retired**: `shared/handoff_schemas.md` retired the v3.6.4 "Consumer-side integration deferred to v3.6.5+" caveat; replaced with backpointer to the consumer protocol.
+- Presence-based, no schema change, no new env flag. Parse failures fall back to external-DB-only flow with a `[CORPUS PARSE FAILURE]` surface. `citation_compliance_agent` corpus integration deferred to v3.6.6+.
+- No breaking changes. Existing user adapters work without modification.
+
 ### v3.6.4 (2026-04-25) — Material Passport `literature_corpus[]` Input Port
 
 - **`literature_corpus[]` field** added to Schema 9 as an optional input port for user-owned literature. Each entry conforms to `shared/contracts/passport/literature_corpus_entry.schema.json` (CSL-JSON authors, year, title, source_pointer + private optional `abstract` / `user_notes`).
@@ -296,7 +306,7 @@ https://github.com/Imbad0202/academic-research-skills
 - **Three reference Python adapters** under `scripts/adapters/`: `folder_scan.py` (filesystem of PDFs), `zotero.py` (Better BibTeX JSON export), `obsidian.py` (vault frontmatter). Starting points only; users are expected to write their own adapters for non-reference sources.
 - **Rejection log contract** at `shared/contracts/passport/rejection_log.schema.json` with closed enum of categorical reason values; always emitted (empty when no rejections).
 - **CI gates**: `scripts/check_literature_corpus_schema.py` validates schemas + adapter examples; `scripts/sync_adapter_docs.py --check` prevents schema→docs drift; new `pytest.yml` workflow runs `scripts/adapters/tests/` on path-filtered triggers.
-- **Not yet shipped**: no ARS agent reads `literature_corpus[]` yet. Consumer-side integration is deferred to v3.6.5+. v3.6.4 defines the input port only.
+- **Input-port-only at v3.6.4**: v3.6.4 shipped the schema and adapter contract without consumer integration. `bibliography_agent` and `literature_strategist_agent` were wired in v3.6.5.
 - No breaking changes.
 
 ### v3.6.3 (2026-04-23) — Opt-in Passport Reset Boundary

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.6.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.4)
+[![Version](https://img.shields.io/badge/version-v3.6.5-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.5)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -270,6 +270,16 @@ https://github.com/Imbad0202/academic-research-skills
 
 ## 更新紀錄
 
+### v3.6.5（2026-04-27）— Material Passport `literature_corpus[]` Consumer 整合
+
+- **Phase 1 兩個文獻 consumer** 接上：`deep-research/agents/bibliography_agent.md` 與 `academic-paper/agents/literature_strategist_agent.md`。當 passport 帶有非空 `literature_corpus[]` 時，兩者都走相同的五步 **corpus-first、search-fills-gap** 流程，並遵守相同的四條 Iron Rule（Same criteria / No silent skip / No corpus mutation / Graceful fallback on parse failure）。
+- **PRE-SCREENED 可重現區塊** 進 Search Strategy 報告：列出已納入／排除／略過的 corpus entry，附 F3 zero-hit 註解與 F4a–F4f provenance 報告（針對 `obtained_via` / `obtained_at` 部分宣告情境）。`final_included = pre_screened_included[] ∪ external_included[]` 維持 neutral — bibliography entry 與 literature matrix row 不掛 provenance 標籤。
+- **Consumer 協定參考文件** 在 `academic-pipeline/references/literature_corpus_consumers.md`，包含 PRE-SCREENED 模板、BAD/GOOD 範例、四條 Iron Rule 與 per-consumer 讀取指示。
+- **CI lint** `scripts/check_corpus_consumer_protocol.py` 透過 manifest 驅動的 consumer 清單（`scripts/corpus_consumer_manifest.json`）強制九條協定不變式。
+- **Schema 9 caveat 退役**：`shared/handoff_schemas.md` 移除 v3.6.4「Consumer-side integration deferred to v3.6.5+」一行，改成指向 consumer 協定的 backpointer。
+- 採 presence-based 啟動，不變更 schema、不引入新 env flag。Parse 失敗 fallback 到 external-DB-only flow，並 surface `[CORPUS PARSE FAILURE]`。`citation_compliance_agent` 的 corpus 整合延到 v3.6.6+。
+- 無破壞性變更，既有使用者 adapter 不需修改。
+
 ### v3.6.4（2026-04-25）— Material Passport `literature_corpus[]` 輸入埠
 
 - **Schema 9 新增 `literature_corpus[]`** 選填欄位作為使用者文獻的輸入埠。每筆 entry 符合 `shared/contracts/passport/literature_corpus_entry.schema.json`（CSL-JSON authors / year / title / source_pointer，加上 PRIVATE 選填的 `abstract` / `user_notes`）。
@@ -277,7 +287,7 @@ https://github.com/Imbad0202/academic-research-skills
 - **三個 reference Python adapter** 在 `scripts/adapters/`：`folder_scan.py`（檔案系統的 PDF 資料夾）、`zotero.py`（Better BibTeX JSON export）、`obsidian.py`（vault frontmatter）。僅供起點參考；非 reference source 預期使用者自行實作 adapter。
 - **Rejection log 契約** 在 `shared/contracts/passport/rejection_log.schema.json`，採用封閉 enum 的 categorical reason 值；永遠輸出（無 rejection 時為空）。
 - **CI 把關**：`scripts/check_literature_corpus_schema.py` 驗 schemas + adapter examples；`scripts/sync_adapter_docs.py --check` 防 schema→docs drift；新 `pytest.yml` workflow 在 path-filtered 觸發跑 `scripts/adapters/tests/`。
-- **尚未推進的部分**：v3.6.4 還沒有任何 ARS agent 讀 `literature_corpus[]`。Consumer-side 整合延到 v3.6.5+，v3.6.4 只定義輸入埠。
+- **僅輸入埠**：v3.6.4 只定義 schema 與 adapter 契約，consumer 整合到 v3.6.5 才接上 `bibliography_agent` 與 `literature_strategist_agent`。
 - 無破壞性變更。
 
 ### v3.6.3（2026-04-23）— 選用式 Passport 重置邊界

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-paper
 description: "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見."
 metadata:
-  version: "3.1.0"
-  last_updated: "2026-04-20"
+  version: "3.1.1"
+  last_updated: "2026-04-27"
   status: active
   data_access_level: redacted
   task_type: open-ended
@@ -318,8 +318,8 @@ academic-paper + academic-paper-reviewer -> Peer review -> revision loop
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.1.0 |
-| Last Updated | 2026-04-20 |
+| Skill Version | 3.1.1 |
+| Last Updated | 2026-04-27 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v1.0+ (upstream), academic-paper-reviewer v1.0+ (downstream) |
 

--- a/academic-paper/agents/literature_strategist_agent.md
+++ b/academic-paper/agents/literature_strategist_agent.md
@@ -101,6 +101,8 @@ Create a Source x Theme matrix:
 | Author3 (Year) | | x | x | main | Mixed | High |
 ```
 
+When the Material Passport carries a non-empty `literature_corpus[]` and the corpus-first flow ran (see §"Reading `literature_corpus[]` from Material Passport"), the matrix is built over `final_included = pre_screened_included[] ∪ external_included[]`. Source rows stay neutral — no provenance column distinguishes corpus from external entries. Provenance accounting lives in the PRE-SCREENED block of the Search Strategy report, not in the matrix.
+
 ## Research Gap Identification
 
 After reviewing the literature, identify:
@@ -111,6 +113,8 @@ After reviewing the literature, identify:
 5. **Geographical gaps** — limited to certain regions
 
 -> These gaps inform the paper's contribution statement.
+
+When the corpus-first flow ran, gap identification operates over the merged `final_included` set. The PRE-SCREENED block's zero-hit note (F3) and `uncovered_topics` from Step 2 case A / B' surface coverage gaps that originated in corpus screening; carry those forward into this section so user-curated coverage limits become explicit research-gap claims rather than silent omissions.
 
 ## Output Format
 
@@ -143,6 +147,132 @@ After reviewing the literature, identify:
 | Methodology | Author3, Author5 |
 | Discussion | Author2, Author7 |
 ```
+
+## Reading `literature_corpus[]` from Material Passport (v3.6.5+)
+
+**Backpointer**: see [`academic-pipeline/references/literature_corpus_consumers.md`](../../academic-pipeline/references/literature_corpus_consumers.md) for the full consumer protocol, BAD/GOOD examples, and shared template.
+
+When the input Material Passport carries a non-empty `literature_corpus[]`, this agent enters the **corpus-first, search-fills-gap** flow. The flow has five steps and four Iron Rules; the PRE-SCREENED block makes corpus utilisation reproducible. The merged `final_included` set feeds the Annotated Bibliography, Literature Matrix, Research Gap Identification, and Recommended Sources by Paper Section sections above without altering their formats.
+
+### The four Iron Rules
+
+1. **Iron Rule 1 — Same criteria.** Apply the same Inclusion / Exclusion criteria (§"Step 4: Inclusion/Exclusion Criteria") to corpus entries and external database results. No exceptions.
+2. **Iron Rule 2 — No silent skip.** Any skipped corpus entry must be recorded in the PRE-SCREENED block's skipped sub-section with a reason. Silently dropping an entry is a prompt-layer violation.
+3. **Iron Rule 3 — No corpus mutation.** Consumer agents never modify, backfill, or derive new content into `literature_corpus[]`. Read only.
+4. **Iron Rule 4 — Graceful fallback on parse failure.** Consumer agents do NOT re-validate schema, do NOT parse JSON Schema at runtime, and do NOT dereference `source_pointer` URIs. When the corpus cannot be parsed, emit `[CORPUS PARSE FAILURE: <cause>]` and fall back to external-DB-only flow.
+
+### Step 0: presence detection and minimal shape
+
+The agent applies a MINIMAL SHAPE CHECK on the corpus before reading further. This is not JSON Schema validation. It checks only what the consumer needs to read each entry safely — the v3.6.4 required fields:
+
+- shape OK ≡ `literature_corpus` is a YAML list AND
+- each entry is a YAML mapping AND
+- each entry has `citation_key` (non-empty string), `title` (non-empty string), `authors` (non-empty list), `year` (numeric-coercible), `source_pointer` (non-empty string).
+
+If the passport lacks `literature_corpus` or it is empty, run the original 4-Layer Progressive Strategy (§"Detailed Execution Algorithm") unchanged. If parse or shape check fails, emit `[CORPUS PARSE FAILURE: <one-line cause>]` and fall back. Otherwise, continue to Step 1.
+
+### Step 1: pre-screen corpus against current RQ
+
+For each entry:
+
+1. Read the five required fields and any optional fields present (`venue`, `doi`, `tags`, `abstract`, `user_notes`).
+2. Apply the current Inclusion / Exclusion criteria (peer-review status, date range, language, relevance) to whatever fields are present. `title` is always available; `abstract` and `tags` participate only when populated. Field absence narrows the screening surface but never causes SKIP.
+3. Classify as INCLUDE / EXCLUDE / SKIP. SKIP fires only when criteria cannot be applied at all (see F1 in spec §4.1).
+
+The Phase A title/abstract screening described in §"Source Screening Protocol" applies to corpus entries identically; the difference is only that the input list is the user's curated corpus rather than the Layer 1-4 hit set.
+
+### Step 2: search-fills-gap (external DB)
+
+```
+derive uncovered_topics = RQ subtopics − {topics covered by pre_screened_included[]}
+user_corpus_only = user explicitly asked "use my corpus only"
+
+case A: uncovered_topics non-empty AND NOT user_corpus_only
+    → external DB search scoped to uncovered_topics, run via 4-Layer Progressive Strategy
+case B: uncovered_topics empty AND user_corpus_only
+    → skip external; surface "external search omitted on user request"
+case B': uncovered_topics non-empty AND user_corpus_only
+    → skip external BUT surface uncovered_topics as known coverage gap
+case C: uncovered_topics empty AND NOT user_corpus_only
+    → standard external search (not scope-limited; newer-work + dedup validation)
+```
+
+The external search executes the 4-Layer Progressive Strategy (Boolean → Citation Chaining → Forward Tracking → Semantic). Iron Rule 1 applies — the same Inclusion/Exclusion criteria screen Layer 1-4 hits as screened corpus entries.
+
+### Step 3: merge
+
+`final_included = pre_screened_included[] ∪ external_included[]`. The annotated bibliography stays neutral — no source-attribution tags on entries, no provenance column in the Literature Matrix.
+
+### Step 4: emit Search Strategy Report
+
+The PRE-SCREENED block goes into the Search Strategy section of the Output Format above, immediately before the existing `Databases` line.
+
+### PRE-SCREENED block template
+
+```markdown
+PRE-SCREENED FROM USER CORPUS:
+- Adapter: <obtained_via enum value | "<unspecified>" | "mixed (...)">
+                                          # e.g., zotero-bbt-export, or "<unspecified>" per F4a,
+                                          # or "<value> (N of M entries declared)" per F4b,
+                                          # or "mixed (zotero-bbt-export: K, ..., undeclared: U)" per F4c
+- Snapshot date: <max(obtained_at)>        # ISO 8601, or "<unspecified>" per F4d,
+                                          # or "<date> (M of N entries declared)" per F4e,
+                                          # or append "(spans <N> days; corpus may not be a single snapshot)" per F4f
+- Total entries scanned: <N>
+- Pre-screening result:
+  - Included: <K> entries
+    citation_keys:
+      - <k1>
+      - <k2>
+  - Excluded by inclusion / exclusion criteria: <E> entries
+    citation_keys:
+      - <e1>
+    (omit this sub-block if 0)
+  - Skipped (criteria cannot be applied): <S> entries
+    citation_keys with reasons:
+      - <key>: <reason>
+    (omit this sub-block if 0)
+- Zero-hit note (emit per F3 only when Included: 0):
+  Zero-hit note (corpus non-empty, 0 included after screening): possible
+  causes are (a) corpus is stale relative to current RQ, (b) RQ has
+  shifted away from what the user originally curated, (c) adapter
+  exported entries unrelated to this RQ.
+- Note: presence in corpus does not imply inclusion;
+  same criteria applied to corpus and external sources.
+```
+
+Lists with more than 50 entries truncate to first 20 + last 5 alphabetically, with an appendix file at `pre_screened_citation_keys_<list>_<timestamp>.txt`. Skipped truncation preserves `<key>: <reason>` in both inline and appendix forms. See spec §3.2 for the full truncation rule.
+
+### Zero-hit and provenance reporting (F3 / F4)
+
+Two reproducibility surfaces sit inside the PRE-SCREENED block. The agent emits each one when the corresponding trigger fires; both are non-blocking.
+
+**Zero-hit note (F3).** When `pre_screened_included[]` is empty after Step 1 — corpus is non-empty but no entry survived screening — the agent emits a zero-hit note inside the PRE-SCREENED block listing the three plausible causes:
+
+```
+- Zero-hit note (corpus non-empty, 0 included after screening): possible causes
+  are (a) corpus is stale relative to current RQ, (b) RQ has shifted away from
+  what the user originally curated, (c) adapter exported entries unrelated to
+  this RQ.
+```
+
+The note appears regardless of which Step 2 case fires next. Step 2 dispatch follows F3 in spec §4.1: NOT user_corpus_only routes through case A or C with external DB; user_corpus_only routes through case B' with no external search but explicit gap surfacing.
+
+**Provenance reporting (F4a–F4f).** `obtained_via` and `obtained_at` are optional in v3.6.4. The PRE-SCREENED block's `Adapter:` and `Snapshot date:` lines must reflect actual coverage, not invent enum values:
+
+| Sub-case | Trigger | `Adapter:` line content |
+|---|---|---|
+| F4a | Zero entries declare `obtained_via` | `Adapter: <unspecified>` + trailing note `Adapter origin not declared; user-written adapter should populate obtained_via per v3.6.4 schema recommendation.` |
+| F4b | At least one entry declares; all declared share single value | `Adapter: <enum value> (N of M entries declared)` |
+| F4c | Two or more distinct enum values among declared entries | `Adapter: mixed (zotero-bbt-export: K, obsidian-vault: L, ..., undeclared: U)` |
+
+| Sub-case | Trigger | `Snapshot date:` line content |
+|---|---|---|
+| F4d | Zero entries declare `obtained_at` | `Snapshot date: <unspecified>` + trailing note `Snapshot date not declared; reproducibility is reduced. Adapter should populate obtained_at per v3.6.4 schema recommendation.` |
+| F4e | Partial coverage | `Snapshot date: <max(obtained_at)> (M of N entries declared)` |
+| F4f | Wide spread (>90 days between min and max) | append `(spans <N> days; corpus may not be a single snapshot)`. Composes with F4e. |
+
+F4a/b/c are mutually exclusive by trigger. F4d applies only when zero entries declare `obtained_at`; F4e and F4f compose. Never silently fill in or guess; never demand presence. See spec §4.2 for the full precedence reasoning.
 
 ## Detailed Execution Algorithm
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.6.4"
-  last_updated: "2026-04-25"
+  version: "3.6.5"
+  last_updated: "2026-04-27"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only
@@ -14,7 +14,7 @@ metadata:
     - academic-paper-reviewer
 ---
 
-# Academic Pipeline v3.6.4 — Full Academic Research Workflow Orchestrator
+# Academic Pipeline v3.6.5 — Full Academic Research Workflow Orchestrator
 
 A lightweight orchestrator that manages the complete academic pipeline from research exploration to final manuscript. It does not perform substantive work — it only detects stages, recommends modes, dispatches skills, manages transitions, and tracks state.
 
@@ -579,8 +579,8 @@ Stage 5: academic-paper (format-convert mode)
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.6.4 |
-| Last Updated | 2026-04-25 |
+| Skill Version | 3.6.5 |
+| Last Updated | 2026-04-27 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v2.0+, academic-paper v2.0+, academic-paper-reviewer v1.1+ |
 | Role | Full academic research workflow orchestrator |

--- a/academic-pipeline/references/literature_corpus_consumers.md
+++ b/academic-pipeline/references/literature_corpus_consumers.md
@@ -139,7 +139,7 @@ F4a/b/c are mutually exclusive by trigger. F4d applies only when zero entries de
 
 ## Consumer: bibliography_agent
 
-**Status**: Wired in PR-A (pre-release of v3.6.5; full release lands with PR-B)
+**Status**: Wired in v3.6.5
 **Skill**: deep-research
 **Phase**: 1 (literature search and curation)
 **Agent file**: [`deep-research/agents/bibliography_agent.md`](../../deep-research/agents/bibliography_agent.md)
@@ -150,9 +150,11 @@ When `literature_corpus[]` is non-empty and parses cleanly, the agent enters Ste
 
 ## Consumer: literature_strategist_agent
 
-**Status:** Stub — implementation in PR-B (v3.6.5)
-<!-- LINT_STUB: skip_cross_check -->
+**Status**: Wired in v3.6.5
+**Skill**: academic-paper
+**Phase**: 1 (literature search and curation)
+**Agent file**: [`academic-paper/agents/literature_strategist_agent.md`](../../academic-paper/agents/literature_strategist_agent.md)
 
-The academic-paper literature_strategist agent will follow the same shared reading flow when PR-B ships. PR-A intentionally does not modify the strategist agent; this stub block exists so the manifest cross-check (L2 sub-invariant) has a target without flagging the strategist as a falsely-shipped consumer.
+The academic-paper literature strategist agent applies the corpus-first flow during its literature search strategy phase. The PRE-SCREENED block sits inside the Search Strategy section of the Literature Search Report (per the agent's existing Output Format), immediately before the `Databases` line. The merged `final_included` set feeds the agent's downstream Annotated Bibliography, Literature Matrix, Research Gap Identification, and Recommended Sources by Paper Section outputs without altering their formats.
 
-PR-B replaces this entire block with the full content (matching the bibliography_agent pattern), removes the LINT_STUB marker and Status line, and appends the strategist entry to `scripts/corpus_consumer_manifest.json`.
+When `literature_corpus[]` is non-empty and parses cleanly, the agent enters Step 1 pre-screening, and Step 2 search-fills-gap dispatches the external 4-Layer Progressive Strategy. When the corpus is absent, empty, or fails the minimal shape check, the agent runs its existing 4-Layer external-DB-only flow unchanged (Iron Rule 4 graceful fallback for the failure cases).

--- a/academic-pipeline/references/literature_corpus_consumers.md
+++ b/academic-pipeline/references/literature_corpus_consumers.md
@@ -1,6 +1,6 @@
 # Consumer Protocol — `literature_corpus[]` Reading
 
-**Status**: Pre-release in PR-A (single consumer wired); full v3.6.5 release pending PR-B
+**Status**: Released in v3.6.5 (both Phase 1 consumers wired)
 **Applies to**: any agent in this repo that reads `literature_corpus[]` from a Material Passport
 **Authoritative spec**: [`docs/design/2026-04-26-ars-v3.6.5-consumer-integration-design.md`](../../docs/design/2026-04-26-ars-v3.6.5-consumer-integration-design.md)
 

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -2,8 +2,8 @@
 name: deep-research
 description: "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題."
 metadata:
-  version: "2.9.1"
-  last_updated: "2026-04-22"
+  version: "2.9.2"
+  last_updated: "2026-04-27"
   status: active
   data_access_level: raw
   task_type: open-ended
@@ -476,8 +476,8 @@ deep-research (systematic-review) + academic-paper -> PRISMA systematic review p
 
 | Item | Content |
 |------|---------|
-| Skill Version | 2.9.0 |
-| Last Updated | 2026-04-20 |
+| Skill Version | 2.9.2 |
+| Last Updated | 2026-04-27 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | academic-paper v1.0+ (downstream) |
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -96,7 +96,7 @@ The Material Passport `literature_corpus[]` field is populated by user-written a
 - `literature_corpus[]` entries are sorted by `citation_key`; rejections are sorted by `source`.
 - Adapter output size grows linearly with corpus size. A 500-entry Zotero library typically produces a passport of ~300 KB YAML. ARS consumers should lazy-load when the corpus is large.
 
-### What v3.6.4 does NOT do
+### Ingestion-layer boundaries
 
 - Does not ingest PDFs, extract text, or run OCR.
 - Does not call the Zotero Web API, Notion API, or any live service.
@@ -106,4 +106,6 @@ These boundaries are deliberate and reflect the ARS data-layer decision: ARS is 
 
 ### Consumer-side integration
 
-As of v3.6.4, no ARS agent reads `literature_corpus[]`. The field is a defined input port only. Consumer-side integration (agents that actually USE the corpus for research planning, citation generation, etc.) is deferred to v3.6.5+.
+As of v3.6.5, two Phase 1 literature agents read `literature_corpus[]` via the **corpus-first, search-fills-gap** flow: `deep-research/agents/bibliography_agent.md` and `academic-paper/agents/literature_strategist_agent.md`. Both consumers follow the same five-step shared flow and four Iron Rules (Same criteria / No silent skip / No corpus mutation / Graceful fallback on parse failure). Search Strategy reports gain a PRE-SCREENED reproducibility block that enumerates included / excluded / skipped corpus entries with F3 zero-hit and F4 provenance reporting. Consumer integration is presence-based — auto-engages when the passport carries a non-empty `literature_corpus[]` and parses cleanly; parse failures fall back to external-DB-only flow with a `[CORPUS PARSE FAILURE]` surface.
+
+See [`academic-pipeline/references/literature_corpus_consumers.md`](../academic-pipeline/references/literature_corpus_consumers.md) for the full consumer protocol. `citation_compliance_agent` corpus integration is deferred to v3.6.6+.

--- a/docs/PERFORMANCE.zh-TW.md
+++ b/docs/PERFORMANCE.zh-TW.md
@@ -96,7 +96,7 @@ Material Passport 的 `literature_corpus[]` 欄位由**使用者自行撰寫的 
 - `literature_corpus[]` 依 `citation_key` 排序；`rejection_log.rejected[]` 依 `source` 排序。
 - Adapter 輸出大小與語料庫大小線性成長。500 筆 Zotero 書目約產出 300 KB 的 passport YAML。大型語料庫建議 ARS 消費端採 lazy load。
 
-### v3.6.4 **不做** 的事
+### 導入層邊界
 
 - 不讀 PDF 內容、不做文字抽取、不跑 OCR。
 - 不呼叫 Zotero Web API、Notion API 或任何遠端服務。
@@ -106,4 +106,6 @@ Material Passport 的 `literature_corpus[]` 欄位由**使用者自行撰寫的 
 
 ### 消費端整合
 
-v3.6.4 時沒有任何 ARS agent 讀取 `literature_corpus[]`。此欄位僅為 input port 定義，消費端整合（agent 實際使用語料做研究規劃 / citation 生成 / ...）留待 v3.6.5+。
+v3.6.5 起，Phase 1 兩個文獻 agent 透過 **corpus-first、search-fills-gap** 流程讀取 `literature_corpus[]`：`deep-research/agents/bibliography_agent.md` 與 `academic-paper/agents/literature_strategist_agent.md`。兩者走相同的五步流程與四條 Iron Rule（Same criteria / No silent skip / No corpus mutation / Graceful fallback on parse failure）。Search Strategy 報告新增 PRE-SCREENED 可重現區塊，列出已納入／排除／略過的 corpus entry，並含 F3 zero-hit 與 F4 provenance 報告。消費端啟動採 presence-based — passport 帶非空 `literature_corpus[]` 且解析成功時自動進入；解析失敗時 fallback 到 external-DB-only flow，並 surface `[CORPUS PARSE FAILURE]`。
+
+完整 consumer 協定見 [`academic-pipeline/references/literature_corpus_consumers.md`](../academic-pipeline/references/literature_corpus_consumers.md)。`citation_compliance_agent` 的 corpus 整合留到 v3.6.6+。

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.6.4 (2026-04-25)")
+    expect_contains(rel_path, "Last updated: v3.6.5 (2026-04-27)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.6.4")
+    expect_contains(rel_path, "**Suite version**: 3.6.5")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.6.4-blue")
-    expect_contains(rel_path, "releases/tag/v3.6.4")
+    expect_contains(rel_path, "version-v3.6.5-blue")
+    expect_contains(rel_path, "releases/tag/v3.6.5")
+    expect_contains(rel_path, "### v3.6.5 (2026-04-27)")
     expect_contains(rel_path, "### v3.6.4 (2026-04-25)")
     expect_contains(rel_path, "### v3.6.3 (2026-04-23)")
     expect_contains(rel_path, "### v3.6.2 (2026-04-23)")
@@ -199,8 +200,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.6.4-blue")
-    expect_contains(rel_path, "releases/tag/v3.6.4")
+    expect_contains(rel_path, "version-v3.6.5-blue")
+    expect_contains(rel_path, "releases/tag/v3.6.5")
+    expect_contains(rel_path, "### v3.6.5（2026-04-27）")
     expect_contains(rel_path, "### v3.6.4（2026-04-25）")
     expect_contains(rel_path, "### v3.6.3（2026-04-23）")
     expect_contains(rel_path, "### v3.6.2（2026-04-23）")

--- a/scripts/corpus_consumer_manifest.json
+++ b/scripts/corpus_consumer_manifest.json
@@ -1,10 +1,17 @@
 {
-  "$schema_note": "Manifest of supported literature_corpus[] consumer agents. PR-A pre-release state: single entry. PR-B release state: both entries.",
+  "$schema_note": "Manifest of supported literature_corpus[] consumer agents. v3.6.5 release state: bibliography_agent (deep-research) + literature_strategist_agent (academic-paper).",
   "supported_consumers": [
     {
       "agent_path": "deep-research/agents/bibliography_agent.md",
       "agent_basename": "bibliography_agent",
       "skill": "deep-research",
+      "since_version": "v3.6.5",
+      "phase": "Phase 1"
+    },
+    {
+      "agent_path": "academic-paper/agents/literature_strategist_agent.md",
+      "agent_basename": "literature_strategist_agent",
+      "skill": "academic-paper",
       "since_version": "v3.6.5",
       "phase": "Phase 1"
     }

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -575,7 +575,7 @@ The optional `literature_corpus[]` field is Schema 9's input port for user-owned
 
 ARS does not produce these entries. User-written adapters read their own corpus source (Zotero, Obsidian, folder, Notion, etc.) and emit a passport with `literature_corpus[]` populated. Three reference adapters ship with v3.6.4 under [`scripts/adapters/`](../scripts/adapters/).
 
-Consumer-side integration deferred to v3.6.5+ — `literature_corpus[]`-reading agents land progressively across PR-A (`bibliography_agent`) and PR-B (`literature_strategist_agent`); v3.6.5 release tag goes on PR-B. v3.6.4 defines the input port only.
+Consumer integration ships in v3.6.5: `bibliography_agent` (deep-research, Phase 1) and `literature_strategist_agent` (academic-paper, Phase 1) read `literature_corpus[]` via the corpus-first, search-fills-gap flow. See [`academic-pipeline/references/literature_corpus_consumers.md`](../academic-pipeline/references/literature_corpus_consumers.md) for the full consumer protocol, the four Iron Rules, and per-consumer reading instructions.
 
 See [`academic-pipeline/references/adapters/overview.md`](../academic-pipeline/references/adapters/overview.md) for the adapter contract.
 


### PR DESCRIPTION
## Summary

PR-B (release sweep) of the two-PR v3.6.5 rollout. Wires the academic-paper `literature_strategist_agent` as the second `literature_corpus[]` consumer, promotes the consumer protocol from PR-A pre-release state to v3.6.5 release state, and applies the seven-touchpoint version sweep + CHANGELOG + tag plan.

Pairs with PR #41 (PR-A, single-consumer pre-release, merged 2026-04-26).

Spec: `docs/design/2026-04-26-ars-v3.6.5-consumer-integration-design.md` §6.2 + §6.3 + §6.5.

## Scope

**Consumer wiring**
- `academic-paper/agents/literature_strategist_agent.md`: Step 0 presence detection, four Iron Rules, five-step corpus-first / search-fills-gap flow, PRE-SCREENED template, F3 zero-hit + F4a–F4f provenance reporting, backpointer to consumer protocol. Literature Matrix and Research Gap Identification gain corpus-aware additions.
- `academic-pipeline/references/literature_corpus_consumers.md`: strategist stub block promoted to full content; LINT_STUB marker + `Status: Stub` line removed; bibliography_agent block updated to release wording; document header promoted to "Released in v3.6.5 (both Phase 1 consumers wired)".
- `scripts/corpus_consumer_manifest.json`: appended `literature_strategist_agent` entry; `$schema_note` updated to v3.6.5 release state.

**Schema 9 caveat retirement**
- `shared/handoff_schemas.md`: v3.6.4 "Consumer-side integration deferred to v3.6.5+" caveat replaced with backpointer to consumer protocol.

**Seven-touchpoint atomic version sweep** (per design doc §6.3, single commit)
1. `academic-pipeline/SKILL.md` 3.6.4 → 3.6.5
2. `deep-research/SKILL.md` 2.9.1 → 2.9.2 (also syncs Version Info footer that lagged at 2.9.0 since v3.5.1 PR #36)
3. `academic-paper/SKILL.md` 3.1.0 → 3.1.1
4. `MODE_REGISTRY.md` last-updated → v3.6.5 (2026-04-27)
5. `.claude/CLAUDE.md` Skills Overview row versions, new `## v3.6.5 Key Additions` section, Suite version footer
6. `README.md` + `README.zh-TW.md` badge / release tag URL / changelog entry
7. `scripts/check_spec_consistency.py` append v3.6.5 expected pin (v3.3.2–v3.6.4 regression pins retained)

**Cross-doc staleness fix** (caught by codex round-1)
- `docs/PERFORMANCE.md` + `docs/PERFORMANCE.zh-TW.md` §"Consumer-side integration": rewritten from v3.6.4 "no agent reads literature_corpus[]" to v3.6.5 corpus-first description; subsection rename `What v3.6.4 does NOT do` → `Ingestion-layer boundaries` (timeless framing for boundaries that don't change between versions).

**CHANGELOG**: `[3.6.5]` entry per design doc §6.5 template.

## Tag plan

After merge, tag `v3.6.5` annotated on the PR-B merge commit. GitHub release titled `v3.6.5 — Material Passport literature_corpus[] Consumer Integration`, release notes link both PR #41 (PR-A) and this PR.

## Verification

**Local pre-push gates (per design doc §6.6)**
- [x] `python scripts/check_corpus_consumer_protocol.py` → exit 0 (PR-B closed-set tuple match)
- [x] `python scripts/check_spec_consistency.py` → exit 0
- [x] `PYTHONPATH=. pytest scripts/` → 331 passed
- [x] `/codex review --base main` round-1: 1 × [P3] (PERFORMANCE docs cross-doc staleness) → fixed
- [x] `/codex review --base main` round-2: 1 × [P3] (consumer protocol header pre-release wording) → fixed
- [x] `/codex review --base main` round-3: 0 findings (release wording consistency converged per `feedback_codex_iterative_spec_review_to_zero.md`)
- [x] `/simplify` review: 1 medium finding (.claude/CLAUDE.md order-coupled "(see above)") → fixed

**CI**
- [ ] `spec-consistency.yml` green
- [ ] `pytest.yml` green

## Test plan

- [ ] CI green on push.
- [ ] After merge: tag `v3.6.5` annotated on merge commit, GitHub release published with PR-A + PR-B links.
- [ ] Spot-check: ARS user with non-empty `literature_corpus[]` runs `academic-paper` Phase 1; observe PRE-SCREENED block emission (deferred to real-run observation backlog per design doc §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)