### PR TITLE
fix(v3.6.5.1): SETUP doc correctness — install paths, claude.ai distinction, prereqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.6.5.1] - 2026-04-27
+
+### Fixed
+
+- **`docs/SETUP.md` Method 3 install paths** — Option A (symlink) and Option B (copy)
+  now install each of the four skill folders separately into `~/.claude/skills/<skill-name>/`,
+  matching the `<install-root>/<skill-name>/SKILL.md` discovery convention. The previous
+  text installed the whole repo under `~/.claude/skills/academic-research-skills/`, which
+  buried the four `SKILL.md` files one level too deep for Cowork / Claude Code discovery.
+- **`docs/SETUP.md` Method 4 (claude.ai) restructured** — split into Method 4a
+  (Custom Skill upload via Settings → Capabilities → Skills, the standard claude.ai Skill
+  install path) and Method 4b (Project + GitHub integration, fallback knowledge mode and
+  not a Skill install). The previous text framed GitHub integration as a Skill install
+  path, which conflated content retrieval with skill execution. Method 4a documents the
+  current 200-character `description` cap blocker; the description trim ships in v3.6.5.2.
+- **Method 3 prerequisites** — expanded from one sentence to a full prerequisites
+  subsection covering Claude Desktop version, internet connectivity, Cowork process model,
+  folder permissions, paid plan, and Team/Enterprise org-admin controls.
+- **Method 4 prerequisites** — split per sub-method. 4a documents zip structure +
+  description cap surfacing as upload-time errors; 4b documents GitHub authentication via
+  the Anthropic connector, private-repo App authorization, and Team/Enterprise owner-level
+  connector enablement.
+- **Cowork UI terminology** — replaced "Cowork tab" / "working directory" with current
+  Cowork UI labels: mode selector (Chat / Cowork), Tasks view, "Use an existing folder"
+  in the left navigation panel, and Cowork Project as the canonical term.
+- **Skill invocation framing** — clarified that Claude uses each skill's `description`
+  for relevance routing rather than literal trigger-phrase matching, and documented the
+  Cowork `/` command palette and `+` capability picker as explicit invocation surfaces.
+- **Method 4 directory table** — added the `scripts/` row (required for Material Passport
+  `literature_corpus[]` adapters and schema validators) and refreshed the project-capacity
+  guidance against current Anthropic Project file limits (per-file 30 MB; file count is
+  not artificially capped at 200).
+- **`docs/SETUP.zh-TW.md`** — mirrored the English rewrite end-to-end so Traditional
+  Chinese readers see the same structure and content for Methods 1-4.
+- **`QUICKSTART.md` Step 1** — install commands aligned with the new Method 3 four-symlink
+  approach.
+
+### Notes
+
+- Doc-only patch. No skill content (`SKILL.md`), no agent file, no schema, no script,
+  and no test changed in this patch.
+- Issue [#44](https://github.com/Imbad0202/academic-research-skills/issues/44) (philpav)
+  reports SETUP problems on Cowork and claude.ai. v3.6.5.1 fixes the SETUP doc; the
+  remaining `SKILL.md` description-length issue (the actual upload blocker on claude.ai)
+  ships in the follow-up patch v3.6.5.2. Issue #44 will receive a single consolidated
+  reply and close on v3.6.5.2 ship.
+
 ## [3.6.5] - 2026-04-27
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,11 +8,19 @@ Get from zero to your first AI-assisted research in 3 steps.
 # Install Claude Code
 curl -fsSL https://claude.ai/install.sh | bash
 
-# Clone this repo into your project
+# Clone this repo somewhere stable
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
+# Install each of the four skills into your project's .claude/skills/
 cd /path/to/your/project
 mkdir -p .claude/skills
-git clone https://github.com/Imbad0202/academic-research-skills.git .claude/skills/academic-research-skills
+ln -s ~/academic-research-skills/deep-research .claude/skills/deep-research
+ln -s ~/academic-research-skills/academic-paper .claude/skills/academic-paper
+ln -s ~/academic-research-skills/academic-paper-reviewer .claude/skills/academic-paper-reviewer
+ln -s ~/academic-research-skills/academic-pipeline .claude/skills/academic-pipeline
 ```
+
+Each skill must sit at `.claude/skills/<skill-name>/SKILL.md` for Claude Code to discover it. See [docs/SETUP.md](docs/SETUP.md) for the copy-based alternative (Option B) and other installation methods (global `~/.claude/skills/`, Cowork, claude.ai).
 
 ## Step 2: Launch
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -166,26 +166,58 @@ Without `ARS_CROSS_MODEL` set, everything works exactly as before. The cross-mod
 
 ## Installation methods
 
+Claude discovers skills at `<install-root>/<skill-name>/SKILL.md`. This repo contains four separate skills, each with its own `SKILL.md`:
+
+- `deep-research`
+- `academic-paper`
+- `academic-paper-reviewer`
+- `academic-pipeline`
+
+Do not install the whole repository as one nested skill folder under `.claude/skills/academic-research-skills/`; that buries the four `SKILL.md` files one level too deep for discovery. See Anthropic's [Claude Code Skills documentation](https://code.claude.com/docs/en/skills).
+
 ### Method 1: As project skills (recommended)
 
-Clone this repo into your project's `.claude/skills/` directory:
+Use this when you want ARS available inside an existing Claude Code project.
+
+Clone the repo to a stable local path, then copy each skill folder into your project's `.claude/skills/` directory:
 
 ```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
 cd /path/to/your/project
 mkdir -p .claude/skills
-git clone https://github.com/Imbad0202/academic-research-skills.git .claude/skills/academic-research-skills
+cp -R ~/academic-research-skills/deep-research .claude/skills/deep-research
+cp -R ~/academic-research-skills/academic-paper .claude/skills/academic-paper
+cp -R ~/academic-research-skills/academic-paper-reviewer .claude/skills/academic-paper-reviewer
+cp -R ~/academic-research-skills/academic-pipeline .claude/skills/academic-pipeline
+```
+
+Expected path shape:
+
+```text
+/path/to/your/project/.claude/skills/deep-research/SKILL.md
+/path/to/your/project/.claude/skills/academic-paper/SKILL.md
+/path/to/your/project/.claude/skills/academic-paper-reviewer/SKILL.md
+/path/to/your/project/.claude/skills/academic-pipeline/SKILL.md
 ```
 
 Then copy the `.claude/CLAUDE.md` content into your project's `.claude/CLAUDE.md` (merge with existing if you have one).
 
-> **Global installation:** To make skills available across all your projects, install to `~/.claude/skills/` instead:
+> **Global Claude Code installation:** To make these skills available across your Claude Code projects, install the four folders to `~/.claude/skills/` instead:
 >
 > ```bash
+> git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+>
 > mkdir -p ~/.claude/skills
-> git clone https://github.com/Imbad0202/academic-research-skills.git ~/.claude/skills/academic-research-skills
+> cp -R ~/academic-research-skills/deep-research ~/.claude/skills/deep-research
+> cp -R ~/academic-research-skills/academic-paper ~/.claude/skills/academic-paper
+> cp -R ~/academic-research-skills/academic-paper-reviewer ~/.claude/skills/academic-paper-reviewer
+> cp -R ~/academic-research-skills/academic-pipeline ~/.claude/skills/academic-pipeline
 > ```
 
 ### Method 2: As a standalone project
+
+Use this when you want to work directly inside the ARS repository.
 
 ```bash
 git clone https://github.com/Imbad0202/academic-research-skills.git
@@ -199,92 +231,168 @@ claude
 1. Go to <https://github.com/Imbad0202/academic-research-skills>
 2. Click the green **Code** button → **Download ZIP**
 3. Extract the ZIP to your desired location
-4. For Method 1: move the extracted folder to `.claude/skills/academic-research-skills` inside your project
+4. For Method 1: copy the four extracted skill folders (`deep-research`, `academic-paper`, `academic-paper-reviewer`, `academic-pipeline`) into `.claude/skills/` inside your project
 5. For standalone use: open a terminal in the extracted folder and run `claude`
 
 </details>
 
 ### Method 3: Claude Cowork (desktop)
 
-Use these skills in [Claude Cowork](https://claude.com/product/cowork) — Claude Desktop's agentic workspace.
+Use this when you want the four ARS skills available in [Claude Cowork](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork), Claude Desktop's agentic workspace.
 
-> [!WARNING]
-> **Known broken (2026-04-27) — instructions in this section bury `SKILL.md` files one level too deep, so Cowork's skill discovery (`.claude/skills/<skill-name>/SKILL.md`) does not register them. A doc-correctness patch (v3.6.5.1) is in progress.**
->
-> **Workaround until the patch ships** — install each of the four skill folders separately into `.claude/skills/`:
->
-> ```bash
-> git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
-> mkdir -p ~/.claude/skills
-> cd ~/.claude/skills
-> ln -s ~/academic-research-skills/deep-research deep-research
-> ln -s ~/academic-research-skills/academic-paper academic-paper
-> ln -s ~/academic-research-skills/academic-paper-reviewer academic-paper-reviewer
-> ln -s ~/academic-research-skills/academic-pipeline academic-pipeline
-> ```
->
-> Restart Cowork and the four skills should register. If you sync `~/.claude/skills` across machines (cloud folders), use `cp -R` instead of `ln -s` — symlinks pointing at absolute paths break on a fresh checkout.
->
-> Tracking: [issue #44](https://github.com/Imbad0202/academic-research-skills/issues/44).
+Cowork uses the same skill folder shape: `~/.claude/skills/<skill-name>/SKILL.md`.
 
-**Option A: folder access (quickest)**
+#### Prerequisites
 
-1. Clone this repo locally:
-   ```bash
-   git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
-   ```
-2. Open Claude Desktop → click **Cowork** tab (top bar)
-3. Select the cloned `academic-research-skills` folder as the working directory
-4. Claude will auto-detect the skills from `SKILL.md` files and load them as needed
+- Claude Desktop latest version on macOS or Windows. Download from Anthropic's [Claude Desktop page](https://claude.ai/download).
+- Active internet connection; Cowork tasks call the Anthropic API.
+- Keep Claude Desktop open while Cowork tasks run. Cowork runs inside the Desktop process.
+- Folder/file permissions that allow Cowork to read and write in the project folder.
+- A paid plan with Cowork access. See Anthropic's [Cowork requirements](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork) for current plan availability.
+- On Team or Enterprise plans, your organization admin may have disabled Skills, plugins, connectors, or egress. If installed skills do not register after restart, ask your admin to check org-level controls.
 
-**Option B: as project skills**
+#### Option A: symlink install (fastest, single-machine)
 
-If you already have a project folder in Cowork:
+Use symlinks if you work on one machine and want updates by pulling the repo.
 
 ```bash
-cd /path/to/your/project
-mkdir -p .claude/skills
-git clone https://github.com/Imbad0202/academic-research-skills.git .claude/skills/academic-research-skills
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
+mkdir -p ~/.claude/skills
+cd ~/.claude/skills
+ln -s ~/academic-research-skills/deep-research deep-research
+ln -s ~/academic-research-skills/academic-paper academic-paper
+ln -s ~/academic-research-skills/academic-paper-reviewer academic-paper-reviewer
+ln -s ~/academic-research-skills/academic-pipeline academic-pipeline
 ```
 
-Skills auto-load when relevant — e.g., saying "help me write a paper" triggers `academic-paper`.
+Expected path shape:
 
-**Requirements:** Claude Desktop (latest version) with Cowork enabled; paid plan (Pro, Max, Team, or Enterprise).
+```text
+~/.claude/skills/deep-research/SKILL.md
+~/.claude/skills/academic-paper/SKILL.md
+~/.claude/skills/academic-paper-reviewer/SKILL.md
+~/.claude/skills/academic-pipeline/SKILL.md
+```
+
+If you sync `~/.claude/skills` across machines via a cloud folder, use Option B instead. Absolute-path symlinks can break on a fresh checkout or another machine.
+
+#### Option B: copy install (cross-machine safe, no auto-update)
+
+Use copies if you sync `~/.claude/skills` across machines or do not want symlinks. Updates require re-running the four `cp -R` commands.
+
+```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
+mkdir -p ~/.claude/skills
+cp -R ~/academic-research-skills/deep-research ~/.claude/skills/deep-research
+cp -R ~/academic-research-skills/academic-paper ~/.claude/skills/academic-paper
+cp -R ~/academic-research-skills/academic-paper-reviewer ~/.claude/skills/academic-paper-reviewer
+cp -R ~/academic-research-skills/academic-pipeline ~/.claude/skills/academic-pipeline
+```
+
+Expected path shape:
+
+```text
+~/.claude/skills/deep-research/SKILL.md
+~/.claude/skills/academic-paper/SKILL.md
+~/.claude/skills/academic-paper-reviewer/SKILL.md
+~/.claude/skills/academic-pipeline/SKILL.md
+```
+
+#### Create or open a Cowork Project
+
+See Anthropic's [Organize your tasks with Projects in Claude Cowork](https://support.claude.com/en/articles/14116274-organize-your-tasks-with-projects-in-claude-cowork) for the canonical UI walk-through.
+
+1. Open Claude Desktop.
+2. Use the mode selector (**Chat / Cowork**) and switch to **Cowork**.
+3. In **Tasks**, use the left navigation panel and choose **Use an existing folder**.
+4. Select the local folder you want Cowork to work in. This creates a Cowork Project pointing at that folder.
+5. Restart Cowork after installing or updating the skill folders so the four skills register.
+
+#### How Cowork invokes the skills
+
+Claude uses each skill's `description` to judge relevance, as described in Anthropic's [Skills documentation](https://code.claude.com/docs/en/skills). Example phrases such as "help me write a paper" are illustrative, not literal trigger phrases; paraphrased intent works too.
+
+If description-based routing does not select the skill you want, Cowork also provides explicit UI surfaces described in Anthropic's [Cowork plugins documentation](https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork):
+
+- Type `/` in a Cowork Task to use the command palette and select an available skill.
+- Use the `+` capability picker to add a skill to the current Task.
 
 ### Method 4: Use with claude.ai (web)
 
-You can use these skills on [claude.ai](https://claude.ai) via the **Project** feature with GitHub integration — no Claude Code installation needed.
+claude.ai has two different ways to use this repository. They are not equivalent:
 
-> [!WARNING]
-> **Known misleading (2026-04-27) — claude.ai's GitHub integration loads files into _Project knowledge_ (static context for retrieval), NOT the Skills system. Skill auto-loading does not happen via this method.** Use this Method 4 only as a fallback knowledge mode (Claude can read the repo content but does not execute the skills as agentic workflows).
->
-> **Real Skill upload on claude.ai** requires Settings → Capabilities → Skills, with one zip uploaded per skill. **Note**: the four skill `description` fields in this repo currently exceed the 200-character cap and would be rejected by the upload UI. A separate patch (v3.6.5.2) trims the descriptions and adds zip upload guidance. Until then, prefer Method 1, 2, or 3.
->
-> A doc-correctness patch (v3.6.5.1) clarifying both modes is in progress. Tracking: [issue #44](https://github.com/Imbad0202/academic-research-skills/issues/44).
+- **Method 4a** uploads real Custom Skills. This is the standard claude.ai Skill install path, with auto-loading and skill routing.
+- **Method 4b** adds repository files to Project knowledge through GitHub integration. This is fallback knowledge mode, not a Skill install.
 
-1. Sign in to [claude.ai](https://claude.ai) (requires a paid plan)
-2. Create a new Project: **Projects** → **Create Project**
-3. Import from GitHub: in the Project, click **Files** → **+** → **GitHub** → select `Imbad0202/academic-research-skills`
+#### Prerequisites
 
-   **Recommended selections** (to stay within capacity):
+- A paid claude.ai plan. See Anthropic's current plan information at [claude.ai](https://claude.ai).
+- For Method 4a, no GitHub authentication is needed. You zip each skill folder locally and upload one zip per skill through **Settings** → **Capabilities** → **Skills**. Zip structure errors and the 200-character `description` cap surface as upload-time errors; see Anthropic's [Custom Skills packaging documentation](https://claude.com/docs/skills/how-to).
+- For Method 4b, GitHub authentication is required through the Anthropic connector. See [Using the GitHub integration](https://support.claude.com/en/articles/10167454-using-the-github-integration) and [Set up Claude integrations](https://support.claude.com/en/articles/10168395-set-up-claude-integrations). Private repositories require the Anthropic GitHub App to be authorized on the repo or organization. Team and Enterprise plans require owner-level connector enablement before users can add GitHub-sourced files.
 
-   | Select | Directory | Why |
+#### Method 4a: Custom Skill upload (claude.ai's standard Skill install path)
+
+This is the real Skill install path for claude.ai. Upload one zip per skill via **Settings** → **Capabilities** → **Skills**.
+
+Each zip must have the skill folder as its top-level entry, so the zip contains `<skill-name>/SKILL.md`, not `<skill-name>/<skill-name>/SKILL.md`.
+
+```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git
+cd academic-research-skills
+
+zip -r deep-research.zip deep-research
+zip -r academic-paper.zip academic-paper
+zip -r academic-paper-reviewer.zip academic-paper-reviewer
+zip -r academic-pipeline.zip academic-pipeline
+```
+
+Then upload:
+
+1. Sign in to [claude.ai](https://claude.ai).
+2. Open **Settings**.
+3. Open **Capabilities**.
+4. Open **Skills**.
+5. Upload `deep-research.zip`.
+6. Upload `academic-paper.zip`.
+7. Upload `academic-paper-reviewer.zip`.
+8. Upload `academic-pipeline.zip`.
+
+Current blocker in v3.6.5.1: the four skill `description` fields in this repo currently exceed the 200-character cap and would be rejected by the upload UI. The description trim ships in a follow-up patch (v3.6.5.2). This path is documented here so the install instructions are correct in advance; until v3.6.5.2 ships, prefer Method 1, Method 2, or Method 3.
+
+#### Method 4b: Project + GitHub integration (fallback knowledge mode, not a Skill install)
+
+claude.ai Projects deliver content as static knowledge for Claude to retrieve and cite — see Anthropic's [What are Projects?](https://support.claude.com/en/articles/9517075-what-are-projects). This is NOT a Skill install. Skill auto-loading does not happen. Trigger phrases do not route. Claude can read the repo content but does not execute the skills as agentic workflows.
+
+Use this when you want claude.ai to have access to the repo content for reading/citation, but you do not need agentic skill execution.
+
+1. Sign in to [claude.ai](https://claude.ai).
+2. Create a new Project: **Projects** → **Create Project**.
+3. Import from GitHub: in the Project, click **Files** → **+** → **GitHub** → select `Imbad0202/academic-research-skills`.
+4. Select the folders/files below.
+
+   | Select | Directory / file | Why |
    |---|---|---|
-   | ✅ | `.claude/` | Routing rules |
-   | ✅ | `deep-research/` | Core skill |
-   | ✅ | `academic-paper/` | Core skill |
-   | ✅ | `academic-paper-reviewer/` | Core skill |
-   | ✅ | `academic-pipeline/` | Core skill |
-   | ✅ | `shared/` | Cross-model verification, handoff schemas |
+   | ✅ | `deep-research/` | Core skill content for reading |
+   | ✅ | `academic-paper/` | Core skill content for reading |
+   | ✅ | `academic-paper-reviewer/` | Core skill content for reading |
+   | ✅ | `academic-pipeline/` | Core skill content for reading |
+   | ✅ | `shared/` | Cross-model verification, handoff schemas, shared protocols |
+   | ✅ | `scripts/` | `literature_corpus[]` adapters (`folder_scan`, `zotero`, `obsidian`) + schema validators; required for Material Passport corpus mode and CI-style validation |
    | ✅ | `MODE_REGISTRY.md` | Mode definitions |
-   | ❌ | `examples/` | Takes ~39% capacity — skip unless you have room |
-   | ❌ | `.github/`, READMEs, LICENSE, etc. | Not needed for functionality |
+   | Optional | `.claude/` | Project-level routing rules. Skip if you set Project Instructions in step 5 below (recommended path); include only if you prefer to keep routing rules visible as Project files. |
+   | Optional | `examples/` | Useful for reference examples; skip if you want a smaller Project knowledge set |
+   | Optional | `.github/`, READMEs, LICENSE, etc. | Repository metadata; not needed for core reading context |
 
-4. (Optional) Set **Instructions** in the Project to the content of `.claude/CLAUDE.md` for better routing
-5. Start chatting: "Guide my research on X" or "Help me write a paper about Y"
+5. (Recommended) Set **Instructions** in the Project to the content of `.claude/CLAUDE.md` for better routing.
+6. Start chatting: "Guide my research on X" or "Help me write a paper about Y".
+
+Anthropic's current [Project file limits](https://support.claude.com/en/articles/8241126-upload-files-to-claude) state that Project file count is not artificially capped at 200; files have a 30 MB per-file limit and total usable content is still subject to context-window limits at runtime. Keep the Project focused so Claude retrieves the relevant files reliably.
 
 **claude.ai vs Claude Code:**
 
-- claude.ai does not support parallel multi-agent execution or shell commands; results may be less comprehensive than Claude Code
-- Cross-model verification (`ARS_CROSS_MODEL`) requires Claude Code with API keys
-- Direct `.docx` generation requires Pandoc, and LaTeX/PDF output requires Claude Code with `tectonic`; claude.ai can still produce Markdown and DOCX conversion instructions
+- Method 4b is for content reading, not active Skill execution. If you need agentic skill execution, prefer Method 1, Method 2, Method 3, or Method 4a after v3.6.5.2.
+- claude.ai does not support local shell commands; results may be less comprehensive than Claude Code workflows that rely on local scripts.
+- Cross-model verification (`ARS_CROSS_MODEL`) requires Claude Code with API keys.
+- Direct `.docx` generation requires Pandoc, and LaTeX/PDF output requires Claude Code with `tectonic`; claude.ai can still produce Markdown and DOCX conversion instructions.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -208,6 +208,25 @@ claude
 
 Use these skills in [Claude Cowork](https://claude.com/product/cowork) — Claude Desktop's agentic workspace.
 
+> [!WARNING]
+> **Known broken (2026-04-27) — instructions in this section bury `SKILL.md` files one level too deep, so Cowork's skill discovery (`.claude/skills/<skill-name>/SKILL.md`) does not register them. A doc-correctness patch (v3.6.5.1) is in progress.**
+>
+> **Workaround until the patch ships** — install each of the four skill folders separately into `.claude/skills/`:
+>
+> ```bash
+> git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+> mkdir -p ~/.claude/skills
+> cd ~/.claude/skills
+> ln -s ~/academic-research-skills/deep-research deep-research
+> ln -s ~/academic-research-skills/academic-paper academic-paper
+> ln -s ~/academic-research-skills/academic-paper-reviewer academic-paper-reviewer
+> ln -s ~/academic-research-skills/academic-pipeline academic-pipeline
+> ```
+>
+> Restart Cowork and the four skills should register. If you sync `~/.claude/skills` across machines (cloud folders), use `cp -R` instead of `ln -s` — symlinks pointing at absolute paths break on a fresh checkout.
+>
+> Tracking: [issue #44](https://github.com/Imbad0202/academic-research-skills/issues/44).
+
 **Option A: folder access (quickest)**
 
 1. Clone this repo locally:
@@ -235,6 +254,13 @@ Skills auto-load when relevant — e.g., saying "help me write a paper" triggers
 ### Method 4: Use with claude.ai (web)
 
 You can use these skills on [claude.ai](https://claude.ai) via the **Project** feature with GitHub integration — no Claude Code installation needed.
+
+> [!WARNING]
+> **Known misleading (2026-04-27) — claude.ai's GitHub integration loads files into _Project knowledge_ (static context for retrieval), NOT the Skills system. Skill auto-loading does not happen via this method.** Use this Method 4 only as a fallback knowledge mode (Claude can read the repo content but does not execute the skills as agentic workflows).
+>
+> **Real Skill upload on claude.ai** requires Settings → Capabilities → Skills, with one zip uploaded per skill. **Note**: the four skill `description` fields in this repo currently exceed the 200-character cap and would be rejected by the upload UI. A separate patch (v3.6.5.2) trims the descriptions and adds zip upload guidance. Until then, prefer Method 1, 2, or 3.
+>
+> A doc-correctness patch (v3.6.5.1) clarifying both modes is in progress. Tracking: [issue #44](https://github.com/Imbad0202/academic-research-skills/issues/44).
 
 1. Sign in to [claude.ai](https://claude.ai) (requires a paid plan)
 2. Create a new Project: **Projects** → **Create Project**

--- a/docs/SETUP.zh-TW.md
+++ b/docs/SETUP.zh-TW.md
@@ -1,6 +1,6 @@
 # ARS 安裝設定
 
-Academic Research Skills 的前置需求與選用設定。只需要 Markdown 輸出 + 預設 Claude Opus 4.7 pipeline 的人，大部分內容可以略過 — 見下方「最小可行設定」。
+Academic Research Skills 的前置需求與選用設定。只需要 Markdown 輸出與預設 Claude Opus 4.7 pipeline 的人，大部分內容可以略過。請見下方「最小可行設定」。
 
 ---
 
@@ -10,7 +10,7 @@ Academic Research Skills 的前置需求與選用設定。只需要 Markdown 輸
 2. 設定 `ANTHROPIC_API_KEY`。
 3. 在這個 repo（或任何把 ARS 放在 `.claude/skills/` 下的專案）執行 `claude`。
 
-這樣就夠了 — 可得到 Markdown 輸出 + DOCX 轉換說明。以下其他內容都是選用。
+這樣就夠了。可得到 Markdown 輸出與 DOCX 轉換說明。以下其他內容都是選用。
 
 ---
 
@@ -22,7 +22,7 @@ Academic Research Skills 的前置需求與選用設定。只需要 Markdown 輸
 # macOS / Linux
 curl -fsSL https://claude.ai/install.sh | bash
 
-# Windows（PowerShell）
+# Windows (PowerShell)
 irm https://claude.ai/install.ps1 | iex
 ```
 
@@ -42,7 +42,7 @@ npm install -g @anthropic-ai/claude-code
 你需要一個 Anthropic API key，請至 <https://console.anthropic.com/> 取得。
 
 ```bash
-# Claude Code 首次執行時會提示輸入 API key
+# Claude Code will prompt for your API key on first run
 claude
 ```
 
@@ -54,7 +54,7 @@ export ANTHROPIC_API_KEY=sk-ant-xxxxx
 
 ## DOCX 輸出（選用）
 
-若要直接產出 `.docx`，需要安裝 [Pandoc](https://pandoc.org/)。若系統沒有 Pandoc，formatter 會回退為提供 Markdown + DOCX 轉換說明。
+若要直接產出 `.docx`，需要安裝 [Pandoc](https://pandoc.org/)。若系統沒有 Pandoc，formatter 會回退為提供 Markdown 與 DOCX 轉換說明。
 
 ```bash
 # macOS
@@ -63,12 +63,12 @@ brew install pandoc
 # Linux (Debian/Ubuntu)
 sudo apt-get install pandoc
 
-# Windows — 請至 https://pandoc.org/installing.html 下載
+# Windows — download from https://pandoc.org/installing.html
 ```
 
 ## LaTeX / PDF 輸出（選用）
 
-PDF 輸出需要 [tectonic](https://tectonic-typesetting.github.io/) 和特定字型。**這是選用的** — Markdown 輸出與 DOCX 轉換說明不需要這些。
+PDF 輸出需要 [tectonic](https://tectonic-typesetting.github.io/) 和特定字型。**這是選用的**。Markdown 輸出與 DOCX 轉換說明不需要這些。
 
 ```bash
 # macOS
@@ -77,42 +77,42 @@ brew install tectonic
 # Linux (Debian/Ubuntu)
 curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net | sh
 
-# Windows — 請至 https://tectonic-typesetting.github.io/en-US/install.html 下載
+# Windows — download from https://tectonic-typesetting.github.io/en-US/install.html
 ```
 
 **所需字型**（APA 7.0 中文輸出）：
 
-- **Times New Roman** — macOS/Windows 通常已內建；Linux 安裝 `ttf-mscorefonts-installer`
-- **思源宋體 VF**（Source Han Serif TC VF）— 從 [Google Fonts](https://fonts.google.com/specimen/Noto+Serif+TC) 或 [Adobe GitHub](https://github.com/adobe-fonts/source-han-serif) 下載
-- **Courier New** — 通常已內建
+- **Times New Roman**：macOS/Windows 通常已內建；Linux 安裝 `ttf-mscorefonts-installer`
+- **Source Han Serif TC VF**（思源宋體）：從 [Google Fonts](https://fonts.google.com/specimen/Noto+Serif+TC) 或 [Adobe GitHub](https://github.com/adobe-fonts/source-han-serif) 下載
+- **Courier New**：通常已內建
 
 > 如果只需要 Markdown 輸出或 DOCX 轉換說明，可完全跳過此步驟。直接產出 `.docx` 需要 Pandoc，PDF 需要 `tectonic`。
 
 ---
 
-## Material Passport `literature_corpus[]` adapter（v3.6.4+，選用）
+## Material Passport `literature_corpus[]` adapters（v3.6.4+，選用）
 
-如果你已經維護一個策展過的文獻語料（Zotero、Obsidian、PDF 資料夾等），可以先把它打包進 Material Passport，讓 Phase 1 ARS agent 在去外部資料庫搜尋之前先讀你的文獻庫。此功能 opt-in、presence-based — 沒提供語料時，ARS 走 external-DB-only flow，行為不變。
+如果你已經維護一個策展過的文獻語料（Zotero、Obsidian、PDF 資料夾等），可以先把它打包進 Material Passport，讓 Phase 1 ARS agent 在去外部資料庫搜尋之前先讀你的文獻庫。此功能採 opt-in 與 presence-based 設計。沒提供語料時，ARS 走 external-DB-only flow，行為不變。
 
 v3.6.4 附三個 reference Python adapter，位於 `scripts/adapters/`：
 
 ```bash
-# 1. 安裝 adapter 依賴（PyYAML + jsonschema，已在 requirements-dev.txt）
+# 1. Install adapter dependencies (PyYAML + jsonschema, already in requirements-dev.txt)
 pip install -r requirements-dev.txt
 
-# 2. 跑一個對應你語料來源的 reference adapter。
-#    --passport 與 --rejection-log 兩個皆為必填。
+# 2. Run a reference adapter (pick one that matches your corpus source).
+#    Both --passport and --rejection-log are required.
 python scripts/adapters/folder_scan.py --input /path/to/pdfs               --passport passport.yaml --rejection-log rejection_log.yaml
 python scripts/adapters/zotero.py      --input my-zotero-export.json       --passport passport.yaml --rejection-log rejection_log.yaml
 python scripts/adapters/obsidian.py    --input ~/Obsidian/Lit\ Notes       --passport passport.yaml --rejection-log rejection_log.yaml
 
-# 3. 把產出的 passport.yaml 帶進你的 ARS session
-#    （實際 invocation 視你跑哪個 skill 而定 — 詳見 scripts/adapters/README.md）
+# 3. Pass the resulting passport.yaml into your ARS session
+#    (concrete invocation depends on which skill you're running — see scripts/adapters/README.md)
 ```
 
 每個 adapter 產兩個檔案：`passport.yaml`（Schema 9，已填 `literature_corpus[]`）與 `rejection_log.yaml`（永遠輸出，無 rejection 時為空，採 categorical reason 封閉 enum）。Reference 之外的語料來源預期由使用者自行撰寫 adapter，遵循 [`academic-pipeline/references/adapters/overview.md`](../academic-pipeline/references/adapters/overview.md)。
 
-v3.6.5 接上 `bibliography_agent`（deep-research, Phase 1）與 `literature_strategist_agent`（academic-paper, Phase 1）作為 consumer — 兩者在 passport 帶非空 corpus 且解析成功時走 corpus-first / search-fills-gap flow。完整 consumer 協定見 [`academic-pipeline/references/literature_corpus_consumers.md`](../academic-pipeline/references/literature_corpus_consumers.md)。
+v3.6.5 接上 `bibliography_agent`（deep-research, Phase 1）與 `literature_strategist_agent`（academic-paper, Phase 1）作為 consumer。兩者在 passport 帶非空 corpus 且解析成功時走 corpus-first / search-fills-gap flow。完整 consumer 協定見 [`academic-pipeline/references/literature_corpus_consumers.md`](../academic-pipeline/references/literature_corpus_consumers.md)。
 
 ## 選用環境變數（v3.5.1+）
 
@@ -121,7 +121,7 @@ ARS 暴露若干 opt-in flag，全部預設 OFF；設定後僅影響當前 sessi
 | Flag | 起始版本 | 作用 | 參考 |
 |---|---|---|---|
 | `ARS_CROSS_MODEL` | v3.0 | 啟用跨模型驗證（見下節） | [§「跨模型驗證」](#跨模型驗證選用) |
-| `ARS_SOCRATIC_READING_PROBE=1` | v3.5.1 | 啟用 `socratic_mentor_agent` 的讀書檢查 probe layer。僅 goal-oriented intent；user 引用過具體論文時最多觸發一次；婉拒不留紀錄懲罰。 | `deep-research/agents/socratic_mentor_agent.md` |
+| `ARS_SOCRATIC_READING_PROBE=1` | v3.5.1 | 啟用 `socratic_mentor_agent` 的讀書檢查 probe layer。僅 goal-oriented intent；使用者引用過具體論文時最多觸發一次；婉拒不留紀錄懲罰。 | `deep-research/agents/socratic_mentor_agent.md` |
 | `ARS_PASSPORT_RESET=1` | v3.6.3 | 把每個 FULL checkpoint 提升為 context 重置邊界。**emit** boundary entry 必須設此 flag；新 session 用 `resume_from_passport=<hash>` 續跑**不需要** flag。`systematic-review` 模式下 flag ON 時，每個 FULL checkpoint 一律強制重置。 | `academic-pipeline/references/passport_as_reset_boundary.md` |
 | `ARS_CROSS_MODEL_SAMPLE_INTERVAL` | v3.5.0 | 跨模型完整性抽查的取樣間隔（advisory） | `shared/cross_model_verification.md` |
 
@@ -129,63 +129,95 @@ ARS 暴露若干 opt-in flag，全部預設 OFF；設定後僅影響當前 sessi
 
 ## 跨模型驗證（選用）
 
-ARS 使用 Claude Opus 4.7 即可完整運作。想要更高信心，可選擇啟用第二 AI 模型獨立驗證。
+ARS 使用 Claude Opus 4.7 即可完整運作。想要更高信心，可選擇啟用第二 AI 模型來獨立驗證完整性檢查，並挑戰魔鬼代言人。
 
 ### 快速設定
 
 ```bash
-# 設定 API key（擇一或兩者皆設）
-export OPENAI_API_KEY="sk-your-key-here"        # GPT-5.4 Pro
-export GOOGLE_AI_API_KEY="AIza-your-key-here"    # Gemini 3.1 Pro
+# Step 1: Set your API key (choose one or both)
+export OPENAI_API_KEY="sk-your-key-here"        # For GPT-5.4 Pro
+export GOOGLE_AI_API_KEY="AIza-your-key-here"    # For Gemini 3.1 Pro
 
-# 選擇跨驗證模型
-export ARS_CROSS_MODEL="gpt-5.4-pro"
-# 或：export ARS_CROSS_MODEL="gemini-3.1-pro-preview"
+# Step 2: Choose your cross-verification model
+export ARS_CROSS_MODEL="gpt-5.4-pro"            # Best reasoning
+# or: export ARS_CROSS_MODEL="gemini-3.1-pro-preview"  # Strong at factual verification
 
-# 照常啟動 Claude Code — 跨驗證會自動啟用
+# Step 3: Run Claude Code as normal — cross-verification activates automatically
 claude
 ```
 
 ### 啟用後的差異
 
-| 功能 | 未啟用 | 啟用後 |
+| 功能 | 未啟用跨模型 | 啟用跨模型 |
 |---|---|---|
-| 誠信驗證 | 單模型 100% 檢查 | + 30% 樣本由第二模型獨立驗證 |
-| 魔鬼代言人 | 單模型 DA | + 跨模型獨立 critique，新發現自動加入 |
-| 同儕審查 | 5 位審稿人（同模型） | + 來自第二模型的獨立 DA critique / calibration |
+| 完整性驗證 | 單模型 100% 檢查 | + 30% 樣本由第二模型獨立驗證 |
+| 魔鬼代言人 | 單模型 DA | + 跨模型產生獨立 critique，新發現自動加入 |
+| 同儕審查 | 5 位審稿人（同模型） | 同樣 5 位審稿人 + 跨模型 DA critique / calibration 支援 |
 
 ### 費用
 
-完整 pipeline 會增加 ~$0.60-1.10 的跨模型 API 費用（GPT-5.4 Pro 定價）。詳細拆解見 [`shared/cross_model_verification.md`](../shared/cross_model_verification.md)。
+完整 pipeline 會增加約 $0.60-1.10 的跨模型 API 費用（GPT-5.4 Pro 定價）。詳細拆解見 [`shared/cross_model_verification.md`](../shared/cross_model_verification.md)。
 
 ### 沒有 API key？沒問題
 
-沒有設定 `ARS_CROSS_MODEL`？一切照舊運作，無任何額外開銷。
+沒有設定 `ARS_CROSS_MODEL` 時，一切照舊運作。跨模型功能不會出現，也不會增加任何額外開銷。
 
 ---
 
 ## 安裝方式
 
+Claude 會在 `<install-root>/<skill-name>/SKILL.md` 尋找 skills。這個 repo 包含四個獨立 skills，每個都有自己的 `SKILL.md`：
+
+- `deep-research`
+- `academic-paper`
+- `academic-paper-reviewer`
+- `academic-pipeline`
+
+不要把整個 repository 當成單一巢狀 skill 資料夾安裝到 `.claude/skills/academic-research-skills/`。那會讓四個 `SKILL.md` 比 Claude 可發現的位置多埋一層。請參考 Anthropic 的 [Claude Code Skills documentation](https://code.claude.com/docs/en/skills)。
+
 ### 方法一：作為專案 Skills（推薦）
 
-將此 repo clone 到專案的 `.claude/skills/` 目錄：
+當你希望 ARS 可在既有 Claude Code 專案內使用時，請用此方式。
+
+先將 repo clone 到穩定的本機路徑，再把每個 skill 資料夾複製到專案的 `.claude/skills/` 目錄：
 
 ```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
 cd /path/to/your/project
 mkdir -p .claude/skills
-git clone https://github.com/Imbad0202/academic-research-skills.git .claude/skills/academic-research-skills
+cp -R ~/academic-research-skills/deep-research .claude/skills/deep-research
+cp -R ~/academic-research-skills/academic-paper .claude/skills/academic-paper
+cp -R ~/academic-research-skills/academic-paper-reviewer .claude/skills/academic-paper-reviewer
+cp -R ~/academic-research-skills/academic-pipeline .claude/skills/academic-pipeline
+```
+
+預期路徑形狀：
+
+```text
+/path/to/your/project/.claude/skills/deep-research/SKILL.md
+/path/to/your/project/.claude/skills/academic-paper/SKILL.md
+/path/to/your/project/.claude/skills/academic-paper-reviewer/SKILL.md
+/path/to/your/project/.claude/skills/academic-pipeline/SKILL.md
 ```
 
 接著將 `.claude/CLAUDE.md` 的內容複製到你專案的 `.claude/CLAUDE.md`（若已有則合併）。
 
-> **全域安裝：** 若希望所有專案都能使用這些 skills，可安裝到 `~/.claude/skills/`：
+> **全域 Claude Code 安裝：** 若希望所有 Claude Code 專案都能使用這些 skills，請改安裝四個資料夾到 `~/.claude/skills/`：
 >
 > ```bash
+> git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+>
 > mkdir -p ~/.claude/skills
-> git clone https://github.com/Imbad0202/academic-research-skills.git ~/.claude/skills/academic-research-skills
+> cp -R ~/academic-research-skills/deep-research ~/.claude/skills/deep-research
+> cp -R ~/academic-research-skills/academic-paper ~/.claude/skills/academic-paper
+> cp -R ~/academic-research-skills/academic-paper-reviewer ~/.claude/skills/academic-paper-reviewer
+> cp -R ~/academic-research-skills/academic-pipeline ~/.claude/skills/academic-pipeline
 > ```
 
 ### 方法二：作為獨立專案
+
+當你想直接在 ARS repository 內工作時，請用此方式。
 
 ```bash
 git clone https://github.com/Imbad0202/academic-research-skills.git
@@ -194,71 +226,173 @@ claude
 ```
 
 <details>
-<summary><strong>沒有安裝 Git？</strong>直接下載 ZIP</summary>
+<summary><strong>沒有安裝 Git？</strong>改下載 ZIP</summary>
 
 1. 前往 <https://github.com/Imbad0202/academic-research-skills>
 2. 點擊綠色 **Code** 按鈕 → **Download ZIP**
-3. 解壓縮到你想要的位置
-4. 方法一：將解壓後的資料夾移動到你專案內的 `.claude/skills/academic-research-skills`
+3. 解壓縮 ZIP 到你想要的位置
+4. 方法一：將解壓後的四個 skill 資料夾（`deep-research`、`academic-paper`、`academic-paper-reviewer`、`academic-pipeline`）複製到你專案內的 `.claude/skills/`
 5. 獨立使用：在解壓後的資料夾中開啟終端機，執行 `claude`
 
 </details>
 
 ### 方法三：Claude Cowork（桌面版）
 
-在 [Claude Cowork](https://claude.com/product/cowork) 中使用這些 skills — Claude Desktop 的 AI 自主工作區。
+當你想在 [Claude Cowork](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork) 使用四個 ARS skills 時，請用此方式。Cowork 是 Claude Desktop 的 agentic workspace。
 
-**選項 A：資料夾存取（最快）**
+Cowork 使用相同的 skill 資料夾形狀：`~/.claude/skills/<skill-name>/SKILL.md`。
 
-1. 將此 repo clone 到本機：
-   ```bash
-   git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
-   ```
-2. 開啟 Claude Desktop → 點擊上方 **Cowork** 分頁
-3. 選擇 clone 下來的 `academic-research-skills` 資料夾作為工作目錄
-4. Claude 會自動從 `SKILL.md` 偵測並載入 skills
+#### 前置需求
 
-**選項 B：作為專案 Skills**
+- macOS 或 Windows 的最新版 Claude Desktop。請從 Anthropic 的 [Claude Desktop page](https://claude.ai/download) 下載。
+- 可用的網路連線；Cowork tasks 會呼叫 Anthropic API。
+- Cowork tasks 執行時，請保持 Claude Desktop 開啟。Cowork 在 Desktop process 內執行。
+- Cowork 對 project folder 需有可讀寫的資料夾與檔案權限。
+- 具備 Cowork 存取權的付費方案。目前方案可用性請參考 Anthropic 的 [Cowork requirements](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork)。
+- Team 或 Enterprise 方案中，組織管理員可能停用了 Skills、plugins、connectors 或 egress。若重啟後已安裝 skills 仍未註冊，請管理員檢查組織層級設定。
 
-若你已有 Cowork 專案資料夾：
+#### 選項 A：symlink 安裝（最快，單機使用）
+
+如果你只在一台機器上工作，且希望日後透過 pull repo 更新，請使用 symlinks。
 
 ```bash
-cd /path/to/your/project
-mkdir -p .claude/skills
-git clone https://github.com/Imbad0202/academic-research-skills.git .claude/skills/academic-research-skills
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
+mkdir -p ~/.claude/skills
+cd ~/.claude/skills
+ln -s ~/academic-research-skills/deep-research deep-research
+ln -s ~/academic-research-skills/academic-paper academic-paper
+ln -s ~/academic-research-skills/academic-paper-reviewer academic-paper-reviewer
+ln -s ~/academic-research-skills/academic-pipeline academic-pipeline
 ```
 
-Skills 會在對話相關時自動載入 — 例如說「幫我寫論文」會觸發 `academic-paper`。
+預期路徑形狀：
 
-**需求：** Claude Desktop（最新版本）且已啟用 Cowork；付費方案（Pro、Max、Team 或 Enterprise）。
+```text
+~/.claude/skills/deep-research/SKILL.md
+~/.claude/skills/academic-paper/SKILL.md
+~/.claude/skills/academic-paper-reviewer/SKILL.md
+~/.claude/skills/academic-pipeline/SKILL.md
+```
+
+如果你透過雲端資料夾在多台機器之間同步 `~/.claude/skills`，請改用選項 B。絕對路徑 symlinks 可能在新的 checkout 或另一台機器上失效。
+
+#### 選項 B：copy 安裝（跨機器安全，不會自動更新）
+
+如果你在多台機器之間同步 `~/.claude/skills`，或不想使用 symlinks，請使用 copies。更新時需要重新執行四個 `cp -R` 指令。
+
+```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+
+mkdir -p ~/.claude/skills
+cp -R ~/academic-research-skills/deep-research ~/.claude/skills/deep-research
+cp -R ~/academic-research-skills/academic-paper ~/.claude/skills/academic-paper
+cp -R ~/academic-research-skills/academic-paper-reviewer ~/.claude/skills/academic-paper-reviewer
+cp -R ~/academic-research-skills/academic-pipeline ~/.claude/skills/academic-pipeline
+```
+
+預期路徑形狀：
+
+```text
+~/.claude/skills/deep-research/SKILL.md
+~/.claude/skills/academic-paper/SKILL.md
+~/.claude/skills/academic-paper-reviewer/SKILL.md
+~/.claude/skills/academic-pipeline/SKILL.md
+```
+
+#### 建立或開啟 Cowork Project
+
+標準 UI 操作流程請參考 Anthropic 的 [Organize your tasks with Projects in Claude Cowork](https://support.claude.com/en/articles/14116274-organize-your-tasks-with-projects-in-claude-cowork)。
+
+1. 開啟 Claude Desktop。
+2. 使用模式選擇器（**Chat / Cowork**），切換到 **Cowork**。
+3. 在 **Tasks** 中使用左側導覽面板，選擇 **Use an existing folder**（使用既有資料夾）。
+4. 選取你希望 Cowork 在其中工作的本機資料夾。這會建立一個指向該資料夾的 Cowork Project。
+5. 安裝或更新 skill 資料夾後，請重啟 Cowork，讓四個 skills 註冊。
+
+#### Cowork 如何呼叫 skills
+
+Claude 會使用每個 skill 的 `description` 判斷相關性，方式如 Anthropic 的 [Skills documentation](https://code.claude.com/docs/en/skills) 所述。例如 "help me write a paper" 這類句子只是示例，不是必須逐字輸入的 trigger phrase；改寫後的意圖也能運作。
+
+若 description-based routing 沒有選到你想用的 skill，Cowork 也提供 Anthropic 的 [Cowork plugins documentation](https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork) 中說明的顯式 UI 入口：
+
+- 在 Cowork Task 中輸入 `/`，使用 command palette 並選取可用 skill。
+- 使用 `+` capability picker，把 skill 加入目前 Task。
 
 ### 方法四：使用 claude.ai（網頁版）
 
-透過 [claude.ai](https://claude.ai) 的 **Project** 功能搭配 GitHub 整合，即可使用這些 skills，不需要安裝 Claude Code。
+claude.ai 有兩種不同方式可以使用這個 repository。兩者並不等價：
 
-1. 登入 [claude.ai](https://claude.ai)（需付費方案）
-2. 建立新 Project：**Projects** → **Create Project**
-3. 從 GitHub 匯入：在 Project 中，點擊 **Files** → **+** → **GitHub** → 選擇 `Imbad0202/academic-research-skills`
+- **方法 4a** 會上傳真正的 Custom Skills。這是標準 claude.ai Skill 安裝路徑，支援自動載入與 skill routing。
+- **方法 4b** 透過 GitHub integration 將 repository 檔案加入 Project 知識庫。這是備援知識模式，不是 Skill 安裝。
 
-   **建議勾選項目**（以控制在容量限制內）：
+#### 前置需求
 
-   | 勾選 | 目錄 | 說明 |
+- 付費 claude.ai 方案。目前方案資訊請見 [claude.ai](https://claude.ai)。
+- 方法 4a 不需要 GitHub 驗證。你要在本機將每個 skill 資料夾各自壓成 zip，再透過 **Settings** → **Capabilities** → **Skills**（設定 → 功能 → Skills）逐一上傳。Zip 結構錯誤與 200 字元 `description` 上限會在上傳時顯示錯誤；請參考 Anthropic 的 [Custom Skills packaging documentation](https://claude.com/docs/skills/how-to)。
+- 方法 4b 需要透過 Anthropic connector 進行 GitHub 驗證。請參考 [Using the GitHub integration](https://support.claude.com/en/articles/10167454-using-the-github-integration) 與 [Set up Claude integrations](https://support.claude.com/en/articles/10168395-set-up-claude-integrations)。Private repositories 需要在 repo 或 organization 上授權 Anthropic GitHub App。Team 與 Enterprise 方案則需要 owner 層級先啟用 connector，使用者才能加入 GitHub 來源的檔案。
+
+#### 方法 4a：Custom Skill upload（claude.ai 的標準 Skill 安裝路徑）
+
+這是 claude.ai 真正的 Skill 安裝路徑。透過 **Settings** → **Capabilities** → **Skills**（設定 → 功能 → Skills）上傳，每個 skill 各一個 zip。
+
+每個 zip 都必須把 skill 資料夾放在最上層，所以 zip 內容應包含 `<skill-name>/SKILL.md`，而不是 `<skill-name>/<skill-name>/SKILL.md`。
+
+```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git
+cd academic-research-skills
+
+zip -r deep-research.zip deep-research
+zip -r academic-paper.zip academic-paper
+zip -r academic-paper-reviewer.zip academic-paper-reviewer
+zip -r academic-pipeline.zip academic-pipeline
+```
+
+接著上傳：
+
+1. 登入 [claude.ai](https://claude.ai)。
+2. 開啟 **Settings**。
+3. 開啟 **Capabilities**。
+4. 開啟 **Skills**。
+5. 上傳 `deep-research.zip`。
+6. 上傳 `academic-paper.zip`。
+7. 上傳 `academic-paper-reviewer.zip`。
+8. 上傳 `academic-pipeline.zip`。
+
+v3.6.5.1 目前的 blocker：這個 repo 中四個 skill 的 `description` 欄位目前超過 200 字元上限，會被 upload UI 拒絕。Description trim 會在後續 patch（v3.6.5.2）推出。此處先記錄正確安裝方式；在 v3.6.5.2 發布前，請優先使用方法一、方法二或方法三。
+
+#### 方法 4b：Project + GitHub integration（備援知識模式，不是 Skill 安裝）
+
+claude.ai Projects 會將內容作為靜態知識提供給 Claude 擷取與引用。請參考 Anthropic 的 [What are Projects?](https://support.claude.com/en/articles/9517075-what-are-projects)。這不是 Skill 安裝。Skill 不會自動載入，trigger phrases 不會路由。Claude 可以讀取 repo 內容，但不會把 skills 當成 agentic workflows 執行。
+
+當你希望 claude.ai 能存取 repo 內容以便閱讀或引用，但不需要 agentic skill execution 時，請使用此方式。
+
+1. 登入 [claude.ai](https://claude.ai)。
+2. 建立新 Project：**Projects** → **Create Project**。
+3. 從 GitHub 匯入：在 Project 中，點擊 **Files** → **+** → **GitHub** → 選擇 `Imbad0202/academic-research-skills`。
+4. 選取以下資料夾與檔案。
+
+   | 選取 | 目錄 / 檔案 | 原因 |
    |---|---|---|
-   | ✅ | `.claude/` | 路由規則 |
-   | ✅ | `deep-research/` | 核心 skill |
-   | ✅ | `academic-paper/` | 核心 skill |
-   | ✅ | `academic-paper-reviewer/` | 核心 skill |
-   | ✅ | `academic-pipeline/` | 核心 skill |
-   | ✅ | `shared/` | 跨模型驗證、handoff schema |
-   | ✅ | `MODE_REGISTRY.md` | Mode 定義 |
-   | ❌ | `examples/` | 佔約 39% 容量，空間不足時可跳過 |
-   | ❌ | `.github/`、README、LICENSE 等 | 功能運行不需要 |
+   | ✅ | `deep-research/` | 核心 skill 內容，可供閱讀 |
+   | ✅ | `academic-paper/` | 核心 skill 內容，可供閱讀 |
+   | ✅ | `academic-paper-reviewer/` | 核心 skill 內容，可供閱讀 |
+   | ✅ | `academic-pipeline/` | 核心 skill 內容，可供閱讀 |
+   | ✅ | `shared/` | 跨模型驗證、handoff schemas、共用 protocols |
+   | ✅ | `scripts/` | `literature_corpus[]` adapters（`folder_scan`、`zotero`、`obsidian`）與 schema validators；Material Passport corpus mode 與 CI-style validation 需要 |
+   | ✅ | `MODE_REGISTRY.md` | Mode definitions |
+   | Optional | `.claude/` | Project-level routing rules。若你在下方步驟 5 設定 Project Instructions，建議跳過；只有在你偏好把 routing rules 作為 Project files 顯示時才納入。 |
+   | Optional | `examples/` | 可作為參考範例；若想縮小 Project 知識庫，請跳過 |
+   | Optional | `.github/`、READMEs、LICENSE 等 | Repository metadata；核心閱讀 context 不需要 |
 
-4. （選用）將 `.claude/CLAUDE.md` 的內容貼入 Project 的 **Instructions**，以獲得更好的路由效果
-5. 開始對話：「引導我研究 X」或「幫我寫一篇關於 Y 的論文」
+5. （建議）將 `.claude/CLAUDE.md` 的內容設為 Project 的 **Instructions**，以獲得更好的 routing。
+6. 開始對話："Guide my research on X" 或 "Help me write a paper about Y"。
+
+Anthropic 目前的 [Project file limits](https://support.claude.com/en/articles/8241126-upload-files-to-claude) 說明：Project 並未刻意設定 200 檔上限，但每個檔案有 30 MB 大小限制，總可用內容仍受 runtime context-window 影響。請讓 Project 保持聚焦，Claude 才能穩定擷取相關檔案。
 
 **claude.ai 與 Claude Code 的差異：**
 
-- claude.ai 不支援多 agent 平行執行和 shell 指令，效果可能不如 Claude Code 完整
-- 跨模型驗證（`ARS_CROSS_MODEL`）需要 Claude Code + API key
-- 直接產出 `.docx` 需要 Pandoc，PDF 需要 `tectonic`；claude.ai 仍可產出 Markdown 與 DOCX 轉換說明
+- 方法 4b 用於內容閱讀，不是主動 Skill execution。若需要 agentic skill execution，請優先使用方法一、方法二、方法三，或在 v3.6.5.2 之後使用方法 4a。
+- claude.ai 不支援本機 shell commands；結果可能不如依賴本機 scripts 的 Claude Code workflows 完整。
+- 跨模型驗證（`ARS_CROSS_MODEL`）需要 Claude Code 與 API keys。
+- 直接產出 `.docx` 需要 Pandoc，LaTeX/PDF 輸出需要 Claude Code 搭配 `tectonic`；claude.ai 仍可產出 Markdown 與 DOCX 轉換說明。

--- a/docs/design/2026-04-27-ars-v3.6.5.1-setup-fix-implementation-brief.md
+++ b/docs/design/2026-04-27-ars-v3.6.5.1-setup-fix-implementation-brief.md
@@ -1,0 +1,375 @@
+# ARS v3.6.5.1 — SETUP.md Doc Correctness Fix — Implementation Brief
+
+**Date**: 2026-04-27
+**Target release**: v3.6.5.1 (patch, doc-only)
+**Branch**: `hotfix/v3.6.5.1-setup-doc-correctness`
+**Trigger**: GitHub issue #44 (philpav, 2026-04-27) + local Codex audit on `docs/SETUP.md`
+**Author**: Cheng-I Wu
+
+---
+
+## Purpose of this document
+
+This brief is the **non-negotiable constraint sheet** for the SETUP.md rewrite. It is given to Codex (or any drafter) so that the prose it produces respects ARS-specific invariants without re-deriving them. Without this brief, the drafter will likely:
+
+- Misname skill folders or invent new directory structures
+- Decide release semver / version bump on its own (not its call)
+- Drift terminology away from existing repo conventions
+- Skip the version sweep checklist
+- Forget that this is a public repo with a Ruleset that blocks direct main commits
+
+**This brief does not write the SETUP.md content itself.** It defines what content must achieve, what conventions it must follow, and what is out of bounds.
+
+---
+
+## §1 — Non-negotiable invariants
+
+The drafter MUST follow these. Deviation requires a separate human decision, not a unilateral drafter call.
+
+### 1.1 Skill folder structure
+
+The repo has exactly **four skill folders** at the root, each with its own `SKILL.md`:
+
+```
+academic-research-skills/
+├── deep-research/SKILL.md
+├── academic-paper/SKILL.md
+├── academic-paper-reviewer/SKILL.md
+└── academic-pipeline/SKILL.md
+```
+
+There is **no root `SKILL.md`**. There is no plan to create one. Any install method that requires a single `SKILL.md` at the install path must install each skill folder separately, not the whole repo.
+
+### 1.2 Skill discovery rule (Claude Code, Cowork, claude.ai upload)
+
+The discovery convention all three platforms share is:
+
+```
+<install-root>/<skill-name>/SKILL.md
+```
+
+For Claude Code project skills: `<project>/.claude/skills/<skill-name>/SKILL.md`.
+For Cowork: `~/.claude/skills/<skill-name>/SKILL.md`.
+For claude.ai upload: each skill is uploaded as one zip, where the zip's top-level entry is `<skill-name>/SKILL.md` (not `<skill-name>/<skill-name>/SKILL.md`).
+
+Any install instruction that produces `<install-root>/academic-research-skills/<skill-name>/SKILL.md` (extra nesting level) is broken — Cowork / Claude Code / claude.ai will not discover the skill.
+
+### 1.3 Method 4 (claude.ai) is two distinct sub-methods
+
+**Sub-method 4a**: Real Skill upload via Settings → Capabilities → Skills, one zip per skill. This is the path that gives skill auto-loading and trigger phrase routing. Currently blocked by the 200-char description cap (fixed in v3.6.5.2, NOT v3.6.5.1).
+
+**Sub-method 4b**: Project + GitHub integration loads files into Project knowledge (static retrieval context). This is NOT a Skill install — Claude can read the files but does not execute them as agentic skills.
+
+The SETUP.md must distinguish these two clearly. 4a is the "real" install; 4b is fallback knowledge mode. Do not conflate.
+
+### 1.4 Public repo, Ruleset-protected main
+
+`Imbad0202/academic-research-skills` is a public repo with branch protection that blocks direct commits to main (GH013). All changes must go via PR. The drafter does not commit directly. The drafter does not invent its own branch name; the branch is `hotfix/v3.6.5.1-setup-doc-correctness` (already created by human).
+
+### 1.5 Authoritative sources for terminology
+
+When in doubt about Cowork / claude.ai UI terminology, prefer (in order):
+
+1. **Anthropic official docs** (highest authority — these are the upstream truth):
+   - Claude Code Skills paths and discovery: https://code.claude.com/docs/en/skills
+   - Custom Skills packaging (incl. ≤200-char description cap): https://claude.com/docs/skills/how-to
+   - Cowork getting started + requirements: https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork
+   - Cowork Projects (left nav, "Use an existing folder"): https://support.claude.com/en/articles/14116274-organize-your-tasks-with-projects-in-claude-cowork
+   - Cowork Skills via plugins (`/` and `+` UI surface): https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork
+   - Projects (claude.ai static knowledge): https://support.claude.com/en/articles/9517075-what-are-projects
+   - GitHub integration (auth, private-repo App, Team/Enterprise enablement): https://support.claude.com/en/articles/10167454-using-the-github-integration
+   - Connectors setup (Team/Enterprise owner enablement): https://support.claude.com/en/articles/10168395-set-up-claude-integrations
+   - Project file limits (per-file 30 MB, count unlimited): https://support.claude.com/en/articles/8241126-upload-files-to-claude
+
+2. **Issue #44 reply (already vetted UI wording, inlined below for self-contained reference):**
+
+   > Cowork install — symlink approach the user already validated:
+   > ```bash
+   > git clone https://github.com/Imbad0202/academic-research-skills.git ~/academic-research-skills
+   > mkdir -p ~/.claude/skills
+   > cd ~/.claude/skills
+   > ln -s ~/academic-research-skills/deep-research deep-research
+   > ln -s ~/academic-research-skills/academic-paper academic-paper
+   > ln -s ~/academic-research-skills/academic-paper-reviewer academic-paper-reviewer
+   > ln -s ~/academic-research-skills/academic-pipeline academic-pipeline
+   > ```
+   > "Restart Cowork and the four skills should register."
+   >
+   > claude.ai distinction (verbatim phrasing the user used):
+   > "the GitHub integration loads files into Project knowledge, not Skills. Real Skill upload needs each skill zipped separately via Settings → Capabilities → Skills, and descriptions in this repo currently exceed the 200-char limit so they'd reject."
+
+3. **Existing `docs/SETUP.md` text** — only for parts the audit (§2 below) did not flag as drifted. Do not lift wording from sections F1-F7 covered by this brief.
+
+Never invent a UI term. Never paraphrase a UI label as a "more readable" alternative — the literal label is what the user clicks. When Anthropic doc and issue #44 reply disagree on a UI label, Anthropic doc wins (it is the upstream truth as of the doc's last-updated date).
+
+### 1.6 Out of bounds (do not touch)
+
+The drafter must NOT modify these as part of v3.6.5.1:
+
+- Any `SKILL.md` (description, frontmatter, body) — those are v3.6.5.2 scope
+- Any agent file under `*/agents/`
+- Any schema under `shared/`
+- Any script under `scripts/`
+- Any test under `tests/`
+- The branch protection / Ruleset config
+- The CHANGELOG section ordering or version numbering convention (just append a new v3.6.5.1 entry above v3.6.5)
+
+The drafter MAY modify (within v3.6.5.1 scope) — this list is the **complete allowed-edit set**:
+
+- `docs/SETUP.md` (primary work)
+- `docs/SETUP.zh-TW.md` if it exists (mirror EN changes)
+- `README.md` and `README.zh-TW.md` install method sections (sweep, only if they mention Cowork or claude.ai install)
+- `.claude/CLAUDE.md` install-related sections (sweep, only if drifted from v3.6.5.1)
+- `QUICKSTART.md` install-related sections (sweep, only if drifted)
+- `CHANGELOG.md` (add v3.6.5.1 entry)
+
+**Sweep vs edit boundary** (resolves apparent conflict with §4): the §4 sweep grep MAY scan a broader path (e.g. all of `docs/`) to find install-method mentions, but the drafter MAY edit only the files in the allowed-edit set above. Hits outside the allowed-edit set are **report-only**: list them in the validation report for human review, do not auto-edit. Touching files outside the allowed-edit set requires explicit human approval (out of v3.6.5.1 scope).
+
+The drafter does NOT decide:
+
+- Whether v3.6.5.1 ships as a tag, a release, or just a merge — that is the user's call
+- Whether the issue #44 follow-up comment goes out at v3.6.5.1 or v3.6.5.2 — already decided (deferred to v3.6.5.2 per ROADMAP)
+- Whether SKILL.md description trim is in this patch — already decided NO (v3.6.5.2)
+
+---
+
+## §2 — Findings to fix in v3.6.5.1
+
+Source: local Codex audit on `docs/SETUP.md` 2026-04-27.
+
+### F1 (P0) — `docs/SETUP.md:213-229` Method 3 wrong path
+
+**Problem**: Current Option A says clone repo to `.claude/skills/academic-research-skills/`. This produces:
+
+```
+.claude/skills/academic-research-skills/deep-research/SKILL.md   ← buried, not discovered
+```
+
+instead of the required:
+
+```
+.claude/skills/deep-research/SKILL.md   ← Cowork finds this
+```
+
+Same problem in Option B if it follows the same pattern.
+
+**Authoritative source**: Claude Code Skills paths and discovery convention — https://code.claude.com/docs/en/skills
+
+**Fix**: Rewrite Option A and Option B to install each of the four skill folders separately into `.claude/skills/`. Two acceptable approaches:
+
+- **Option A — symlink (fastest, single-machine)**: `git clone` repo to a stable path (e.g. `~/academic-research-skills`), then `ln -s <repo>/<skill-name> ~/.claude/skills/<skill-name>` for each of the four skills. Must include a caveat: if the user syncs `~/.claude/skills` across machines via cloud folders, prefer `cp -R` because absolute-path symlinks break on a fresh checkout (this is a real ARS lesson from `feedback_relative_symlinks_in_repos.md`).
+- **Option B — copy (cross-machine safe, no auto-update)**: `git clone` repo, then `cp -R <repo>/<skill-name> ~/.claude/skills/<skill-name>` for each of the four skills. Note that updates require re-running cp.
+
+The four skill folder names are exact: `deep-research`, `academic-paper`, `academic-paper-reviewer`, `academic-pipeline`. Use bash code blocks with explicit per-skill commands.
+
+**Hard rule on consolidation** (resolves apparent conflict with §8 drafter judgement zone): the drafter MAY consolidate Option A and Option B into a single section if it improves readability, BUT every final command must name all four skill folders explicitly. No `for skill in ...` loop, no parameterised one-liner, no "repeat for each skill" instruction without showing each command. Reason: readers copy-paste in a hurry and skip iteration syntax; explicit four-line blocks have ~zero misuse rate.
+
+### F2 (P0) — `docs/SETUP.md:237` Method 4 conceptually wrong
+
+**Problem**: Current text says "use these skills on claude.ai via the Project feature with GitHub integration". This frames GitHub integration as a Skill install path. It is not — GitHub integration loads files into Project knowledge (static retrieval context), not the Skills system. Skill auto-loading and trigger phrase routing do not happen via this method.
+
+**Authoritative sources**:
+- Projects (claude.ai static knowledge): https://support.claude.com/en/articles/9517075-what-are-projects
+- GitHub integration: https://support.claude.com/en/articles/10167454-using-the-github-integration
+- Custom Skills packaging (zip per skill, ≤200-char description): https://claude.com/docs/skills/how-to
+
+**Fix**: Restructure Method 4 into two clearly labelled sub-methods. Use neutral framing — neither is "recommended" right now (4a is blocked on v3.6.5.2; 4b is documented-but-limited):
+
+- **Method 4a — Custom Skill upload (claude.ai's standard Skill install path)**: Settings → Capabilities → Skills, upload one zip per skill (the zip's top-level entry must be `<skill-name>/SKILL.md`, matching the `name` field in the skill's frontmatter). **State the current blocker explicitly**: the four skill `description` fields in this repo currently exceed the 200-char cap and would be rejected by the upload UI; the description trim ships in patch v3.6.5.2 immediately after this v3.6.5.1 doc patch. The path is documented here so the install instructions are correct in advance; until v3.6.5.2 ships, prefer Methods 1, 2, or 3.
+- **Method 4b — Project + GitHub integration (fallback knowledge mode, not a Skill install)**: GitHub integration loads files into Project knowledge for retrieval. **Explicitly state**: "this is NOT a Skill install. Skill auto-loading does not happen. Trigger phrases do not route. Claude can read the repo content but does not execute the skills as agentic workflows. Useful when you want claude.ai to have access to the repo content for reading/citation but you do not need agentic skill execution."
+
+### F3 (P1) — `docs/SETUP.md:233` Method 3 prereqs missing
+
+**Problem**: Current line is one sentence: "Requirements: Claude Desktop (latest version) with Cowork enabled; paid plan."
+
+**Authoritative source**: Cowork getting started + requirements — https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork
+
+**Fix**: Expand into a `**Prerequisites**` subsection covering:
+
+- Claude Desktop latest version (macOS or Windows; link to Anthropic Desktop download page)
+- Active internet connection (Cowork tasks call Anthropic API)
+- Desktop app must remain open during Cowork task execution (Cowork runs inside the Desktop process)
+- Folder/file permissions: Cowork needs read/write access to the project working folder
+- Org-level controls: on Team or Enterprise plans, your org admin may have disabled Skills, plugins, connectors, or egress; if symlinks/skills do not register after restart, ask your admin
+- Paid plan: Pro, Max, Team, or Enterprise (cite the Cowork article above for current plan availability — do not paraphrase the plan list, link to it because Anthropic adjusts plan tiers)
+
+### F4 (P1) — `docs/SETUP.md:241` Method 4 prereqs missing
+
+**Problem**: Current line is one bullet: "1. Sign in to claude.ai (requires a paid plan)".
+
+**Authoritative sources**:
+- GitHub integration (auth, App authorization, Team/Enterprise enablement): https://support.claude.com/en/articles/10167454-using-the-github-integration
+- Connectors setup: https://support.claude.com/en/articles/10168395-set-up-claude-integrations
+- Custom Skills packaging (4a): https://claude.com/docs/skills/how-to
+
+**Fix**: Expand into a `**Prerequisites**` subsection (apply to both 4a and 4b where relevant) covering:
+
+- Paid plan (link to Anthropic plan page; do not paraphrase tier list)
+- **For Method 4a (Skill upload)**: no GitHub auth needed; zip each skill folder locally so the zip's top-level entry is `<skill-name>/SKILL.md`; upload via Settings → Capabilities → Skills. Note that zip structure errors and the 200-char description cap will surface as upload-time errors per the Custom Skills doc.
+- **For Method 4b (GitHub integration)**: GitHub authentication via the Anthropic connector (see Connectors setup link); private repos require the Anthropic GitHub App authorized on the repo or org; Team/Enterprise plans require owner-level connector enablement before users can add GitHub-sourced files.
+
+### F5 (P2) — `docs/SETUP.md:217-218` Cowork UI terminology drift
+
+**Problem**: Current text says: "click **Cowork** tab (top bar)" and refers to a "working directory". Both wrong against current Cowork UI.
+
+**Authoritative sources** (use the literal labels from these pages — do not paraphrase):
+- Cowork access (mode selector wording): https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork
+- Cowork Projects (left nav, "Use an existing folder", Cowork Project): https://support.claude.com/en/articles/14116274-organize-your-tasks-with-projects-in-claude-cowork
+
+**Fix**: Use current Cowork UI terms:
+
+- "mode selector (Chat / Cowork)" — the toggle between Claude's two modes
+- After switching to Cowork, the relevant view is **Tasks**
+- Left navigation panel offers "Use an existing folder" to create a Cowork Project pointing at a local folder
+- The folder is referred to as a **Cowork Project**, not "working directory"
+
+Walk the reader through each click using the literal current UI labels from the linked Anthropic pages.
+
+### F6 (P2) — `docs/SETUP.md:231` Trigger phrase oversimplified
+
+**Problem**: Current text says skills are invoked "via trigger phrases". True but incomplete — Cowork now also surfaces installed plugin Skills via the `/` command palette and the `+` (add capability) visual UI. The audit also notes that "trigger phrase" is itself a slight overstatement: Claude uses the skill description to decide relevance, not literal trigger-phrase matching.
+
+**Authoritative sources**:
+- Skills invocation (Claude uses description for relevance, not literal trigger matching): https://code.claude.com/docs/en/skills
+- Cowork Skills via plugins (`/` and `+` UI): https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork
+
+**Fix**: List three discovery surfaces and correct the trigger-phrase framing:
+
+- Description-based relevance (the primary mechanism, per Claude Code Skills doc): Claude reads each skill's `description` and routes the user request to whichever skill it judges most relevant. The example phrases in the SETUP table are illustrative, not literal triggers.
+- `/` command palette in Cowork: type `/` and the four skills appear as completions for explicit invocation.
+- `+` capability picker in Cowork: visual UI to add a skill to the current Task.
+
+Reader should know that explicit `/` and `+` UI exist as a fallback when description-based routing does not pick the desired skill, and that paraphrased intent ("help me draft a paper") works equally well as the example phrases.
+
+### F7 (P2) — `docs/SETUP.md:243-255` Method 4 directory table omits `scripts/` + capacity outdated
+
+**Problem**: Current Method 4 directory table omits `scripts/`, but adapter and validator workflows live there and break without it. The audit also notes the section's capacity rationale references a 200-file cap that conflicts with current Anthropic Project limits (the audit team did not actually find the 200-file claim on line 235-264 — it may already have been removed in an earlier doc rev — but the surrounding capacity guidance is shaky and needs a refresh against current limits).
+
+**Authoritative source**: Project file limits (per-file 30 MB; file count unlimited subject to total content/context limits) — https://support.claude.com/en/articles/8241126-upload-files-to-claude
+
+**Fix**:
+
+- Add a `scripts/` row to the directory table with rationale "literature_corpus[] adapters (folder_scan, zotero, obsidian) + schema validators; required for Material Passport corpus mode and CI-style validation."
+- Rewrite the capacity section: state current Anthropic Project limits per the linked page (file count is not artificially capped at 200; per-file 30 MB; total subject to context-window limits at runtime). If the existing text still contains the 200-file claim, remove it; if it does not, just add the current-limits reference for clarity.
+- Keep the practical guidance "Method 4b is for content reading, not active Skill execution; if you need agentic skill execution, prefer Methods 1-3 or 4a (after v3.6.5.2)."
+
+---
+
+## §3 — Banner removal
+
+The hotfix branch already has banners on Method 3 and Method 4 (commit `d176578`). After the rewrite addresses F1-F7, the banners must come out. Their purpose was harm reduction during the patch interval; once the instructions are correct, the banners are noise.
+
+**Drafter responsibility**: prepare banner removal as part of the SETUP.md rewrite diff. The drafter does not commit (per §1.4 — public repo, drafter never commits directly). The human maintainer reviews the diff and decides whether banner removal goes in the same commit as the F1-F7 rewrite (atomic) or as a separate commit immediately after (cleaner history). Recommended commit message if separate: "remove banners superseded by v3.6.5.1 SETUP rewrite".
+
+---
+
+## §4 — Sweep checklist
+
+After SETUP.md is fixed, grep the rest of the repo for install-method mentions and align:
+
+```bash
+grep -rn -E "Cowork|claude\.ai|claude\.com/product/cowork|GitHub integration|\.claude/skills" \
+  README.md README.zh-TW.md QUICKSTART.md .claude/CLAUDE.md docs/ \
+  --exclude-dir=design
+```
+
+Any hit inside the §1.6 allowed-edit set that contradicts the v3.6.5.1 SETUP.md must be aligned. Hits outside the allowed-edit set are **report-only** per §1.6: list them in the validation report for human review, do not auto-edit. Files known to potentially need touch (verify; update only if drifted):
+
+- `README.md` — Quick Start / Installation section
+- `README.zh-TW.md` — same as English
+- `QUICKSTART.md` — if it exists and mentions Cowork or claude.ai
+- `.claude/CLAUDE.md` — Skills Overview table is unlikely to need changes (no install instructions there), but check
+- `docs/SETUP.zh-TW.md` — mirror EN changes if zh-TW exists (may or may not — check first)
+
+Files NOT to touch in v3.6.5.1: anything under `*/agents/`, `shared/`, `scripts/`, `tests/`, individual `SKILL.md` files.
+
+---
+
+## §5 — Validation gate
+
+Validation has two tiers: **required (filesystem path-shape)** and **optional (live discovery)**. Required must pass before opening PR; optional is documented when environment supports it, otherwise reported as "not validated in this run" without blocking ship.
+
+### 5.0 Environment protection (mandatory before any validation)
+
+The drafter / validator MUST NOT pollute the developer's real `~/.claude/skills` while validating instructions. Two acceptable approaches:
+
+- **Disposable HOME**: `tmpdir=$(mktemp -d)` then run validation steps with `HOME=$tmpdir`. Filesystem checks resolve against `$tmpdir/.claude/skills/`. Cleanup is `rm -rf $tmpdir` when done.
+- **Backup + restore**: `mv ~/.claude/skills ~/.claude/skills.backup-pre-v3.6.5.1-validation`, run validation, then `rm -rf ~/.claude/skills && mv ~/.claude/skills.backup-pre-v3.6.5.1-validation ~/.claude/skills` after. Riskier — if the validation step fails partway, the backup might not get restored. Disposable HOME is preferred.
+
+Document which approach was used in the validation report.
+
+### 5.1 Required: filesystem path-shape validation
+
+These steps verify that the corrected SETUP.md instructions produce the right paths on disk. They do NOT require Claude Desktop, Claude Code session, Cowork, or claude.ai access.
+
+For each install method below, run the exact commands from the v3.6.5.1 SETUP.md draft (no edits, no shortcuts) inside the protected environment from §5.0:
+
+1. **Method 1 (project skills)**: confirm `<project>/.claude/skills/deep-research/SKILL.md` exists at the expected path and is the file from the repo (not a placeholder). Repeat for the other three skills.
+2. **Method 3 Option A (symlink)**: confirm `~/.claude/skills/deep-research/SKILL.md` resolves (test with `test -f`, not `ls -L`, to follow symlinks). Confirm `readlink` shows the absolute path back to the cloned repo. Repeat for all four skills.
+3. **Method 3 Option B (copy)**: confirm `~/.claude/skills/deep-research/SKILL.md` exists, is a regular file (not symlink), and content matches `<repo>/deep-research/SKILL.md` (e.g. `diff` returns 0). Repeat for all four skills.
+
+All three must pass. If any path-shape check fails, the SETUP.md instructions are still wrong and the rewrite is not done.
+
+### 5.2 Optional: live discovery validation
+
+These steps verify that platforms actually discover the installed skills. Run them only when the corresponding platform is available; otherwise mark as "not validated in this run" in the validation report.
+
+4. **Method 1 live**: open Claude Code in the project directory, start a session, confirm the four skills appear in the available-skills list. (Available if Claude Code is installed locally.)
+5. **Method 3 live (Cowork)**: with the protected `$HOME` from §5.0 set as the active HOME for the Claude Desktop session, restart Claude Desktop, switch to Cowork mode, confirm the four skills appear under the `+` capability picker. (Available only if Claude Desktop is installed and Cowork is enabled on the account.)
+6. **Method 4a live**: zip one skill folder per the SETUP.md instructions, attempt upload via Settings → Capabilities → Skills. Expected outcome **before v3.6.5.2 ships**: rejection with a description-too-long error, which validates that the documented upload path is the right one and that v3.6.5.2 description trim is the correct unblocker.
+7. **Method 4b live**: connect a claude.ai Project to the GitHub repo per Method 4b instructions, confirm the file tree appears in Project knowledge and is selectable for Claude to read.
+
+### 5.3 Validation report format
+
+The validation report is a Markdown block included in the PR description (or attached as a file under `examples/v3.6.5.1-validation/` if it is large). Required content:
+
+- Which §5.0 environment-protection approach was used
+- For each of steps 1-3: PASS / FAIL with the exact command output that proves it
+- For each of steps 4-7: PASS / FAIL / NOT VALIDATED (reason: e.g. "no Claude Desktop on validation machine"). Marking "NOT VALIDATED" is acceptable for steps 4-7; it is not acceptable for steps 1-3.
+
+Open the PR only after steps 1-3 pass. Steps 4-7 results inform reviewers but do not block.
+
+---
+
+## §6 — Codex review iteration
+
+After the SETUP.md draft is complete (and sweep is done):
+
+1. Bundle the draft + this brief + the original audit findings into a single file.
+2. Run `codex exec --sandbox read-only` with a verification task: "Apply the v3.6.5.1 brief constraints; flag any deviation. Output severity-tagged findings."
+3. Iterate fixes; re-run Codex.
+
+**Ship gate** (refined from `feedback_codex_iterative_spec_review_to_zero.md` discipline for the doc-patch context):
+
+- **Zero P1 and zero P2 findings**: required. Every P1 and P2 finding must be fixed before ship. No "reject with rationale" path for P1/P2 — they are blockers by definition. If a Codex P1 or P2 is technically wrong (e.g. Codex misread the brief), the response is to clarify the brief or argue the finding back, not to declare it rejected and ship.
+- **P3 findings**: either fixed, OR accepted with one-line rationale in the PR description (e.g. "P3 wording preference declined: deviates from the user's vetted issue #44 phrasing"). P3 wording or stylistic findings should not block ship indefinitely; rejection-with-rationale is the P3-only escape hatch.
+- The "zero findings" phrasing was developed for high-blast-radius schema/contract spec (e.g. v3.6.2 sprint contract) where any drift could cascade through validators and runtime. SETUP.md is moderate blast radius (broken instructions harm new users but do not corrupt data); P3 acceptance is the correct trade-off here. P1/P2 are non-negotiable in both contexts.
+
+Reviewing prose against a brief is what Codex is good at; reviewing prose against vague stylistic preferences is not. Keep the brief as the contract. When Codex raises a P3 that the brief does not actually constrain, accept-with-rationale rather than re-engineering the brief mid-iteration.
+
+---
+
+## §7 — PR body template
+
+When opening the PR, the body should:
+
+- Reference issue #44 by URL
+- Summarise F1-F7 fixes (one line each)
+- Note that v3.6.5.2 (description trim) is the planned follow-up patch and that issue #44 close happens at v3.6.5.2 ship, not at this PR merge
+- Link to ROADMAP commit `eb240b4` for the patch sequencing decision
+- List validation steps performed (per §5)
+
+Do NOT reference internal terminology (e.g. "blast radius", "Codex second-opinion"). PR is public-facing.
+
+---
+
+## §8 — What this brief deliberately does not specify
+
+These are intentionally left to the drafter's judgement:
+
+- Exact section ordering inside SETUP.md (the drafter may reorganise for readability as long as F1-F7 are addressed)
+- Inline code formatting style (bash vs shell prompt syntax) as long as consistent within the doc
+- Word choice within the constraints of §1.5 authoritative sources
+- Whether to consolidate Method 3 Options A and B into a single set of commands with toggles, or keep them as separate options (drafter's call based on readability)
+
+These are explicitly delegated; no follow-up question needed.


### PR DESCRIPTION
## Summary

Doc-only patch fixing the SETUP problems reported in [#44](https://github.com/Imbad0202/academic-research-skills/issues/44). The four ARS skills were not registering on Cowork, and claude.ai install instructions conflated GitHub integration with real Skill upload.

## Fixes

- **F1** — `docs/SETUP.md` Method 3 Option A and Option B now install each of the four skill folders separately into `~/.claude/skills/<skill-name>/`, matching the `<install-root>/<skill-name>/SKILL.md` discovery convention. Previous text buried the four `SKILL.md` files under `~/.claude/skills/academic-research-skills/`, one level too deep for Cowork to discover.
- **F2** — Method 4 (claude.ai) split into two clearly labelled sub-methods. Method 4a is the standard claude.ai Skill install (Settings → Capabilities → Skills, one zip per skill, with auto-loading and routing). Method 4b is Project + GitHub integration (knowledge-mode retrieval, NOT a Skill install). Method 4a documents the current 200-character `description` cap blocker; the description trim ships in the follow-up patch v3.6.5.2.
- **F3** — Method 3 prerequisites expanded from one sentence to a full subsection covering Claude Desktop version, internet connectivity, the Cowork process model, folder permissions, paid-plan requirements, and Team/Enterprise org-admin controls.
- **F4** — Method 4 prerequisites split per sub-method. 4a documents zip structure and the description cap surfacing as upload-time errors; 4b documents GitHub authentication via the Anthropic connector, private-repo App authorization, and Team/Enterprise owner-level connector enablement.
- **F5** — Cowork UI terminology refreshed to current labels: mode selector (Chat / Cowork), Tasks view, "Use an existing folder" in the left navigation panel, and Cowork Project as the canonical term (replacing "Cowork tab" and "working directory").
- **F6** — Skill invocation framing clarified: Claude uses each skill's `description` for relevance routing rather than literal trigger-phrase matching. Documented the Cowork `/` command palette and `+` capability picker as explicit invocation surfaces.
- **F7** — Method 4 directory table adds the `scripts/` row (required for Material Passport `literature_corpus[]` adapters and schema validators) and refreshes the project-capacity guidance against current Anthropic Project file limits (per-file 30 MB; file count is not artificially capped at 200).

`docs/SETUP.zh-TW.md` mirrors the English rewrite end-to-end, and `QUICKSTART.md` Step 1 commands align with the new Method 3 four-symlink approach.

## Out of scope (deferred to v3.6.5.2)

The four `SKILL.md` `description` fields currently exceed claude.ai's 200-character cap. Trimming them is the actual unblocker for Method 4a uploads, but it touches skill routing surfaces and warrants a separate atomic patch with regression coverage. v3.6.5.2 will trim the descriptions, add a routing regression test, and sync `.claude/CLAUDE.md`. Issue #44 stays open through this PR's merge and will receive a single consolidated reply when v3.6.5.2 ships.

## Validation

Disposable HOME (`mktemp -d`) used for all filesystem checks; the developer's real `~/.claude/skills/` was not modified.

| Step | Method | Result | Evidence |
|---|---|---|---|
| 1 | Method 1 (project skills, `cp -R` into `<project>/.claude/skills/`) | **4/4 PASS** | `test -f` resolves on all four `SKILL.md` files; `diff -q` vs repo source returns 0 |
| 2 | Method 3 Option A (symlink into `~/.claude/skills/`) | **4/4 PASS** | `test -L` confirms symlinks; `readlink` returns the expected absolute path back to the cloned repo; `test -f` follows links to regular files; `diff -q` returns 0 |
| 3 | Method 3 Option B (`cp -R` into `~/.claude/skills/`) | **4/4 PASS** | `test -d` + `! test -L` confirms regular directory; `test -f` + `! test -L` confirms regular file; `diff -q` returns 0 |

All four skill folders verified per step: `deep-research`, `academic-paper`, `academic-paper-reviewer`, `academic-pipeline`. Path shape produced by every documented command matches the `<install-root>/<skill-name>/SKILL.md` discovery convention.

Live discovery (Cowork registration, claude.ai upload error surfacing, claude.ai Project knowledge import) was not validated on this machine. Method 4a's expected behaviour (description-too-long upload rejection) is documented in SETUP.md and will become a passing path after v3.6.5.2.

## Test plan

- [x] Path-shape required gate (Methods 1, 3A, 3B) all 4/4 PASS in disposable HOME
- [ ] Reviewer confirms F1-F7 wording reads cleanly to a fresh user (no internal jargon)
- [ ] Cowork live discovery (Method 3, optional) — opportunistic verification on a machine with Claude Desktop
- [ ] claude.ai upload rejection (Method 4a, optional) — verify after v3.6.5.2 ships that the documented path now succeeds