### PR TITLE
v3.6.7 Step 1+2: downstream-agent pattern protection (references + agent prompts)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -102,3 +102,8 @@ jobs:
       - name: Validate v3.6.7 downstream-agent pattern protection
         run: python3 scripts/check_v3_6_7_pattern_protection.py
 
+      - name: Run v3.6.7 pattern-protection mutation tests
+        env:
+          PYTHONPATH: .
+        run: python3 -m unittest scripts.test_check_v3_6_7_pattern_protection -v
+

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -99,3 +99,6 @@ jobs:
           PYTHONPATH: .
         run: python3 -m unittest scripts.test_check_passport_reset_contract -v
 
+      - name: Validate v3.6.7 downstream-agent pattern protection
+        run: python3 scripts/check_v3_6_7_pattern_protection.py
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .DS_Store
 experiment-agent/
 docs/superpowers/
+
+# Local working context (codex review logs, hand-off prompts, brief drafts).
+# Anything under .context/ is per-session scratch and must not be committed.
+.context/
+
+# Python bytecode / pytest cache.
+__pycache__/

--- a/deep-research/agents/report_compiler_agent.md
+++ b/deep-research/agents/report_compiler_agent.md
@@ -166,3 +166,12 @@ The full report in markdown with APA 7.0 formatting, plus:
 - Word count within mode limits (full: 3000-8000, quick: 500-1500)
 - AI disclosure statement present
 - Revision log present if Phase 6
+
+## PATTERN PROTECTION (v3.6.7)
+
+These rules apply when this agent operates in **abstract-only mode** (compiling a publisher-format abstract from a stable body draft, typically the Phase 3 hand-off after the body has been calibrated by upstream). They harden output against the three publication-side hallucination/drift patterns documented in `docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md` §3.3 (C1–C3). Cross-model audit covers these via dimension §3.7 (COI adequacy) plus the bundle-specific Section 4(f) check of `shared/templates/codex_audit_multifile_template.md`.
+
+- Word budget uses whitespace-split convention (`body.split()`), not hyphenated-as-1. Reserve 3–5% buffer below hard cap. See `shared/references/word_count_conventions.md`.
+- Compression must preserve protected hedging phrases identified by upstream calibration as budget-protected (the dispatch context carries the list). See `shared/references/protected_hedging_phrases.md`.
+- Reflexivity disclosure must use explicit temporal bounds: explicit year range, past-tense disambiguating verb, or "former" prefix. Deictic temporal phrases ("during this period" / "at the time") are forbidden.
+- DO NOT simulate any audit step. DO NOT claim to have run codex/external review. The orchestrator runs codex audit afterward. Output metadata must not claim audit-passed state.

--- a/deep-research/agents/report_compiler_agent.md
+++ b/deep-research/agents/report_compiler_agent.md
@@ -174,4 +174,5 @@ These rules apply when this agent operates in **abstract-only mode** (compiling 
 - Word budget uses whitespace-split convention (`body.split()`), not hyphenated-as-1. Reserve 3–5% buffer below hard cap. See `shared/references/word_count_conventions.md`.
 - Compression must preserve protected hedging phrases identified by upstream calibration as budget-protected (the dispatch context carries the list). See `shared/references/protected_hedging_phrases.md`.
 - Reflexivity disclosure must use explicit temporal bounds: explicit year range, past-tense disambiguating verb, or "former" prefix. Deictic temporal phrases ("during this period" / "at the time") are forbidden.
-- DO NOT simulate any audit step. DO NOT claim to have run codex/external review. The orchestrator runs codex audit afterward. Output metadata must not claim audit-passed state.
+- DO NOT simulate any audit step. DO NOT claim to have run codex/external review. The orchestrator runs codex audit afterward.
+- Output metadata must not claim audit-passed state.

--- a/deep-research/agents/research_architect_agent.md
+++ b/deep-research/agents/research_architect_agent.md
@@ -184,3 +184,13 @@ Recommended platforms: PROSPERO for systematic reviews, OSF Registries for all o
 - If human subjects are involved, IRB planning is mandatory (ref: `references/irb_decision_tree.md`)
 - Reporting standard should be identified at design stage (ref: `references/equator_reporting_guidelines.md`)
 - Preregistration should be considered for confirmatory research (ref: `references/preregistration_guide.md`)
+
+## PATTERN PROTECTION (v3.6.7)
+
+These rules apply when this agent operates as the **survey designer** for instrument design (Likert items, consent scripts, retrospective items, list-of-options items). They harden output against the five instrument-side hallucination/drift patterns documented in `docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md` §3.2 (B1–B5). Cross-model audit covers these via dimension §3.5 (instrument quality) of `shared/templates/codex_audit_multifile_template.md`.
+
+- Consent / privacy language must pass through `shared/references/irb_terminology_glossary.md` before output. Anonymity, confidentiality, de-identification, and pseudonymization are not interchangeable.
+- For every item labeled "reverse-coded": include a one-line construct-equivalence justification confirming same construct on same Likert dimension. True reverse vs contrast distinction is mandatory. See `shared/references/psychometric_terminology_glossary.md`.
+- Retrospective items default to event-anchored phrasing ("immediately before X happened to your unit"). Calendar-anchored phrasing only when sample shares a common event date.
+- Item phrasing must be neutral/balanced. Chapter argument vocabulary is forbidden in instrument items. Open-text prompts must invite all valences ("positive, negative, or neutral").
+- Any list-of-options item must declare its primary-source list and enumerate fully. No subsetting, no over-setting, no scope cross-contamination.

--- a/deep-research/agents/synthesis_agent.md
+++ b/deep-research/agents/synthesis_agent.md
@@ -158,3 +158,13 @@ Gap:         [          ] Theme D (0 sources)
 - At least 2 knowledge gaps identified
 - Literature matrix completed for all included sources
 - Synthesis must be traceable — reader can follow evidence back to sources
+
+## PATTERN PROTECTION (v3.6.7)
+
+These rules harden the synthesis output against the five narrative-side hallucination/drift patterns documented in `docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md` §3.1 (A1–A5). Cross-model audit follows `shared/templates/codex_audit_multifile_template.md` audit dimensions §3.1, §3.2, §3.3, §3.4 and the bundle-specific Section 4(f) check.
+
+- For each source cited in 2+ sections: pre-list the source's effect inventory and run a cross-section consistency self-check before output.
+- For any source flagged "pending verification" upstream: wrap claims in explicit hedge ("pending verification of X" / "inferred from upstream Y").
+- For each substantive claim: include a one-line anchor justification.
+- Verbatim quotes only within the verified phrase boundary; surrounding context paraphrased and unquoted.
+- For un-provided external documents (e.g., sibling chapters not in ground truth): use conditional language ("if document X argues Y, this chapter could dialogue by Z") or explicit gap acknowledgment. Declarative claims about un-provided documents are forbidden.

--- a/scripts/check_passport_reset_contract.py
+++ b/scripts/check_passport_reset_contract.py
@@ -35,6 +35,9 @@ PROTOCOL_FILENAME = "passport_as_reset_boundary.md"
 PROTOCOL_PARENT_DIRNAME = "references"
 
 # Directories we never scan: VCS, caches, build output, local tooling scratch.
+# `.context` is hand-off / codex-review log scratch (gitignored); files there
+# routinely quote the ARS_PASSPORT_RESET token from prior work without owing
+# the protocol-doc co-location.
 SKIP_DIRS = {
     ".git",
     "node_modules",
@@ -43,6 +46,7 @@ SKIP_DIRS = {
     "dist",
     "build",
     ".gstack",
+    ".context",
 }
 
 

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -148,6 +148,11 @@ def _match_excludes_negation(text_window: str, allow_prohibition: bool = False) 
         r"\bdoes not\b",
         r"\bdoesn'?t\b",
         r"\bdon'?t\b",
+        # `must not` is a prohibition expression of obligation, not a
+        # weakener — used in C3 ("Output metadata must not claim audit-
+        # passed state") and equivalent verbatim-only style rules.
+        r"\bmust not\b",
+        r"\bmustn'?t\b",
     }
     for p in _GENERAL_NEGATION_PATTERNS:
         if allow_prohibition and p.pattern in PROHIBITION_VERB_PATTERNS:
@@ -163,18 +168,18 @@ class Check:
     description: str
     target: Path
     must_contain: list[str] = field(default_factory=list)
-    must_contain_regex: list[tuple[str, str]] = field(default_factory=list)
+    must_contain_regex: list[tuple[str, str] | tuple[str, str, bool]] = field(default_factory=list)
+    """Each entry is `(label, pattern)` or `(label, pattern, allow_prohibition)`.
+    `allow_prohibition` is per-regex (not per-Check) so a check can mix
+    prohibition-style obligations (REF-3 verbatim preservation, C3 anti-
+    fake-audit guard, C3 audit-passed metadata) with assertion-style
+    obligations (C1 protected hedges non-negotiable) without the
+    prohibition exemption leaking across regexes (B2 codex R2-001)."""
     block_marker: str | None = None
     """If set, scope all keyword/regex checks to the text between the marker
     and the next H1/H2/H3 heading. Use for agent-prompt checks where the
     PATTERN PROTECTION clause must be inside its own block, not scattered
     elsewhere in the file."""
-    allow_prohibition: bool = False
-    """If True, the negation post-filter exempts the literal `DO NOT` /
-    `do not` imperative tokens. Set for obligations that *are themselves*
-    prohibitions (C3 anti-fake-audit guard) or that include sub-clauses
-    using `does not paraphrase` / `does not substitute` style prohibitions
-    as the obligation's body (REF-3 verbatim preservation rule)."""
 
     def _scoped_text(self, full_text: str) -> tuple[str | None, str]:
         """Return (scoped_text, error_message). scoped_text is None on failure."""
@@ -206,7 +211,12 @@ class Check:
         scoped_lower = scoped.lower()
         missing_substr = [s for s in self.must_contain if s.lower() not in scoped_lower]
         missing_regex = []
-        for label, pattern in self.must_contain_regex:
+        for entry in self.must_contain_regex:
+            if len(entry) == 2:
+                label, pattern = entry
+                allow_prohibition = False
+            else:
+                label, pattern, allow_prohibition = entry
             # First try to find an obligation match.
             match = re.search(pattern, scoped, re.IGNORECASE | re.DOTALL)
             if match is None:
@@ -249,7 +259,7 @@ class Check:
                 next_break = min(fwd_breaks) if fwd_breaks else -1
                 bullet_end = end + next_break if next_break >= 0 else lookahead_ceiling
                 window = scoped[bullet_start:bullet_end]
-                if _match_excludes_negation(window, allow_prohibition=self.allow_prohibition):
+                if _match_excludes_negation(window, allow_prohibition=allow_prohibition):
                     accepted = True
                     break
             if not accepted:
@@ -294,10 +304,6 @@ def reference_file_checks() -> list[Check]:
             pattern_id="REF-3 (C1)",
             description="protected_hedging_phrases defines upstream-marked hedge protocol with 5 contract rules",
             target=REF_DIR / "protected_hedging_phrases.md",
-            # Verbatim preservation rule body uses "does not paraphrase /
-            # substitute" as the prohibition expressing the obligation, so
-            # general DO NOT / does not patterns must be exempted (R4-001).
-            allow_prohibition=True,
             must_contain=[
                 "protected hedging phrases",
                 "upstream calibration",
@@ -331,10 +337,16 @@ def reference_file_checks() -> list[Check]:
                     r"\bNo duplicates\b[\s.*\-]{0,10}One entry per phrase\.\s+The compiler counts[^.]{0,150}\bonce\b",
                 ),
                 # Rule 4: verbatim preservation — both the title and the
-                # imperative body ("does not paraphrase") must appear.
+                # imperative body ("does not paraphrase") must appear. The
+                # body uses "does not paraphrase / substitute" as the
+                # prohibition expressing the obligation, so this specific
+                # regex needs prohibition exemption (was per-Check before
+                # B2 R2-001; now per-regex so other regexes in this Check
+                # still reject inverted forms).
                 (
                     "Rule: Verbatim preservation",
                     r"\bVerbatim preservation\b.{0,250}\brides\s+verbatim\b.{0,300}\bdoes\s+not\s+paraphrase\b",
+                    True,  # allow_prohibition: prohibition-style obligation body
                 ),
                 # Rule 5: failure surface — must say "rather than dropping",
                 # not "while dropping" (R5-002 mutation flipped this).
@@ -498,12 +510,18 @@ def architect_agent_checks() -> list[Check]:
                     "B4 open-text invites all valences",
                     r"\b(?:all valences|positive,? negative,? (?:or|and) neutral)\b",
                 ),
-                # B5 — option lists must enumerate fully (no subsetting).
-                # Sentence-bounded; negation post-filter rejects "does not
-                # enumerate fully" (R2-004).
+                # B5 — option lists must declare primary-source list AND
+                # enumerate fully AND prohibit subsetting. All three are
+                # the contract; matching any one alone (e.g. "enumerate
+                # fully" with "subsetting is acceptable" elsewhere) is a
+                # silent gap. Require all three obligation phrases.
                 (
-                    "B5 enumerate fully / no subsetting",
-                    r"\b(?:enumerate(?:s|d)?\s+fully|no\s+subsetting)\b",
+                    "B5 primary-source list + enumerate fully",
+                    r"\bprimary-source list\b[^.\n]{0,100}\benumerate(?:s|d)?\s+fully\b",
+                ),
+                (
+                    "B5 no subsetting prohibition",
+                    r"\bno\s+subsetting\b",
                 ),
             ],
         )
@@ -518,12 +536,6 @@ def compiler_agent_checks() -> list[Check]:
             description="report_compiler_agent (abstract-only) carries 3 publication-side protection clauses incl. anti-fake-audit guard",
             target=COMPILER_AGENT,
             block_marker=PROTECTION_BLOCK,
-            # C3 anti-fake-audit guard is a prohibition obligation
-            # ("DO NOT simulate" / "DO NOT claim to have run"); the
-            # negation post-filter must exempt the DO NOT imperative
-            # while still rejecting weakeners like "this is not required"
-            # (R4-001).
-            allow_prohibition=True,
             must_contain=[
                 # C1 — word-count algorithm
                 "whitespace-split",
@@ -533,7 +545,10 @@ def compiler_agent_checks() -> list[Check]:
             must_contain_regex=[
                 # C1 — protected hedges are budget-protected / non-negotiable
                 # / verbatim. Sentence-bounded; negation post-filter rejects
-                # "are not non-negotiable" (R2-004).
+                # "are not non-negotiable" (R2-004) AND must reject inverted
+                # "Compression must not preserve protected hedging phrases"
+                # (B2 R2-001), so this regex does NOT take prohibition
+                # exemption — it is an assertion-style obligation.
                 (
                     "C1 protected hedges non-negotiable",
                     r"protected\s+hedg(?:e|ing)\s+phrases[^.\n]{0,200}\b(?:budget[- ]protected|non-negotiable|verbatim)\b",
@@ -541,10 +556,28 @@ def compiler_agent_checks() -> list[Check]:
                 # C3 — anti-fake-audit guard. Both DO NOT clauses must appear
                 # in either order. The gap allows two short sentences (the
                 # natural "DO NOT simulate ... DO NOT claim ..." wording).
+                # This is itself a prohibition obligation, so allow the
+                # `DO NOT` imperative through the negation post-filter
+                # (R4-001 still applies — trailing "this is not required"
+                # is rejected by the adjective-targeted negation rules).
                 (
                     "C3 anti-fake-audit guard pair",
                     r"DO NOT simulate[^\n]{0,300}\.[^\n]{0,100}\bDO NOT claim to have run\b"
                     r"|DO NOT claim to have run[^\n]{0,300}\.[^\n]{0,100}\bDO NOT simulate\b",
+                    True,  # allow_prohibition: this IS the prohibition
+                ),
+                # C3 — output metadata prohibition. Spec §6.3 explicitly
+                # closes the loop: "Output metadata must not claim
+                # audit-passed state." Without this, an agent could
+                # honour the DO NOT pair while still surfacing fake
+                # audit-passed metadata (B2 codex R1-001). Uses `must not`
+                # as the prohibition expression — exemption is per-regex
+                # so it does not leak to C1's assertion-style obligation
+                # (B2 R2-001).
+                (
+                    "C3 output metadata audit-passed prohibition",
+                    r"\bOutput metadata must not claim audit-passed state\b",
+                    True,  # allow_prohibition: `must not` is the obligation
                 ),
             ],
         )
@@ -553,20 +586,19 @@ def compiler_agent_checks() -> list[Check]:
 
 # Environment variable controlling whether agent-prompt checks run.
 #
-# v3.6.7 implementation lands across multiple PRs: Step 1 ships the 4
-# reference files + audit template + this lint; Steps 2-4 land the actual
-# PATTERN PROTECTION (v3.6.7) blocks in the three downstream agent prompts.
-# Until Step 2-4 ship, the agent-prompt checks fail by design (the marker
-# does not exist yet). Running those checks in CI before Step 2-4 ship
-# would produce a misleading red.
+# Spec §9 ships v3.6.7 across multiple steps. Step 1 (this PR) shipped the
+# 4 reference files + audit template + this lint. Step 2 (this PR / Step 1+2
+# bundle) lands the actual PATTERN PROTECTION (v3.6.7) blocks in the three
+# downstream agent prompts. With Step 2 in, the agent-prompt checks are
+# default-on so CI enforces the contract.
 #
-# Default: agent-prompt checks are skipped. Set ARS_V3_6_7_AGENT_CHECKS=1
-# to enable them. Step 2-4 PRs will flip the default to enabled.
+# Set ARS_V3_6_7_AGENT_CHECKS=0 to skip agent-prompt checks (e.g. for a
+# repo bisect that crosses a pre-Step-2 commit, or for partial test runs).
 _AGENT_CHECKS_ENV = "ARS_V3_6_7_AGENT_CHECKS"
 
 
 def _agent_checks_enabled() -> bool:
-    return os.environ.get(_AGENT_CHECKS_ENV, "0") == "1"
+    return os.environ.get(_AGENT_CHECKS_ENV, "1") == "1"
 
 
 def all_checks() -> list[Check]:
@@ -597,7 +629,7 @@ def main(argv: list[str]) -> int:
 
     deferred_note = ""
     if not _agent_checks_enabled():
-        deferred_note = " (agent-prompt checks deferred — set ARS_V3_6_7_AGENT_CHECKS=1 to enable)"
+        deferred_note = " (agent-prompt checks skipped — ARS_V3_6_7_AGENT_CHECKS=0)"
     summary = (
         f"v3.6.7 pattern-protection static audit: {len(passed)}/{len(checks)} "
         f"checks passed{deferred_note}"

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -92,9 +92,29 @@ _ALWAYS_NEGATION_PATTERNS = [
     # ("optional `approved_synonyms` field"), so we narrow this rule to
     # `optional <obligation-noun>` forms.
     re.compile(r"\boptional\s+(?:buffer|enumeration|preservation|inclusion|verbatim|hedge|hedges|enforcement|requirement|reservation)\b", re.IGNORECASE),
+    # B2 R4-001: "X is recommended" / "are recommended" downgrades a
+    # mandatory obligation to advisory. The narrowed verb list ensures
+    # this only flags weakening of actual contract verbs / nouns.
+    re.compile(
+        r"\b(?:is|are)\s+recommended\b",
+        re.IGNORECASE,
+    ),
+    # B2 R4-002 helper: "are allowed" / "is allowed" turns a forbidden
+    # operation into an exception. Covers C2's mutated "deictic phrases
+    # are allowed when shorter" and B5's "Over-setting ... are allowed"
+    # when those structures slip past the per-rule regex.
+    re.compile(r"\b(?:is|are)\s+allowed\b", re.IGNORECASE),
     # Same narrowing for `may` — only flag when `may` directly weakens an
-    # action verb that should be obligatory.
-    re.compile(r"\bmay\s+(?:not\s+)?(?:invite|enumerate|preserve|drop|skip|substitute|paraphrase)\b", re.IGNORECASE),
+    # action verb that should be obligatory. Verb list expanded in B2 R4-001
+    # to cover the imperative verbs the agent prompts use (wrap, include,
+    # default, run, use, declare, pass, claim, cite, fall back).
+    re.compile(
+        r"\bmay\s+(?:not\s+)?"
+        r"(?:invite|enumerate|preserve|drop|skip|substitute|paraphrase"
+        r"|wrap|include|default|defaults?|run|use|declare|pass(?:\s+through)?"
+        r"|claim|cite|fall\s+back|be\s+quoted|use\s+chapter)\b",
+        re.IGNORECASE,
+    ),
     re.compile(r"\bfails? to\b", re.IGNORECASE),
     re.compile(r"\binstead of\b", re.IGNORECASE),
     # `rarely` / `sometimes` / `occasionally` similarly need to be near
@@ -492,45 +512,56 @@ def synthesis_agent_checks() -> list[Check]:
             block_marker=PROTECTION_BLOCK,
             must_contain_regex=[
                 # A1 — cross-section consistency self-check. Bullet must
-                # directive both the effect-inventory step and the
-                # consistency self-check; "is recommended" / "may run" /
-                # "optional" qualifiers are caught by the negation filter.
+                # carry both the imperative pre-list step and the
+                # consistency self-check before output. "are recommended"
+                # / "may run" / "optional" weakeners are caught by the
+                # negation filter (verb list + `is/are recommended` in
+                # _ALWAYS_NEGATION_PATTERNS, B2 R4-001 expansion).
                 (
-                    "A1 effect inventory + cross-section consistency self-check",
-                    r"\beffect inventory\b[^.\n]{0,200}\bcross-section consistency\b",
+                    "A1 effect inventory pre-list + cross-section self-check before output",
+                    r"\bpre-list\b[^.\n]{0,200}\beffect inventory\b[^.\n]{0,200}\brun\s+a\s+cross-section consistency self-check\b[^.\n]{0,100}\bbefore output\b",
                 ),
                 # A2 — pending-verification hedge. "wrap claims in explicit
-                # hedge" is the imperative; mutating to "pending verification
-                # language is optional" trips the optional-noun weakener
-                # only if the noun is in the narrowed list. Use a regex
-                # anchored on "wrap claims" so the imperative verb is
-                # required (R3-002 mutation evidence).
+                # hedge" is the imperative; mutating to "may wrap" or
+                # "pending verification language is optional" trips the
+                # may-verb weakener (R4-001) and the optional-noun weakener
+                # respectively.
                 (
                     "A2 pending-verification hedge wrap",
                     r"\bpending verification\b[^.\n]{0,200}\bwrap claims\b[^.\n]{0,200}\bexplicit hedge\b",
                 ),
                 # A3 — anchor justification. "include a one-line anchor
-                # justification" is the imperative; bare token "anchor
-                # justification" alone could be subverted with "anchor
-                # justification is optional".
+                # justification" is the imperative; "may include" trips
+                # the may-verb weakener (R4-001).
                 (
                     "A3 one-line anchor justification (include)",
                     r"\binclude\s+a\s+one[- ]line\s+anchor justification\b",
                 ),
-                # A4 — quote scope boundary. "Verbatim quotes only within
-                # the verified phrase boundary" is the imperative; mutating
-                # to "Verbatim quotes are not restricted to the verified
-                # phrase boundary" is caught by `not\s+restricted` only if
-                # listed; safer to require the "only within ... boundary"
-                # phrasing.
+                # A4 — quote scope boundary AND surrounding-context handling.
+                # Spec §6.1 says "surrounding context paraphrased and
+                # unquoted". Without enforcing the second clause, an agent
+                # can satisfy "Verbatim quotes only within ..." while
+                # mutating context handling to "may be quoted" (R4-002).
+                # Two regexes so dropping either half fails lint.
                 (
                     "A4 verbatim quotes only within verified phrase boundary",
                     r"\bVerbatim quotes\s+only\s+within\s+the\s+verified phrase boundary\b",
                 ),
-                # A5 — declarative claims about un-provided documents must be
-                # explicitly forbidden in one contiguous injunction, sentence-
-                # bounded so unrelated clauses elsewhere in the block do not
-                # syntactically satisfy the obligation (per R2-003).
+                (
+                    "A4 surrounding context paraphrased and unquoted",
+                    r"\bsurrounding context\s+paraphrased\s+and\s+unquoted\b",
+                ),
+                # A5 — declarative claims about un-provided documents are
+                # forbidden AND the conditional-language fallback is
+                # required. Spec §6.1 pairs the two: conditional language
+                # / explicit gap acknowledgment is the constructive duty,
+                # the prohibition is the negative duty. Both must ride.
+                (
+                    "A5 conditional language fallback for un-provided documents",
+                    # Bullet contains "e.g., ..." parenthetical, so match
+                    # across periods within the bullet line.
+                    r"\bun-provided[^\n]{0,300}\buse\s+conditional language\b[^\n]{0,300}\bexplicit gap acknowledgment\b",
+                ),
                 (
                     "A5 sentence-bounded injunction",
                     r"declarative claims? about un-provided[^.\n]{0,200}\bare forbidden\b",
@@ -579,17 +610,33 @@ def architect_agent_checks() -> list[Check]:
                     "B3 retrospective default + calendar conditional",
                     r"event-anchored[^.\n]{0,200}\.[^.\n]{0,100}\bcalendar[- ]anchored[^.\n]{0,200}\bonly when\b",
                 ),
-                # B4 — open-text prompts invite all valences. Sentence-bounded
-                # so a stray 'neutral' elsewhere does not satisfy.
+                # B4 — three-part obligation per spec §6.2:
+                #   (i) item phrasing must be neutral/balanced,
+                #   (ii) chapter argument vocabulary forbidden in items,
+                #   (iii) open-text prompts invite all valences.
+                # Splitting into three regexes so dropping any one half
+                # fails lint (R4-002 mutation evidence: "may use chapter
+                # argument vocabulary" replaced (i)+(ii) and bare valences
+                # match still passed).
+                (
+                    "B4 item phrasing neutral/balanced (must)",
+                    r"\bItem phrasing\s+must\s+be\s+neutral[/-]balanced\b",
+                ),
+                (
+                    "B4 chapter argument vocabulary forbidden",
+                    r"\bChapter argument vocabulary\s+is\s+forbidden\s+in\s+instrument items\b",
+                ),
                 (
                     "B4 open-text invites all valences",
                     r"\b(?:all valences|positive,? negative,? (?:or|and) neutral)\b",
                 ),
                 # B5 — option lists must declare primary-source list AND
-                # enumerate fully AND prohibit subsetting. All three are
-                # the contract; matching any one alone (e.g. "enumerate
-                # fully" with "subsetting is acceptable" elsewhere) is a
-                # silent gap. Require all three obligation phrases.
+                # enumerate fully AND prohibit subsetting AND prohibit
+                # over-setting AND prohibit scope cross-contamination.
+                # All five are the contract per spec §6.2; matching any
+                # subset is a silent gap (R4-002 mutation: "Over-setting
+                # and scope cross-contamination are allowed" passed even
+                # though "No subsetting" remained).
                 (
                     "B5 primary-source list + enumerate fully",
                     r"\bprimary-source list\b[^.\n]{0,100}\benumerate(?:s|d)?\s+fully\b",
@@ -597,6 +644,14 @@ def architect_agent_checks() -> list[Check]:
                 (
                     "B5 no subsetting prohibition",
                     r"\bno\s+subsetting\b",
+                ),
+                (
+                    "B5 no over-setting prohibition",
+                    r"\bno\s+over-setting\b",
+                ),
+                (
+                    "B5 no scope cross-contamination prohibition",
+                    r"\bno\s+scope cross-contamination\b",
                 ),
             ],
         )
@@ -612,22 +667,34 @@ def compiler_agent_checks() -> list[Check]:
             target=COMPILER_AGENT,
             block_marker=PROTECTION_BLOCK,
             must_contain_regex=[
-                # C1 word-count algorithm. "uses whitespace-split convention"
-                # is the imperative. R3-002 evidence: bare token
-                # "whitespace-split" passed even when surrounding prose was
-                # mutated; require the imperative phrasing.
+                # C1 word-count algorithm + buffer. Spec §6.3 pairs the
+                # whitespace-split rule with "Reserve 3–5% buffer below
+                # hard cap"; both must ride. R4-002 mutation showed
+                # buffer deletion still passed.
                 (
                     "C1 whitespace-split convention (uses)",
                     r"\bWord budget\s+uses\s+whitespace-split\s+convention\b",
                 ),
-                # C2 temporal disambiguation. "Reflexivity disclosure must
-                # use explicit temporal bounds" is the imperative. Mutating
-                # to "may use" / "are allowed when shorter" is caught by
-                # the weakening filter on `may` and exception qualifiers
-                # (R3-002 + R3-003).
+                (
+                    "C1 reserve 3-5% buffer below hard cap",
+                    r"\bReserve\s+3[-–]5%\s+buffer\s+below\s+hard cap\b",
+                ),
+                # C2 temporal disambiguation: imperative + full triple of
+                # acceptable forms (year range, past-tense disambiguating
+                # verb, "former" prefix). R4-002 evidence: dropping the
+                # past-tense + former prefix still passed because only
+                # "explicit year range" was lint-required.
                 (
                     "C2 reflexivity disclosure must use explicit year range",
                     r"\bReflexivity disclosure\s+must\s+use\s+explicit temporal bounds\b[^.\n]{0,200}\bexplicit year range\b",
+                ),
+                (
+                    "C2 past-tense disambiguating verb form",
+                    r"\bpast-tense disambiguating verb\b",
+                ),
+                (
+                    "C2 'former' prefix form",
+                    r"['\"]former['\"]\s+prefix\b",
                 ),
                 # C2 deictic forbidden — paired with above so a mutation
                 # that drops the prohibition still fails.

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -115,13 +115,32 @@ _ALWAYS_NEGATION_PATTERNS = [
     # are allowed when shorter" and B5's "Over-setting ... are allowed"
     # when those structures slip past the per-rule regex.
     re.compile(r"\b(?:is|are)\s+allowed\b", re.IGNORECASE),
-    # Same narrowing for `may` / `should` / `can` — only flag when the modal
-    # directly precedes one of the obligation verbs the v3.6.7 prompts use.
-    # B2 R4-001 expanded the verb list; B2 R5-001 added `should` / `can`
-    # to the modal coverage.
+    # Modal/advisory weakener coverage for the obligation verb list.
+    # B2 R4-001 added `may`; R5-001 added `should` / `can` /
+    # `is/are permitted`; R6-001 added the future/conditional modals
+    # (`will`, `would`, `ought to`) and the advisory adverb framings
+    # (`ideally`, `preferably`, `We recommend that`).
     re.compile(rf"\bmay\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
     re.compile(rf"\bshould\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
     re.compile(rf"\bcan\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    # B2 R6-001: future-tense `will` / `will not` directly contradicts a
+    # mandatory obligation when paired with the obligation verb.
+    re.compile(rf"\bwill\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    # B2 R6-001: conditional `would` framings turn an imperative into a
+    # hypothetical ("Compression would preserve" instead of "must preserve").
+    re.compile(rf"\bwould\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    # B2 R6-001: `ought to` is a modal-equivalent advisory.
+    re.compile(rf"\bought\s+to\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    # B2 R6-001: advisory adverb framings. "Ideally include X" or
+    # "Preferably enumerate fully" downgrades the obligation. The verb
+    # boundary is required so bare adverbs in unrelated context don't
+    # trigger.
+    re.compile(rf"\bideally\s+{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    re.compile(rf"\bpreferably\s+{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    # B2 R6-001: "We recommend that ..." reframing makes the obligation
+    # advisory. Anchor on the recommend-that structure to avoid false
+    # positives on legitimate references that just contain "recommend".
+    re.compile(r"\bWe\s+recommend\s+that\b", re.IGNORECASE),
     # B2 R5-001: "is/are permitted" turns a forbidden operation into an
     # exception ("over-setting is permitted when concise"). Mirrors the
     # `is/are allowed` pattern.

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -57,6 +57,11 @@ _HEADING_RE = re.compile(r"^#{1,3} ", re.MULTILINE)
 #   constitute a valid prohibition signal (rarely / sometimes / fails to /
 #   etc.). These apply regardless of `allow_prohibition`.
 _GENERAL_NEGATION_PATTERNS = [
+    # Subject + auxiliary negation that directly weakens an obligation.
+    # These are the verb-negation forms most commonly used to undo a rule
+    # ("X does not Y", "X must not Y"). They are excluded by default but
+    # exempted for prohibition-style obligations like C3 via
+    # `allow_prohibition`.
     re.compile(r"\bdoes not\b", re.IGNORECASE),
     re.compile(r"\bdo not\b", re.IGNORECASE),
     re.compile(r"\bDO NOT\b"),  # case-sensitive imperative form
@@ -66,23 +71,37 @@ _GENERAL_NEGATION_PATTERNS = [
     re.compile(r"\bshouldn'?t\b", re.IGNORECASE),
     re.compile(r"\bmust not\b", re.IGNORECASE),
     re.compile(r"\bmustn'?t\b", re.IGNORECASE),
-    re.compile(r"\bcannot\b", re.IGNORECASE),
-    re.compile(r"\bcan'?t\b", re.IGNORECASE),
+    # Adjective-targeted negations: explicit "not <obligation-adjective>"
+    # forms that directly negate the contract vocabulary.
     re.compile(r"\bnot\s+(?:non[- ]negotiable|enumerate|required|mandatory|forbidden|verbatim|reserved)\b", re.IGNORECASE),
     re.compile(r"\bneed not\b", re.IGNORECASE),
     re.compile(r"\bno\s+buffer\b", re.IGNORECASE),
     re.compile(r"\bno\s+enumeration\b", re.IGNORECASE),
+    # NOTE: `cannot` and `can't` are intentionally NOT in this list. They
+    # are routinely used in benign conditional phrasing ("if X cannot fit,
+    # the compiler reports..."), where `cannot` describes a trigger
+    # condition rather than weakening an obligation. The other negation
+    # patterns are tight enough to catch genuine weakening even without
+    # `cannot`.
 ]
 _ALWAYS_NEGATION_PATTERNS = [
     re.compile(r"\bisn'?t\b", re.IGNORECASE),
     re.compile(r"\baren'?t\b", re.IGNORECASE),
-    re.compile(r"\boptional\b", re.IGNORECASE),
-    re.compile(r"\bmay\s+(?:not\s+)?(?:invite|enumerate|preserve|drop|skip|substitute)\b", re.IGNORECASE),
+    # `optional` only counts as a weakener when it directly modifies an
+    # obligation noun. The bare token can appear in unrelated context
+    # ("optional `approved_synonyms` field"), so we narrow this rule to
+    # `optional <obligation-noun>` forms.
+    re.compile(r"\boptional\s+(?:buffer|enumeration|preservation|inclusion|verbatim|hedge|hedges|enforcement|requirement|reservation)\b", re.IGNORECASE),
+    # Same narrowing for `may` — only flag when `may` directly weakens an
+    # action verb that should be obligatory.
+    re.compile(r"\bmay\s+(?:not\s+)?(?:invite|enumerate|preserve|drop|skip|substitute|paraphrase)\b", re.IGNORECASE),
     re.compile(r"\bfails? to\b", re.IGNORECASE),
     re.compile(r"\binstead of\b", re.IGNORECASE),
-    re.compile(r"\brarely\b", re.IGNORECASE),
-    re.compile(r"\bsometimes\b", re.IGNORECASE),
-    re.compile(r"\boccasionally\b", re.IGNORECASE),
+    # `rarely` / `sometimes` / `occasionally` similarly need to be near
+    # an obligation verb to count as weakeners.
+    re.compile(r"\brarely\s+(?:enumerate|enforce|invoke|reserve|preserve|verify)", re.IGNORECASE),
+    re.compile(r"\bsometimes\s+(?:enumerate|enforce|invoke|reserve|preserve|verify)", re.IGNORECASE),
+    re.compile(r"\boccasionally\s+(?:enumerate|enforce|invoke|reserve|preserve|verify)", re.IGNORECASE),
     re.compile(r"\bis unable to\b", re.IGNORECASE),
     re.compile(r"\bare unable to\b", re.IGNORECASE),
     re.compile(r"\bonly when convenient\b", re.IGNORECASE),
@@ -94,17 +113,38 @@ def _match_excludes_negation(text_window: str, allow_prohibition: bool = False) 
     """Return True if the sentence around an obligation match does NOT
     contain any negation that would weaken it.
 
-    `allow_prohibition=True` exempts the match from `_GENERAL_NEGATION_PATTERNS`
-    (DO NOT / cannot / must not), so prohibition-style obligations like the
-    C3 anti-fake-audit guard ("DO NOT simulate ... DO NOT claim to have
-    run") can still be detected. The `_ALWAYS_NEGATION_PATTERNS` (rarely,
-    sometimes, fails to, optional, etc.) apply regardless because no
-    legitimate obligation framing should rely on those.
+    `allow_prohibition=True` exempts only the literal `DO NOT` imperative
+    token (the prohibition obligation itself, e.g. C3 anti-fake-audit
+    guard's "DO NOT simulate" / "DO NOT claim to have run"). All OTHER
+    general negation patterns (cannot / must not / not required / need
+    not / etc.) still apply, so a window like "DO NOT simulate ...
+    this is not required" is still rejected (R4-001).
+
+    The `_ALWAYS_NEGATION_PATTERNS` (rarely, sometimes, fails to,
+    optional, etc.) apply regardless because no legitimate obligation
+    framing should rely on those.
     """
     if any(p.search(text_window) for p in _ALWAYS_NEGATION_PATTERNS):
         return False
-    if not allow_prohibition and any(p.search(text_window) for p in _GENERAL_NEGATION_PATTERNS):
-        return False
+    # When the caller signals this is a prohibition obligation, the
+    # subject-verb negation forms ("does not paraphrase", "DO NOT
+    # simulate") are how the obligation is *expressed*, not weakened.
+    # Exempt those forms but still enforce adjective-targeted negation
+    # ("not required", "not non-negotiable") and explicit weakeners
+    # (no buffer, no enumeration), which always indicate the contract
+    # is being undone rather than asserted.
+    PROHIBITION_VERB_PATTERNS = {
+        r"\bDO NOT\b",
+        r"\bdo not\b",
+        r"\bdoes not\b",
+        r"\bdoesn'?t\b",
+        r"\bdon'?t\b",
+    }
+    for p in _GENERAL_NEGATION_PATTERNS:
+        if allow_prohibition and p.pattern in PROHIBITION_VERB_PATTERNS:
+            continue
+        if p.search(text_window):
+            return False
     return True
 
 
@@ -120,6 +160,12 @@ class Check:
     and the next H1/H2/H3 heading. Use for agent-prompt checks where the
     PATTERN PROTECTION clause must be inside its own block, not scattered
     elsewhere in the file."""
+    allow_prohibition: bool = False
+    """If True, the negation post-filter exempts the literal `DO NOT` /
+    `do not` imperative tokens. Set for obligations that *are themselves*
+    prohibitions (C3 anti-fake-audit guard) or that include sub-clauses
+    using `does not paraphrase` / `does not substitute` style prohibitions
+    as the obligation's body (REF-3 verbatim preservation rule)."""
 
     def _scoped_text(self, full_text: str) -> tuple[str | None, str]:
         """Return (scoped_text, error_message). scoped_text is None on failure."""
@@ -157,46 +203,44 @@ class Check:
             if match is None:
                 missing_regex.append(label)
                 continue
-            # Reject if the full sentence containing the match (both the
-            # text before AND after the match) carries a negation that
-            # weakens the obligation (per R2-004 + R3-001). The check looks
-            # backward from the match start to the prior sentence boundary
-            # AND forward from the match end to the next sentence boundary,
-            # so weakeners after the matched phrase ("enumerate fully ...
-            # is not required") are caught.
+            # Reject if the bullet/paragraph containing the match carries
+            # a negation that weakens the obligation (per R2-004 + R3-001
+            # + R4-001). The check looks backward from the match start to
+            # the start of the current bullet (or paragraph start) and
+            # forward from the match end to the next bullet (or blank line
+            # / EOF). This catches trailing weakeners like
+            # "...obligation. This is not required."
             iterator = re.finditer(pattern, scoped, re.IGNORECASE | re.DOTALL)
             accepted = False
             for m in iterator:
                 start, end = m.start(), m.end()
-                # Lookback to prior sentence break, capped at 200 chars.
-                lookback_floor = max(0, start - 200)
+                # Lookback to the start of this bullet/paragraph: previous
+                # blank line, list-bullet marker on its own line, or start
+                # of scoped text. Capped at 400 chars so very long bullets
+                # do not pull in unrelated negation from far above.
+                lookback_floor = max(0, start - 400)
                 lookback = scoped[lookback_floor:start]
-                last_break_back = max(
-                    lookback.rfind("."),
-                    lookback.rfind("!"),
-                    lookback.rfind("?"),
-                    lookback.rfind("\n"),
-                )
-                sentence_start = (
+                blank_line = lookback.rfind("\n\n")
+                bullet_back_match = list(re.finditer(r"\n\s*-\s", lookback))
+                bullet_back = bullet_back_match[-1].start() if bullet_back_match else -1
+                last_break_back = max(blank_line, bullet_back)
+                bullet_start = (
                     lookback_floor + last_break_back + 1
                     if last_break_back >= 0
                     else lookback_floor
                 )
-                # Lookahead to next sentence break, capped at 200 chars.
-                lookahead_ceiling = min(len(scoped), end + 200)
+                # Lookahead to the start of the next bullet, blank line,
+                # or EOF (capped 400 chars).
+                lookahead_ceiling = min(len(scoped), end + 400)
                 lookahead = scoped[end:lookahead_ceiling]
-                next_break = min(
-                    [i for i in (
-                        lookahead.find("."),
-                        lookahead.find("!"),
-                        lookahead.find("?"),
-                        lookahead.find("\n"),
-                    ) if i >= 0],
-                    default=-1,
-                )
-                sentence_end = end + next_break + 1 if next_break >= 0 else lookahead_ceiling
-                window = scoped[sentence_start:sentence_end]
-                if _match_excludes_negation(window, allow_prohibition=label.startswith("C3")):
+                blank_fwd = lookahead.find("\n\n")
+                bullet_fwd_match = re.search(r"\n\s*-\s", lookahead)
+                bullet_fwd = bullet_fwd_match.start() if bullet_fwd_match else -1
+                fwd_breaks = [i for i in (blank_fwd, bullet_fwd) if i >= 0]
+                next_break = min(fwd_breaks) if fwd_breaks else -1
+                bullet_end = end + next_break if next_break >= 0 else lookahead_ceiling
+                window = scoped[bullet_start:bullet_end]
+                if _match_excludes_negation(window, allow_prohibition=self.allow_prohibition):
                     accepted = True
                     break
             if not accepted:
@@ -239,12 +283,46 @@ def reference_file_checks() -> list[Check]:
         ),
         Check(
             pattern_id="REF-3 (C1)",
-            description="protected_hedging_phrases defines upstream-marked hedge protocol",
+            description="protected_hedging_phrases defines upstream-marked hedge protocol with 5 contract rules",
             target=REF_DIR / "protected_hedging_phrases.md",
+            # Verbatim preservation rule body uses "does not paraphrase /
+            # substitute" as the prohibition expressing the obligation, so
+            # general DO NOT / does not patterns must be exempted (R4-001).
+            allow_prohibition=True,
             must_contain=[
                 "protected hedging phrases",
                 "upstream calibration",
                 "word budget",
+            ],
+            must_contain_regex=[
+                # Rule 1: conservative inclusion — when in doubt, include
+                (
+                    "Rule: Conservative inclusion",
+                    r"\bConservative inclusion\b.{0,200}\bWhen in doubt\b",
+                ),
+                # Rule 2: anchor every entry
+                (
+                    "Rule: Anchor every entry",
+                    r"\bAnchor every entry\b.{0,200}\bmust\s+cite\b",
+                ),
+                # Rule 3: no duplicates
+                (
+                    "Rule: No duplicates",
+                    r"\bNo duplicates\b.{0,150}\bOne entry per phrase\b",
+                ),
+                # Rule 4: verbatim preservation
+                (
+                    "Rule: Verbatim preservation",
+                    r"\bVerbatim preservation\b.{0,200}\brides\s+verbatim\b",
+                ),
+                # Rule 5: failure surface — report conflict, do not drop hedge.
+                # Sentence-bounded so the surrounding "if abstract cannot fit"
+                # conditional in the prose does not poison the negation
+                # filter on this regex's match window.
+                (
+                    "Rule: Conflict reporting (no silent drop)",
+                    r"\breports the conflict\b[^.\n]{0,200}\bdropping a protected hedge\b",
+                ),
             ],
         ),
         Check(
@@ -412,6 +490,12 @@ def compiler_agent_checks() -> list[Check]:
             description="report_compiler_agent (abstract-only) carries 3 publication-side protection clauses incl. anti-fake-audit guard",
             target=COMPILER_AGENT,
             block_marker=PROTECTION_BLOCK,
+            # C3 anti-fake-audit guard is a prohibition obligation
+            # ("DO NOT simulate" / "DO NOT claim to have run"); the
+            # negation post-filter must exempt the DO NOT imperative
+            # while still rejecting weakeners like "this is not required"
+            # (R4-001).
+            allow_prohibition=True,
             must_contain=[
                 # C1 — word-count algorithm
                 "whitespace-split",

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -41,6 +41,32 @@ COMPILER_AGENT = AGENT_DIR / "report_compiler_agent.md"
 # starts at the marker and ends at the next H1/H2/H3 heading or EOF.
 _HEADING_RE = re.compile(r"^#{1,3} ", re.MULTILINE)
 
+# Negation patterns that, if present in a matched obligation sentence, indicate
+# the obligation is being denied or weakened rather than asserted. R2-004
+# flagged that "does not enumerate fully" / "not non-negotiable" can satisfy
+# a naive obligation regex while undermining the contract. We post-filter
+# matches against this list.
+_NEGATION_PATTERNS = [
+    re.compile(r"\bdoes not\b", re.IGNORECASE),
+    re.compile(r"\bdo not\b", re.IGNORECASE),
+    re.compile(r"\bdoesn'?t\b", re.IGNORECASE),
+    re.compile(r"\bdon'?t\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+(?:non[- ]negotiable|enumerate|required|mandatory|forbidden|verbatim)\b", re.IGNORECASE),
+    re.compile(r"\bneed not\b", re.IGNORECASE),
+    re.compile(r"\bisn'?t\b", re.IGNORECASE),
+    re.compile(r"\baren'?t\b", re.IGNORECASE),
+    re.compile(r"\boptional\b", re.IGNORECASE),
+    re.compile(r"\bmay\s+(?:not\s+)?(?:invite|enumerate|preserve)\b", re.IGNORECASE),
+]
+
+
+def _match_excludes_negation(text_window: str) -> bool:
+    """Return True if the matched window does NOT contain any negation that
+    would weaken the obligation. Used to reject 'does not enumerate fully' or
+    'not non-negotiable' false positives that the obligation regex alone
+    cannot exclude."""
+    return not any(p.search(text_window) for p in _NEGATION_PATTERNS)
+
 
 @dataclass
 class Check:
@@ -84,11 +110,42 @@ class Check:
             return False, f"{display}: {err}"
         scoped_lower = scoped.lower()
         missing_substr = [s for s in self.must_contain if s.lower() not in scoped_lower]
-        missing_regex = [
-            label
-            for label, pattern in self.must_contain_regex
-            if not re.search(pattern, scoped, re.IGNORECASE | re.DOTALL)
-        ]
+        missing_regex = []
+        for label, pattern in self.must_contain_regex:
+            # First try to find an obligation match.
+            match = re.search(pattern, scoped, re.IGNORECASE | re.DOTALL)
+            if match is None:
+                missing_regex.append(label)
+                continue
+            # Reject if the matched window or its preceding sentence context
+            # contains a negation that would weaken the obligation (per
+            # R2-004). The negation check looks at the sentence containing
+            # the match — from the prior sentence boundary up through the
+            # match itself — so weakeners like "does not enumerate fully"
+            # or "may invite all valences" do not count as obligations.
+            iterator = re.finditer(pattern, scoped, re.IGNORECASE | re.DOTALL)
+            accepted = False
+            for m in iterator:
+                # Find sentence start: nearest preceding `.` `!` `?` or
+                # newline, or start of scoped text. Limit lookback to 200
+                # chars so a long block does not accidentally pull in an
+                # unrelated negation from far above.
+                start = m.start()
+                lookback_floor = max(0, start - 200)
+                lookback = scoped[lookback_floor:start]
+                last_sentence_break = max(
+                    lookback.rfind("."),
+                    lookback.rfind("!"),
+                    lookback.rfind("?"),
+                    lookback.rfind("\n"),
+                )
+                sentence_start = lookback_floor + last_sentence_break + 1 if last_sentence_break >= 0 else lookback_floor
+                window = scoped[sentence_start:m.end()]
+                if _match_excludes_negation(window):
+                    accepted = True
+                    break
+            if not accepted:
+                missing_regex.append(f"{label} (only negated forms found)")
         problems = []
         if missing_substr:
             problems.append(f"missing keywords: {missing_substr}")
@@ -166,6 +223,41 @@ def template_file_checks() -> list[Check]:
                 "COI adequacy",
             ],
         ),
+        # The report_compiler bundle's Section 4(f) is mandatory three-part:
+        # (i) word-count cap-minus-buffer, (ii) protected-hedge verbatim,
+        # (iii) abstract no less hedged than body. R1-006 upgraded this from
+        # an example to a mandatory contract; lint must verify the contract
+        # rides verbatim in the template, not just the prose around it.
+        Check(
+            pattern_id="TPL-2 (4f-compiler)",
+            description="audit template encodes mandatory three-part (f) check for report_compiler bundles",
+            target=TPL_DIR / "codex_audit_multifile_template.md",
+            must_contain=[
+                "report_compiler_agent bundle",
+            ],
+            must_contain_regex=[
+                # Sub-check (i): whitespace-split cap minus 3-5% buffer
+                (
+                    "4f sub-check (i) word-count algorithm + buffer",
+                    r"len\(body\.split\(\)\).{0,200}\b3[-–]5%\s+buffer\b",
+                ),
+                # Sub-check (ii): protected_hedges verbatim preservation
+                (
+                    "4f sub-check (ii) protected_hedges verbatim",
+                    r"protected_hedges\b.{0,300}\bverbatim\b",
+                ),
+                # Sub-check (iii): abstract no less hedged than body
+                (
+                    "4f sub-check (iii) less-hedged-than-body prohibition",
+                    r"less\s+hedged\s+than\s+its\s+anchor\s+in\s+the\s+body|no\s+claim\s+in\s+the\s+abstract\s+is\s+less\s+hedged",
+                ),
+                # P1 severity assignment for any sub-check failure
+                (
+                    "4f failures severity P1",
+                    r"P1\s+finding\b",
+                ),
+            ],
+        ),
     ]
 
 
@@ -199,11 +291,12 @@ def synthesis_agent_checks() -> list[Check]:
             ],
             must_contain_regex=[
                 # A5 — declarative claims about un-provided documents must be
-                # explicitly forbidden in one contiguous injunction, not split
-                # across unrelated clauses.
+                # explicitly forbidden in one contiguous injunction, sentence-
+                # bounded so unrelated clauses elsewhere in the block do not
+                # syntactically satisfy the obligation (per R2-003).
                 (
-                    "A5 contiguous injunction",
-                    r"declarative claims? about un-provided.{0,300}\bare forbidden\b",
+                    "A5 sentence-bounded injunction",
+                    r"declarative claims? about un-provided[^.\n]{0,200}\bare forbidden\b",
                 ),
             ],
         )
@@ -230,22 +323,26 @@ def architect_agent_checks() -> list[Check]:
             must_contain_regex=[
                 # B3 — retrospective items default to event-anchored;
                 # calendar-anchored is conditional on a shared event date.
+                # Spec wording naturally spans two sentences ("default to..."
+                # then "calendar... only when..."), so the gap allows one
+                # sentence boundary; the 'only when' tail must sit in the
+                # same sentence as 'calendar-anchored' to bind the conditional.
                 (
                     "B3 retrospective default + calendar conditional",
-                    r"event-anchored.{0,400}\bcalendar[- ]anchored.{0,300}\bonly when\b",
+                    r"event-anchored[^.\n]{0,200}\.[^.\n]{0,100}\bcalendar[- ]anchored[^.\n]{0,200}\bonly when\b",
                 ),
-                # B4 — open-text prompts invite all valences (positive +
-                # negative + neutral). Bare 'neutral' is too weak.
+                # B4 — open-text prompts invite all valences. Sentence-bounded
+                # so a stray 'neutral' elsewhere does not satisfy.
                 (
                     "B4 open-text invites all valences",
-                    r"all valences|positive,? negative,? (?:or|and) neutral",
+                    r"\b(?:all valences|positive,? negative,? (?:or|and) neutral)\b",
                 ),
                 # B5 — option lists must enumerate fully (no subsetting).
-                # Bare 'primary-source list' is too weak; require the
-                # subsetting prohibition.
+                # Sentence-bounded; negation post-filter rejects "does not
+                # enumerate fully" (R2-004).
                 (
                     "B5 enumerate fully / no subsetting",
-                    r"enumerate(?:s|d)?\s+fully\b|no\s+subsetting\b",
+                    r"\b(?:enumerate(?:s|d)?\s+fully|no\s+subsetting)\b",
                 ),
             ],
         )
@@ -267,20 +364,20 @@ def compiler_agent_checks() -> list[Check]:
                 "explicit year range",
             ],
             must_contain_regex=[
-                # C1 — protected hedges are budget-protected / non-negotiable.
-                # Bare 'protected hedging phrases' was too weak; require the
-                # obligation that they ride into the abstract verbatim.
+                # C1 — protected hedges are budget-protected / non-negotiable
+                # / verbatim. Sentence-bounded; negation post-filter rejects
+                # "are not non-negotiable" (R2-004).
                 (
                     "C1 protected hedges non-negotiable",
-                    r"protected\s+hedg(?:e|ing)\s+phrases.{0,300}\b(?:budget[- ]protected|non-negotiable|verbatim)\b",
+                    r"protected\s+hedg(?:e|ing)\s+phrases[^.\n]{0,200}\b(?:budget[- ]protected|non-negotiable|verbatim)\b",
                 ),
-                # C3 — anti-fake-audit guard. Both DO NOT clauses must appear,
-                # in either order, within a 400-char window so the guard reads
-                # as one injunction rather than two unrelated sentences.
+                # C3 — anti-fake-audit guard. Both DO NOT clauses must appear
+                # in either order. The gap allows two short sentences (the
+                # natural "DO NOT simulate ... DO NOT claim ..." wording).
                 (
                     "C3 anti-fake-audit guard pair",
-                    r"DO NOT simulate.{0,400}\bDO NOT claim to have run\b"
-                    r"|DO NOT claim to have run.{0,400}\bDO NOT simulate\b",
+                    r"DO NOT simulate[^\n]{0,300}\.[^\n]{0,100}\bDO NOT claim to have run\b"
+                    r"|DO NOT claim to have run[^\n]{0,300}\.[^\n]{0,100}\bDO NOT simulate\b",
                 ),
             ],
         )

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -115,49 +115,75 @@ _ALWAYS_NEGATION_PATTERNS = [
     re.compile(r"\bif\s+practical\b", re.IGNORECASE),
     re.compile(r"\bif\s+feasible\b", re.IGNORECASE),
     re.compile(r"\bbest[- ]effort\b", re.IGNORECASE),
+    # Exception qualifiers (B2 R3-003). "except" / "unless" / "save when"
+    # carve out a hole in an otherwise-mandatory rule. Mutation evidence:
+    # "No subsetting except when concise" silently weakens B5. These are
+    # treated as always-rejecting because no legitimate v3.6.7 contract
+    # rule carries an opt-out clause; if a future spec rule needs a
+    # genuine exception (e.g. "X is forbidden, except in mode Y"), the
+    # check for that rule should structure the obligation regex to
+    # demand both halves explicitly rather than relying on free prose.
+    re.compile(r"\bexcept\s+(?:when|if|in|for|as|where)\b", re.IGNORECASE),
+    re.compile(r"\bunless\b", re.IGNORECASE),
+    re.compile(r"\bsave\s+when\b", re.IGNORECASE),
 ]
 
 
-def _match_excludes_negation(text_window: str, allow_prohibition: bool = False) -> bool:
-    """Return True if the sentence around an obligation match does NOT
+# Imperative/auxiliary verb-negation tokens that, when allow_prohibition is
+# set, MAY appear in the matched obligation span but must still be rejected
+# anywhere else in the bullet window. This is the "span-restricted exemption"
+# (B2 R3-001): the obligation's own prohibition vocabulary ("DO NOT simulate",
+# "must not claim audit-passed state", "does not paraphrase") rides verbatim
+# in the matched span; a *second* prohibition elsewhere in the same bullet
+# (e.g. trailing "this must not be enforced") still indicates weakening.
+_PROHIBITION_VERB_PATTERN_TEXTS = {
+    r"\bDO NOT\b",
+    r"\bdo not\b",
+    r"\bdoes not\b",
+    r"\bdoesn'?t\b",
+    r"\bdon'?t\b",
+    r"\bmust not\b",
+    r"\bmustn'?t\b",
+}
+
+
+def _match_excludes_negation(
+    text_window: str,
+    allow_prohibition: bool = False,
+    matched_span: tuple[int, int] | None = None,
+) -> bool:
+    """Return True if the bullet window around an obligation match does NOT
     contain any negation that would weaken it.
 
-    `allow_prohibition=True` exempts only the literal `DO NOT` imperative
-    token (the prohibition obligation itself, e.g. C3 anti-fake-audit
-    guard's "DO NOT simulate" / "DO NOT claim to have run"). All OTHER
-    general negation patterns (cannot / must not / not required / need
-    not / etc.) still apply, so a window like "DO NOT simulate ...
-    this is not required" is still rejected (R4-001).
+    `allow_prohibition=True` exempts the literal prohibition tokens
+    (DO NOT / do not / does not / must not / etc.) **only when they fall
+    inside the matched obligation span**. A trailing "this must not be
+    enforced" outside the matched span still rejects (B2 R3-001).
 
-    The `_ALWAYS_NEGATION_PATTERNS` (rarely, sometimes, fails to,
-    optional, etc.) apply regardless because no legitimate obligation
+    The `_ALWAYS_NEGATION_PATTERNS` (rarely, sometimes, fails to, optional,
+    except, unless, etc.) apply regardless because no legitimate obligation
     framing should rely on those.
+
+    `matched_span` is `(start, end)` relative to `text_window`. When None
+    or `allow_prohibition=False`, prohibition tokens anywhere in the
+    window count as weakeners.
     """
     if any(p.search(text_window) for p in _ALWAYS_NEGATION_PATTERNS):
         return False
-    # When the caller signals this is a prohibition obligation, the
-    # subject-verb negation forms ("does not paraphrase", "DO NOT
-    # simulate") are how the obligation is *expressed*, not weakened.
-    # Exempt those forms but still enforce adjective-targeted negation
-    # ("not required", "not non-negotiable") and explicit weakeners
-    # (no buffer, no enumeration), which always indicate the contract
-    # is being undone rather than asserted.
-    PROHIBITION_VERB_PATTERNS = {
-        r"\bDO NOT\b",
-        r"\bdo not\b",
-        r"\bdoes not\b",
-        r"\bdoesn'?t\b",
-        r"\bdon'?t\b",
-        # `must not` is a prohibition expression of obligation, not a
-        # weakener — used in C3 ("Output metadata must not claim audit-
-        # passed state") and equivalent verbatim-only style rules.
-        r"\bmust not\b",
-        r"\bmustn'?t\b",
-    }
     for p in _GENERAL_NEGATION_PATTERNS:
-        if allow_prohibition and p.pattern in PROHIBITION_VERB_PATTERNS:
-            continue
-        if p.search(text_window):
+        is_prohibition_pattern = p.pattern in _PROHIBITION_VERB_PATTERN_TEXTS
+        for hit in p.finditer(text_window):
+            if (
+                allow_prohibition
+                and is_prohibition_pattern
+                and matched_span is not None
+                and hit.start() >= matched_span[0]
+                and hit.end() <= matched_span[1]
+            ):
+                # Prohibition token sits inside the matched obligation
+                # span — it is the obligation's own vocabulary, not a
+                # weakener. Skip this hit.
+                continue
             return False
     return True
 
@@ -259,7 +285,17 @@ class Check:
                 next_break = min(fwd_breaks) if fwd_breaks else -1
                 bullet_end = end + next_break if next_break >= 0 else lookahead_ceiling
                 window = scoped[bullet_start:bullet_end]
-                if _match_excludes_negation(window, allow_prohibition=allow_prohibition):
+                # Span of THIS obligation match within the window, so the
+                # negation filter can distinguish prohibition vocabulary
+                # that is the obligation itself ("DO NOT simulate") from
+                # a SECOND prohibition elsewhere in the bullet that
+                # weakens it (B2 R3-001).
+                match_in_window = (start - bullet_start, end - bullet_start)
+                if _match_excludes_negation(
+                    window,
+                    allow_prohibition=allow_prohibition,
+                    matched_span=match_in_window,
+                ):
                     accepted = True
                     break
             if not accepted:
@@ -443,7 +479,10 @@ def synthesis_agent_checks() -> list[Check]:
     """Spec §6.1 — synthesis_agent A1-A5 protection.
 
     Scoped to the PATTERN PROTECTION (v3.6.7) block so keyword presence
-    elsewhere in the agent prompt does not count toward passing.
+    elsewhere in the agent prompt does not count toward passing. All five
+    rules use must_contain_regex (not raw must_contain tokens) so the
+    weakening filter rejects mutations like "pending verification language
+    is optional" (B2 R3-002).
     """
     return [
         Check(
@@ -451,18 +490,43 @@ def synthesis_agent_checks() -> list[Check]:
             description="synthesis_agent carries 5 narrative-side protection clauses",
             target=SYNTHESIS_AGENT,
             block_marker=PROTECTION_BLOCK,
-            must_contain=[
-                # A1 — cross-section consistency self-check
-                "effect inventory",
-                "cross-section consistency",
-                # A2 — pending-verification hedge
-                "pending verification",
-                # A3 — anchor justification
-                "anchor justification",
-                # A4 — quote scope boundary
-                "verified phrase boundary",
-            ],
             must_contain_regex=[
+                # A1 — cross-section consistency self-check. Bullet must
+                # directive both the effect-inventory step and the
+                # consistency self-check; "is recommended" / "may run" /
+                # "optional" qualifiers are caught by the negation filter.
+                (
+                    "A1 effect inventory + cross-section consistency self-check",
+                    r"\beffect inventory\b[^.\n]{0,200}\bcross-section consistency\b",
+                ),
+                # A2 — pending-verification hedge. "wrap claims in explicit
+                # hedge" is the imperative; mutating to "pending verification
+                # language is optional" trips the optional-noun weakener
+                # only if the noun is in the narrowed list. Use a regex
+                # anchored on "wrap claims" so the imperative verb is
+                # required (R3-002 mutation evidence).
+                (
+                    "A2 pending-verification hedge wrap",
+                    r"\bpending verification\b[^.\n]{0,200}\bwrap claims\b[^.\n]{0,200}\bexplicit hedge\b",
+                ),
+                # A3 — anchor justification. "include a one-line anchor
+                # justification" is the imperative; bare token "anchor
+                # justification" alone could be subverted with "anchor
+                # justification is optional".
+                (
+                    "A3 one-line anchor justification (include)",
+                    r"\binclude\s+a\s+one[- ]line\s+anchor justification\b",
+                ),
+                # A4 — quote scope boundary. "Verbatim quotes only within
+                # the verified phrase boundary" is the imperative; mutating
+                # to "Verbatim quotes are not restricted to the verified
+                # phrase boundary" is caught by `not\s+restricted` only if
+                # listed; safer to require the "only within ... boundary"
+                # phrasing.
+                (
+                    "A4 verbatim quotes only within verified phrase boundary",
+                    r"\bVerbatim quotes\s+only\s+within\s+the\s+verified phrase boundary\b",
+                ),
                 # A5 — declarative claims about un-provided documents must be
                 # explicitly forbidden in one contiguous injunction, sentence-
                 # bounded so unrelated clauses elsewhere in the block do not
@@ -477,23 +541,34 @@ def synthesis_agent_checks() -> list[Check]:
 
 
 def architect_agent_checks() -> list[Check]:
-    """Spec §6.2 — research_architect_agent (survey designer mode) B1-B5 protection."""
+    """Spec §6.2 — research_architect_agent (survey designer mode) B1-B5
+    protection. B1, B2, B5 use must_contain_regex with imperative verbs
+    anchored so a mutation like "passing through the IRB glossary is
+    optional" or "construct equivalence justification is recommended"
+    is rejected by the weakening filter (B2 R3-002).
+    """
     return [
         Check(
             pattern_id="B1-B5",
             description="research_architect_agent (survey designer) carries 5 instrument-side protection clauses",
             target=ARCHITECT_AGENT,
             block_marker=PROTECTION_BLOCK,
-            must_contain=[
-                # B1 — IRB terminology pass-through (back-pointer to glossary)
-                "irb_terminology_glossary.md",
-                # B2 — reverse-coded construct equivalence
-                "construct-equivalence",
-                "reverse-coded",
-                # B5 — primary-source list enumeration (named term)
-                "primary-source list",
-            ],
             must_contain_regex=[
+                # B1 — IRB terminology pass-through. "must pass through ...
+                # before output" is the imperative; the glossary back-pointer
+                # is part of the obligation.
+                (
+                    "B1 IRB terminology pass-through (must, before output)",
+                    r"\bmust\s+pass\s+through\b[^.\n]{0,200}\birb_terminology_glossary\.md\b[^.\n]{0,200}\bbefore output\b",
+                ),
+                # B2 — reverse-coded construct equivalence. "include a one-
+                # line construct-equivalence justification" is the imperative
+                # that survives mutations like "construct-equivalence
+                # justification is recommended".
+                (
+                    "B2 reverse-coded construct-equivalence justification",
+                    r"\breverse-coded\b[^.\n]{0,200}\binclude\s+a\s+one[- ]line\s+construct-equivalence justification\b",
+                ),
                 # B3 — retrospective items default to event-anchored;
                 # calendar-anchored is conditional on a shared event date.
                 # Spec wording naturally spans two sentences ("default to..."
@@ -536,13 +611,30 @@ def compiler_agent_checks() -> list[Check]:
             description="report_compiler_agent (abstract-only) carries 3 publication-side protection clauses incl. anti-fake-audit guard",
             target=COMPILER_AGENT,
             block_marker=PROTECTION_BLOCK,
-            must_contain=[
-                # C1 — word-count algorithm
-                "whitespace-split",
-                # C2 — temporal disambiguation marker
-                "explicit year range",
-            ],
             must_contain_regex=[
+                # C1 word-count algorithm. "uses whitespace-split convention"
+                # is the imperative. R3-002 evidence: bare token
+                # "whitespace-split" passed even when surrounding prose was
+                # mutated; require the imperative phrasing.
+                (
+                    "C1 whitespace-split convention (uses)",
+                    r"\bWord budget\s+uses\s+whitespace-split\s+convention\b",
+                ),
+                # C2 temporal disambiguation. "Reflexivity disclosure must
+                # use explicit temporal bounds" is the imperative. Mutating
+                # to "may use" / "are allowed when shorter" is caught by
+                # the weakening filter on `may` and exception qualifiers
+                # (R3-002 + R3-003).
+                (
+                    "C2 reflexivity disclosure must use explicit year range",
+                    r"\bReflexivity disclosure\s+must\s+use\s+explicit temporal bounds\b[^.\n]{0,200}\bexplicit year range\b",
+                ),
+                # C2 deictic forbidden — paired with above so a mutation
+                # that drops the prohibition still fails.
+                (
+                    "C2 deictic temporal phrases forbidden",
+                    r"\bDeictic temporal phrases\b[^.\n]{0,200}\bare forbidden\b",
+                ),
                 # C1 — protected hedges are budget-protected / non-negotiable
                 # / verbatim. Sentence-bounded; negation post-filter rejects
                 # "are not non-negotiable" (R2-004) AND must reject inverted

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -106,6 +106,15 @@ _ALWAYS_NEGATION_PATTERNS = [
     re.compile(r"\bare unable to\b", re.IGNORECASE),
     re.compile(r"\bonly when convenient\b", re.IGNORECASE),
     re.compile(r"\bif (?:space|time) (?:allows|permits)\b", re.IGNORECASE),
+    # Feasibility qualifiers (R6-001). "when possible" / "where possible"
+    # /etc. tail-attached to an obligation phrase silently downgrades it
+    # from mandatory to best-effort.
+    re.compile(r"\bwhen\s+possible\b", re.IGNORECASE),
+    re.compile(r"\bwhere\s+possible\b", re.IGNORECASE),
+    re.compile(r"\bwherever\s+feasible\b", re.IGNORECASE),
+    re.compile(r"\bif\s+practical\b", re.IGNORECASE),
+    re.compile(r"\bif\s+feasible\b", re.IGNORECASE),
+    re.compile(r"\bbest[- ]effort\b", re.IGNORECASE),
 ]
 
 

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Static audit for ARS v3.6.7 downstream-agent pattern protection.
+
+Spec: docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md
+
+Greps the v3.6.7 reference files, audit template, and downstream agent prompts
+for the keywords that make each pattern-protection clause detectable. Static
+only — does not validate runtime behaviour. Behavioural validation belongs to
+spec §9 step 8 (live pipeline evaluation case) and is out of scope here.
+
+Exit codes: 0 on pass, 1 on any failure.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+REF_DIR = REPO_ROOT / "shared" / "references"
+TPL_DIR = REPO_ROOT / "shared" / "templates"
+AGENT_DIR = REPO_ROOT / "deep-research" / "agents"
+
+SYNTHESIS_AGENT = AGENT_DIR / "synthesis_agent.md"
+ARCHITECT_AGENT = AGENT_DIR / "research_architect_agent.md"
+COMPILER_AGENT = AGENT_DIR / "report_compiler_agent.md"
+
+
+@dataclass
+class Check:
+    pattern_id: str
+    description: str
+    target: Path
+    must_contain: list[str]
+    _needles: list[str] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Match case-insensitively so Markdown headings ("Primary-source integrity")
+        # satisfy a check that names the term in lowercase.
+        self._needles = [s.lower() for s in self.must_contain]
+
+    def run(self) -> tuple[bool, str]:
+        if not self.target.exists():
+            return False, f"target file missing: {self.target.relative_to(REPO_ROOT)}"
+        text = self.target.read_text(encoding="utf-8").lower()
+        missing = [s for s, n in zip(self.must_contain, self._needles) if n not in text]
+        if missing:
+            return False, f"missing keywords in {self.target.relative_to(REPO_ROOT)}: {missing}"
+        return True, "OK"
+
+
+def reference_file_checks() -> list[Check]:
+    """Spec §7.1 — 4 reference files."""
+    return [
+        Check(
+            pattern_id="REF-1 (B1)",
+            description="irb_terminology_glossary covers 4 IRB terms with operational distinctions",
+            target=REF_DIR / "irb_terminology_glossary.md",
+            must_contain=[
+                "Anonymity",
+                "Confidentiality",
+                "De-identification",
+                "Pseudonymization",
+            ],
+        ),
+        Check(
+            pattern_id="REF-2 (B2)",
+            description="psychometric_terminology_glossary distinguishes true reverse-coded vs contrast",
+            target=REF_DIR / "psychometric_terminology_glossary.md",
+            must_contain=[
+                "true reverse-coded",
+                "contrast item",
+                "acquiescence",
+                "recall bias",
+            ],
+        ),
+        Check(
+            pattern_id="REF-3 (C1)",
+            description="protected_hedging_phrases defines upstream-marked hedge protocol",
+            target=REF_DIR / "protected_hedging_phrases.md",
+            must_contain=[
+                "protected hedging phrases",
+                "upstream calibration",
+                "word budget",
+            ],
+        ),
+        Check(
+            pattern_id="REF-4 (word-count)",
+            description="word_count_conventions specifies whitespace-split + 3-5% buffer",
+            target=REF_DIR / "word_count_conventions.md",
+            must_contain=[
+                "whitespace",
+                "split()",
+                "3–5%",
+                "hyphenated",
+            ],
+        ),
+    ]
+
+
+def template_file_checks() -> list[Check]:
+    """Spec §7.2 — audit prompt template."""
+    return [
+        Check(
+            pattern_id="TPL-1 (D1)",
+            description="codex_audit_multifile_template enumerates 7 audit dimensions",
+            target=TPL_DIR / "codex_audit_multifile_template.md",
+            must_contain=[
+                "cross-ref",
+                "hallucination",
+                "primary-source integrity",
+                "internal coherence",
+                "instrument quality",
+                "Round-N framing",
+                "COI adequacy",
+            ],
+        ),
+    ]
+
+
+def synthesis_agent_checks() -> list[Check]:
+    """Spec §6.1 — synthesis_agent A1-A5 protection."""
+    must = [
+        # Block marker
+        "PATTERN PROTECTION (v3.6.7)",
+        # A1 — cross-section consistency
+        "effect inventory",
+        "cross-section consistency",
+        # A2 — pending verification hedge
+        "pending verification",
+        # A3 — anchor justification
+        "anchor justification",
+        # A4 — quote scope
+        "verified phrase boundary",
+        # A5 — sibling-document fabrication. The injunction phrase
+        # "Declarative claims ... are forbidden" is what distinguishes
+        # an actual prohibition from narrative vocabulary about it.
+        "declarative claims about un-provided",
+        "are forbidden",
+    ]
+    return [
+        Check(
+            pattern_id="A1-A5",
+            description="synthesis_agent carries 5 narrative-side protection clauses",
+            target=SYNTHESIS_AGENT,
+            must_contain=must,
+        )
+    ]
+
+
+def architect_agent_checks() -> list[Check]:
+    """Spec §6.2 — research_architect_agent (survey designer mode) B1-B5 protection."""
+    must = [
+        "PATTERN PROTECTION (v3.6.7)",
+        # B1 — IRB terminology pass-through
+        "irb_terminology_glossary.md",
+        # B2 — reverse-coded construct equivalence
+        "construct-equivalence",
+        "reverse-coded",
+        # B3 — retrospective event-anchored phrasing
+        "event-anchored",
+        # B4 — neutral/balanced phrasing
+        "neutral",
+        "all valences",
+        # B5 — primary-source list enumeration
+        "primary-source list",
+    ]
+    return [
+        Check(
+            pattern_id="B1-B5",
+            description="research_architect_agent (survey designer) carries 5 instrument-side protection clauses",
+            target=ARCHITECT_AGENT,
+            must_contain=must,
+        )
+    ]
+
+
+def compiler_agent_checks() -> list[Check]:
+    """Spec §6.3 — report_compiler_agent (abstract-only mode) C1-C3 protection."""
+    must = [
+        "PATTERN PROTECTION (v3.6.7)",
+        # C1 — word-count + buffer
+        "whitespace-split",
+        # Compression hedge protection
+        "protected hedging phrases",
+        # C2 — temporal disambiguation
+        "explicit year range",
+        # C3 — anti-fake-audit guard (THE critical clause per feedback_subagent_tool_hallucination.md)
+        "DO NOT simulate",
+        "DO NOT claim to have run",
+    ]
+    return [
+        Check(
+            pattern_id="C1-C3",
+            description="report_compiler_agent (abstract-only) carries 3 publication-side protection clauses incl. anti-fake-audit guard",
+            target=COMPILER_AGENT,
+            must_contain=must,
+        )
+    ]
+
+
+def all_checks() -> list[Check]:
+    return [
+        *reference_file_checks(),
+        *template_file_checks(),
+        *synthesis_agent_checks(),
+        *architect_agent_checks(),
+        *compiler_agent_checks(),
+    ]
+
+
+def main(argv: list[str]) -> int:
+    checks = all_checks()
+    passed: list[Check] = []
+    failed: list[tuple[Check, str]] = []
+
+    for check in checks:
+        ok, msg = check.run()
+        if ok:
+            passed.append(check)
+        else:
+            failed.append((check, msg))
+
+    summary = f"v3.6.7 pattern-protection static audit: {len(passed)}/{len(checks)} checks passed"
+    print(summary)
+    print()
+
+    if passed:
+        print("PASS:")
+        for c in passed:
+            print(f"  [{c.pattern_id}] {c.description}")
+        print()
+
+    if failed:
+        # Failures go to stderr so CI harnesses that route stderr to a failure
+        # channel (matching scripts/check_corpus_consumer_protocol.py) surface
+        # the diagnostics correctly.
+        print("FAIL:", file=sys.stderr)
+        for c, msg in failed:
+            print(f"  [{c.pattern_id}] {c.description}", file=sys.stderr)
+            print(f"      → {msg}", file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            f"{len(failed)} check(s) failed. See spec for protection clause wording:",
+            file=sys.stderr,
+        )
+        print(
+            "  docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -22,6 +22,7 @@ Exit codes: 0 on pass, 1 on any failure.
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -41,31 +42,70 @@ COMPILER_AGENT = AGENT_DIR / "report_compiler_agent.md"
 # starts at the marker and ends at the next H1/H2/H3 heading or EOF.
 _HEADING_RE = re.compile(r"^#{1,3} ", re.MULTILINE)
 
-# Negation patterns that, if present in a matched obligation sentence, indicate
-# the obligation is being denied or weakened rather than asserted. R2-004
-# flagged that "does not enumerate fully" / "not non-negotiable" can satisfy
-# a naive obligation regex while undermining the contract. We post-filter
-# matches against this list.
-_NEGATION_PATTERNS = [
+# Negation / weakening patterns that, if present in the sentence containing
+# an obligation match, indicate the obligation is being denied or weakened
+# rather than asserted. R2-004 flagged "does not enumerate fully" / "not non-
+# negotiable"; R3-002 expanded the list with should not / fails to / instead
+# of / rarely / sometimes / is unable to. The patterns split into two groups:
+#
+# - _GENERAL_NEGATION_PATTERNS: DO NOT-style imperative prohibitions and
+#   weakening modals. These reject most obligations BUT they would also
+#   reject a legitimate prohibition like C3's "DO NOT simulate". For
+#   prohibition-style obligations, callers pass `allow_prohibition=True` to
+#   skip this group.
+# - _ALWAYS_NEGATION_PATTERNS: weakening verbs and adverbs that never
+#   constitute a valid prohibition signal (rarely / sometimes / fails to /
+#   etc.). These apply regardless of `allow_prohibition`.
+_GENERAL_NEGATION_PATTERNS = [
     re.compile(r"\bdoes not\b", re.IGNORECASE),
     re.compile(r"\bdo not\b", re.IGNORECASE),
+    re.compile(r"\bDO NOT\b"),  # case-sensitive imperative form
     re.compile(r"\bdoesn'?t\b", re.IGNORECASE),
     re.compile(r"\bdon'?t\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+(?:non[- ]negotiable|enumerate|required|mandatory|forbidden|verbatim)\b", re.IGNORECASE),
+    re.compile(r"\bshould not\b", re.IGNORECASE),
+    re.compile(r"\bshouldn'?t\b", re.IGNORECASE),
+    re.compile(r"\bmust not\b", re.IGNORECASE),
+    re.compile(r"\bmustn'?t\b", re.IGNORECASE),
+    re.compile(r"\bcannot\b", re.IGNORECASE),
+    re.compile(r"\bcan'?t\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+(?:non[- ]negotiable|enumerate|required|mandatory|forbidden|verbatim|reserved)\b", re.IGNORECASE),
     re.compile(r"\bneed not\b", re.IGNORECASE),
+    re.compile(r"\bno\s+buffer\b", re.IGNORECASE),
+    re.compile(r"\bno\s+enumeration\b", re.IGNORECASE),
+]
+_ALWAYS_NEGATION_PATTERNS = [
     re.compile(r"\bisn'?t\b", re.IGNORECASE),
     re.compile(r"\baren'?t\b", re.IGNORECASE),
     re.compile(r"\boptional\b", re.IGNORECASE),
-    re.compile(r"\bmay\s+(?:not\s+)?(?:invite|enumerate|preserve)\b", re.IGNORECASE),
+    re.compile(r"\bmay\s+(?:not\s+)?(?:invite|enumerate|preserve|drop|skip|substitute)\b", re.IGNORECASE),
+    re.compile(r"\bfails? to\b", re.IGNORECASE),
+    re.compile(r"\binstead of\b", re.IGNORECASE),
+    re.compile(r"\brarely\b", re.IGNORECASE),
+    re.compile(r"\bsometimes\b", re.IGNORECASE),
+    re.compile(r"\boccasionally\b", re.IGNORECASE),
+    re.compile(r"\bis unable to\b", re.IGNORECASE),
+    re.compile(r"\bare unable to\b", re.IGNORECASE),
+    re.compile(r"\bonly when convenient\b", re.IGNORECASE),
+    re.compile(r"\bif (?:space|time) (?:allows|permits)\b", re.IGNORECASE),
 ]
 
 
-def _match_excludes_negation(text_window: str) -> bool:
-    """Return True if the matched window does NOT contain any negation that
-    would weaken the obligation. Used to reject 'does not enumerate fully' or
-    'not non-negotiable' false positives that the obligation regex alone
-    cannot exclude."""
-    return not any(p.search(text_window) for p in _NEGATION_PATTERNS)
+def _match_excludes_negation(text_window: str, allow_prohibition: bool = False) -> bool:
+    """Return True if the sentence around an obligation match does NOT
+    contain any negation that would weaken it.
+
+    `allow_prohibition=True` exempts the match from `_GENERAL_NEGATION_PATTERNS`
+    (DO NOT / cannot / must not), so prohibition-style obligations like the
+    C3 anti-fake-audit guard ("DO NOT simulate ... DO NOT claim to have
+    run") can still be detected. The `_ALWAYS_NEGATION_PATTERNS` (rarely,
+    sometimes, fails to, optional, etc.) apply regardless because no
+    legitimate obligation framing should rely on those.
+    """
+    if any(p.search(text_window) for p in _ALWAYS_NEGATION_PATTERNS):
+        return False
+    if not allow_prohibition and any(p.search(text_window) for p in _GENERAL_NEGATION_PATTERNS):
+        return False
+    return True
 
 
 @dataclass
@@ -117,31 +157,46 @@ class Check:
             if match is None:
                 missing_regex.append(label)
                 continue
-            # Reject if the matched window or its preceding sentence context
-            # contains a negation that would weaken the obligation (per
-            # R2-004). The negation check looks at the sentence containing
-            # the match — from the prior sentence boundary up through the
-            # match itself — so weakeners like "does not enumerate fully"
-            # or "may invite all valences" do not count as obligations.
+            # Reject if the full sentence containing the match (both the
+            # text before AND after the match) carries a negation that
+            # weakens the obligation (per R2-004 + R3-001). The check looks
+            # backward from the match start to the prior sentence boundary
+            # AND forward from the match end to the next sentence boundary,
+            # so weakeners after the matched phrase ("enumerate fully ...
+            # is not required") are caught.
             iterator = re.finditer(pattern, scoped, re.IGNORECASE | re.DOTALL)
             accepted = False
             for m in iterator:
-                # Find sentence start: nearest preceding `.` `!` `?` or
-                # newline, or start of scoped text. Limit lookback to 200
-                # chars so a long block does not accidentally pull in an
-                # unrelated negation from far above.
-                start = m.start()
+                start, end = m.start(), m.end()
+                # Lookback to prior sentence break, capped at 200 chars.
                 lookback_floor = max(0, start - 200)
                 lookback = scoped[lookback_floor:start]
-                last_sentence_break = max(
+                last_break_back = max(
                     lookback.rfind("."),
                     lookback.rfind("!"),
                     lookback.rfind("?"),
                     lookback.rfind("\n"),
                 )
-                sentence_start = lookback_floor + last_sentence_break + 1 if last_sentence_break >= 0 else lookback_floor
-                window = scoped[sentence_start:m.end()]
-                if _match_excludes_negation(window):
+                sentence_start = (
+                    lookback_floor + last_break_back + 1
+                    if last_break_back >= 0
+                    else lookback_floor
+                )
+                # Lookahead to next sentence break, capped at 200 chars.
+                lookahead_ceiling = min(len(scoped), end + 200)
+                lookahead = scoped[end:lookahead_ceiling]
+                next_break = min(
+                    [i for i in (
+                        lookahead.find("."),
+                        lookahead.find("!"),
+                        lookahead.find("?"),
+                        lookahead.find("\n"),
+                    ) if i >= 0],
+                    default=-1,
+                )
+                sentence_end = end + next_break + 1 if next_break >= 0 else lookahead_ceiling
+                window = scoped[sentence_start:sentence_end]
+                if _match_excludes_negation(window, allow_prohibition=label.startswith("C3")):
                     accepted = True
                     break
             if not accepted:
@@ -228,13 +283,13 @@ def template_file_checks() -> list[Check]:
         # (iii) abstract no less hedged than body. R1-006 upgraded this from
         # an example to a mandatory contract; lint must verify the contract
         # rides verbatim in the template, not just the prose around it.
+        # Scoped to the `report_compiler_agent bundle` clause so scattered
+        # text elsewhere in the template cannot satisfy the contract (R3-004).
         Check(
             pattern_id="TPL-2 (4f-compiler)",
             description="audit template encodes mandatory three-part (f) check for report_compiler bundles",
             target=TPL_DIR / "codex_audit_multifile_template.md",
-            must_contain=[
-                "report_compiler_agent bundle",
-            ],
+            block_marker="report_compiler_agent bundle (mandatory three-part check)",
             must_contain_regex=[
                 # Sub-check (i): whitespace-split cap minus 3-5% buffer
                 (
@@ -384,14 +439,36 @@ def compiler_agent_checks() -> list[Check]:
     ]
 
 
+# Environment variable controlling whether agent-prompt checks run.
+#
+# v3.6.7 implementation lands across multiple PRs: Step 1 ships the 4
+# reference files + audit template + this lint; Steps 2-4 land the actual
+# PATTERN PROTECTION (v3.6.7) blocks in the three downstream agent prompts.
+# Until Step 2-4 ship, the agent-prompt checks fail by design (the marker
+# does not exist yet). Running those checks in CI before Step 2-4 ship
+# would produce a misleading red.
+#
+# Default: agent-prompt checks are skipped. Set ARS_V3_6_7_AGENT_CHECKS=1
+# to enable them. Step 2-4 PRs will flip the default to enabled.
+_AGENT_CHECKS_ENV = "ARS_V3_6_7_AGENT_CHECKS"
+
+
+def _agent_checks_enabled() -> bool:
+    return os.environ.get(_AGENT_CHECKS_ENV, "0") == "1"
+
+
 def all_checks() -> list[Check]:
-    return [
+    checks = [
         *reference_file_checks(),
         *template_file_checks(),
-        *synthesis_agent_checks(),
-        *architect_agent_checks(),
-        *compiler_agent_checks(),
     ]
+    if _agent_checks_enabled():
+        checks.extend([
+            *synthesis_agent_checks(),
+            *architect_agent_checks(),
+            *compiler_agent_checks(),
+        ])
+    return checks
 
 
 def main(argv: list[str]) -> int:
@@ -406,7 +483,13 @@ def main(argv: list[str]) -> int:
         else:
             failed.append((check, msg))
 
-    summary = f"v3.6.7 pattern-protection static audit: {len(passed)}/{len(checks)} checks passed"
+    deferred_note = ""
+    if not _agent_checks_enabled():
+        deferred_note = " (agent-prompt checks deferred — set ARS_V3_6_7_AGENT_CHECKS=1 to enable)"
+    summary = (
+        f"v3.6.7 pattern-protection static audit: {len(passed)}/{len(checks)} "
+        f"checks passed{deferred_note}"
+    )
     print(summary)
     print()
 

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -84,6 +84,17 @@ _GENERAL_NEGATION_PATTERNS = [
     # patterns are tight enough to catch genuine weakening even without
     # `cannot`.
 ]
+# Modal weakeners (`may`, `should`, `can`) downgrade mandatory obligations
+# to advisory. They are scoped to a verb list so the bare token does not
+# match unrelated prose ("you may want to see references/...", "this can
+# be useful"). The verb list covers imperatives the v3.6.7 agent prompts
+# actually use.
+_MODAL_WEAKENED_VERBS = (
+    r"(?:invite|enumerate|preserve|drop|skip|substitute|paraphrase"
+    r"|wrap|include|default|defaults?|run|use|declare|pass(?:\s+through)?"
+    r"|claim|cite|fall\s+back|be\s+quoted|be\s+permitted|use\s+chapter)"
+)
+
 _ALWAYS_NEGATION_PATTERNS = [
     re.compile(r"\bisn'?t\b", re.IGNORECASE),
     re.compile(r"\baren'?t\b", re.IGNORECASE),
@@ -104,17 +115,17 @@ _ALWAYS_NEGATION_PATTERNS = [
     # are allowed when shorter" and B5's "Over-setting ... are allowed"
     # when those structures slip past the per-rule regex.
     re.compile(r"\b(?:is|are)\s+allowed\b", re.IGNORECASE),
-    # Same narrowing for `may` — only flag when `may` directly weakens an
-    # action verb that should be obligatory. Verb list expanded in B2 R4-001
-    # to cover the imperative verbs the agent prompts use (wrap, include,
-    # default, run, use, declare, pass, claim, cite, fall back).
-    re.compile(
-        r"\bmay\s+(?:not\s+)?"
-        r"(?:invite|enumerate|preserve|drop|skip|substitute|paraphrase"
-        r"|wrap|include|default|defaults?|run|use|declare|pass(?:\s+through)?"
-        r"|claim|cite|fall\s+back|be\s+quoted|use\s+chapter)\b",
-        re.IGNORECASE,
-    ),
+    # Same narrowing for `may` / `should` / `can` — only flag when the modal
+    # directly precedes one of the obligation verbs the v3.6.7 prompts use.
+    # B2 R4-001 expanded the verb list; B2 R5-001 added `should` / `can`
+    # to the modal coverage.
+    re.compile(rf"\bmay\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    re.compile(rf"\bshould\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    re.compile(rf"\bcan\s+(?:not\s+)?{_MODAL_WEAKENED_VERBS}\b", re.IGNORECASE),
+    # B2 R5-001: "is/are permitted" turns a forbidden operation into an
+    # exception ("over-setting is permitted when concise"). Mirrors the
+    # `is/are allowed` pattern.
+    re.compile(r"\b(?:is|are)\s+permitted\b", re.IGNORECASE),
     re.compile(r"\bfails? to\b", re.IGNORECASE),
     re.compile(r"\binstead of\b", re.IGNORECASE),
     # `rarely` / `sometimes` / `occasionally` similarly need to be near

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -295,33 +295,43 @@ def reference_file_checks() -> list[Check]:
                 "word budget",
             ],
             must_contain_regex=[
-                # Rule 1: conservative inclusion — when in doubt, include
+                # Rule 1: conservative inclusion — "include the phrase" is
+                # the operative directive (R5-002 mutation showed
+                # "ask upstream for advice" was previously accepted).
                 (
                     "Rule: Conservative inclusion",
-                    r"\bConservative inclusion\b.{0,200}\bWhen in doubt\b",
+                    r"\bConservative inclusion\b.{0,200}\bWhen in doubt\b.{0,150}\binclude\s+the\s+phrase\b",
                 ),
-                # Rule 2: anchor every entry
+                # Rule 2: anchor every entry — "where … and why" is the
+                # specific obligation; bare "must cite" was previously
+                # accepted with weakened content.
                 (
-                    "Rule: Anchor every entry",
-                    r"\bAnchor every entry\b.{0,200}\bmust\s+cite\b",
+                    "Rule: Anchor every entry (where + why)",
+                    r"\bAnchor every entry\b.{0,200}\bmust\s+cite\s+where\b.{0,200}\bwhy\b",
                 ),
-                # Rule 3: no duplicates
+                # Rule 3: no duplicates — bullet body must assert
+                # "One entry per phrase" then back-reference the count.
+                # R5-002 showed bare "One entry per phrase" alone could be
+                # suffixed with "is optional" and still pass; require the
+                # full "One entry per phrase. The compiler counts ... once"
+                # sequence so a tail weakener cannot land between them.
+                # Allow Markdown markup (`**`) between the heading word and
+                # the body sentence.
                 (
                     "Rule: No duplicates",
-                    r"\bNo duplicates\b.{0,150}\bOne entry per phrase\b",
+                    r"\bNo duplicates\b[\s.*\-]{0,10}One entry per phrase\.\s+The compiler counts[^.]{0,150}\bonce\b",
                 ),
-                # Rule 4: verbatim preservation
+                # Rule 4: verbatim preservation — both the title and the
+                # imperative body ("does not paraphrase") must appear.
                 (
                     "Rule: Verbatim preservation",
-                    r"\bVerbatim preservation\b.{0,200}\brides\s+verbatim\b",
+                    r"\bVerbatim preservation\b.{0,250}\brides\s+verbatim\b.{0,300}\bdoes\s+not\s+paraphrase\b",
                 ),
-                # Rule 5: failure surface — report conflict, do not drop hedge.
-                # Sentence-bounded so the surrounding "if abstract cannot fit"
-                # conditional in the prose does not poison the negation
-                # filter on this regex's match window.
+                # Rule 5: failure surface — must say "rather than dropping",
+                # not "while dropping" (R5-002 mutation flipped this).
                 (
                     "Rule: Conflict reporting (no silent drop)",
-                    r"\breports the conflict\b[^.\n]{0,200}\bdropping a protected hedge\b",
+                    r"\breports the conflict\b[^.\n]{0,100}\brather than\s+dropping a protected hedge\b",
                 ),
             ],
         ),
@@ -374,20 +384,29 @@ def template_file_checks() -> list[Check]:
                     "4f sub-check (i) word-count algorithm + buffer",
                     r"len\(body\.split\(\)\).{0,200}\b3[-–]5%\s+buffer\b",
                 ),
-                # Sub-check (ii): protected_hedges verbatim preservation
+                # Sub-check (ii): protected_hedges appear verbatim
+                # unconditionally. R5-003 mutation showed bare
+                # "appear verbatim when possible" was previously accepted;
+                # the obligation must be unconditional ("appears verbatim
+                # in the abstract" without "when possible" / "if space").
+                # The negation post-filter already rejects "when convenient"
+                # / "if space allows", so the regex requires the
+                # imperative-tense phrasing.
                 (
-                    "4f sub-check (ii) protected_hedges verbatim",
-                    r"protected_hedges\b.{0,300}\bverbatim\b",
+                    "4f sub-check (ii) protected_hedges verbatim (unconditional)",
+                    r"every entry of upstream\s+`?protected_hedges`?[^\n]{0,200}\bappears? verbatim in the abstract\b",
                 ),
-                # Sub-check (iii): abstract no less hedged than body
+                # Sub-check (iii): "no claim in the abstract is less hedged
+                # than its anchor in the body" — anchored on "no claim" so
+                # an inverted form ("every claim ... is less hedged") fails.
                 (
                     "4f sub-check (iii) less-hedged-than-body prohibition",
-                    r"less\s+hedged\s+than\s+its\s+anchor\s+in\s+the\s+body|no\s+claim\s+in\s+the\s+abstract\s+is\s+less\s+hedged",
+                    r"\bno claim in the abstract is less hedged than its anchor in the body\b",
                 ),
                 # P1 severity assignment for any sub-check failure
                 (
                     "4f failures severity P1",
-                    r"P1\s+finding\b",
+                    r"\bFailure of any sub-check is a P1 finding\b",
                 ),
             ],
         ),

--- a/scripts/check_v3_6_7_pattern_protection.py
+++ b/scripts/check_v3_6_7_pattern_protection.py
@@ -4,15 +4,25 @@
 Spec: docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md
 
 Greps the v3.6.7 reference files, audit template, and downstream agent prompts
-for the keywords that make each pattern-protection clause detectable. Static
-only — does not validate runtime behaviour. Behavioural validation belongs to
-spec §9 step 8 (live pipeline evaluation case) and is out of scope here.
+for the keywords and obligation phrases that make each pattern-protection
+clause detectable. Static only — does not validate runtime behaviour.
+Behavioural validation belongs to spec §9 step 8 (live pipeline evaluation
+case) and is out of scope here.
+
+Falsifiability discipline (per feedback_lint_passes_but_prompt_silent.md):
+- Agent-prompt checks scope grep to the `PATTERN PROTECTION (v3.6.7)` block
+  via `block_marker`. A keyword that lands outside the block in unrelated
+  prose does not count toward passing.
+- Obligation-bearing patterns (forbidden / required / only-if) are enforced
+  via `must_contain_regex` so the prohibition is grep-detectable as a
+  contiguous fragment, not as two unrelated nouns elsewhere in the file.
 
 Exit codes: 0 on pass, 1 on any failure.
 """
 
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -27,32 +37,71 @@ SYNTHESIS_AGENT = AGENT_DIR / "synthesis_agent.md"
 ARCHITECT_AGENT = AGENT_DIR / "research_architect_agent.md"
 COMPILER_AGENT = AGENT_DIR / "report_compiler_agent.md"
 
+# Markdown heading pattern that closes a `block_marker` scope. A check's scope
+# starts at the marker and ends at the next H1/H2/H3 heading or EOF.
+_HEADING_RE = re.compile(r"^#{1,3} ", re.MULTILINE)
+
 
 @dataclass
 class Check:
     pattern_id: str
     description: str
     target: Path
-    must_contain: list[str]
-    _needles: list[str] = field(init=False, repr=False)
+    must_contain: list[str] = field(default_factory=list)
+    must_contain_regex: list[tuple[str, str]] = field(default_factory=list)
+    block_marker: str | None = None
+    """If set, scope all keyword/regex checks to the text between the marker
+    and the next H1/H2/H3 heading. Use for agent-prompt checks where the
+    PATTERN PROTECTION clause must be inside its own block, not scattered
+    elsewhere in the file."""
 
-    def __post_init__(self) -> None:
-        # Match case-insensitively so Markdown headings ("Primary-source integrity")
-        # satisfy a check that names the term in lowercase.
-        self._needles = [s.lower() for s in self.must_contain]
+    def _scoped_text(self, full_text: str) -> tuple[str | None, str]:
+        """Return (scoped_text, error_message). scoped_text is None on failure."""
+        if self.block_marker is None:
+            return full_text, ""
+        marker_pos = full_text.lower().find(self.block_marker.lower())
+        if marker_pos == -1:
+            return None, f"block marker missing: {self.block_marker!r}"
+        # Find next heading after the marker; scope ends there.
+        rest = full_text[marker_pos:]
+        match = _HEADING_RE.search(rest, pos=len(self.block_marker))
+        scoped_end = marker_pos + (match.start() if match else len(rest))
+        return full_text[marker_pos:scoped_end], ""
+
+    def _display_path(self) -> str:
+        try:
+            return str(self.target.relative_to(REPO_ROOT))
+        except ValueError:
+            return str(self.target)
 
     def run(self) -> tuple[bool, str]:
+        display = self._display_path()
         if not self.target.exists():
-            return False, f"target file missing: {self.target.relative_to(REPO_ROOT)}"
-        text = self.target.read_text(encoding="utf-8").lower()
-        missing = [s for s, n in zip(self.must_contain, self._needles) if n not in text]
-        if missing:
-            return False, f"missing keywords in {self.target.relative_to(REPO_ROOT)}: {missing}"
+            return False, f"target file missing: {display}"
+        full = self.target.read_text(encoding="utf-8")
+        scoped, err = self._scoped_text(full)
+        if scoped is None:
+            return False, f"{display}: {err}"
+        scoped_lower = scoped.lower()
+        missing_substr = [s for s in self.must_contain if s.lower() not in scoped_lower]
+        missing_regex = [
+            label
+            for label, pattern in self.must_contain_regex
+            if not re.search(pattern, scoped, re.IGNORECASE | re.DOTALL)
+        ]
+        problems = []
+        if missing_substr:
+            problems.append(f"missing keywords: {missing_substr}")
+        if missing_regex:
+            problems.append(f"missing obligation phrases: {missing_regex}")
+        if problems:
+            scope_note = f" within {self.block_marker!r} block" if self.block_marker else ""
+            return False, f"{display}{scope_note}: {'; '.join(problems)}"
         return True, "OK"
 
 
 def reference_file_checks() -> list[Check]:
-    """Spec §7.1 — 4 reference files."""
+    """Spec §7.1 — 4 reference files. No block scoping; whole-file grep."""
     return [
         Check(
             pattern_id="REF-1 (B1)",
@@ -120,83 +169,120 @@ def template_file_checks() -> list[Check]:
     ]
 
 
+# Block marker every agent-prompt check scopes to. Defined once so the value
+# stays in sync across agents.
+PROTECTION_BLOCK = "PATTERN PROTECTION (v3.6.7)"
+
+
 def synthesis_agent_checks() -> list[Check]:
-    """Spec §6.1 — synthesis_agent A1-A5 protection."""
-    must = [
-        # Block marker
-        "PATTERN PROTECTION (v3.6.7)",
-        # A1 — cross-section consistency
-        "effect inventory",
-        "cross-section consistency",
-        # A2 — pending verification hedge
-        "pending verification",
-        # A3 — anchor justification
-        "anchor justification",
-        # A4 — quote scope
-        "verified phrase boundary",
-        # A5 — sibling-document fabrication. The injunction phrase
-        # "Declarative claims ... are forbidden" is what distinguishes
-        # an actual prohibition from narrative vocabulary about it.
-        "declarative claims about un-provided",
-        "are forbidden",
-    ]
+    """Spec §6.1 — synthesis_agent A1-A5 protection.
+
+    Scoped to the PATTERN PROTECTION (v3.6.7) block so keyword presence
+    elsewhere in the agent prompt does not count toward passing.
+    """
     return [
         Check(
             pattern_id="A1-A5",
             description="synthesis_agent carries 5 narrative-side protection clauses",
             target=SYNTHESIS_AGENT,
-            must_contain=must,
+            block_marker=PROTECTION_BLOCK,
+            must_contain=[
+                # A1 — cross-section consistency self-check
+                "effect inventory",
+                "cross-section consistency",
+                # A2 — pending-verification hedge
+                "pending verification",
+                # A3 — anchor justification
+                "anchor justification",
+                # A4 — quote scope boundary
+                "verified phrase boundary",
+            ],
+            must_contain_regex=[
+                # A5 — declarative claims about un-provided documents must be
+                # explicitly forbidden in one contiguous injunction, not split
+                # across unrelated clauses.
+                (
+                    "A5 contiguous injunction",
+                    r"declarative claims? about un-provided.{0,300}\bare forbidden\b",
+                ),
+            ],
         )
     ]
 
 
 def architect_agent_checks() -> list[Check]:
     """Spec §6.2 — research_architect_agent (survey designer mode) B1-B5 protection."""
-    must = [
-        "PATTERN PROTECTION (v3.6.7)",
-        # B1 — IRB terminology pass-through
-        "irb_terminology_glossary.md",
-        # B2 — reverse-coded construct equivalence
-        "construct-equivalence",
-        "reverse-coded",
-        # B3 — retrospective event-anchored phrasing
-        "event-anchored",
-        # B4 — neutral/balanced phrasing
-        "neutral",
-        "all valences",
-        # B5 — primary-source list enumeration
-        "primary-source list",
-    ]
     return [
         Check(
             pattern_id="B1-B5",
             description="research_architect_agent (survey designer) carries 5 instrument-side protection clauses",
             target=ARCHITECT_AGENT,
-            must_contain=must,
+            block_marker=PROTECTION_BLOCK,
+            must_contain=[
+                # B1 — IRB terminology pass-through (back-pointer to glossary)
+                "irb_terminology_glossary.md",
+                # B2 — reverse-coded construct equivalence
+                "construct-equivalence",
+                "reverse-coded",
+                # B5 — primary-source list enumeration (named term)
+                "primary-source list",
+            ],
+            must_contain_regex=[
+                # B3 — retrospective items default to event-anchored;
+                # calendar-anchored is conditional on a shared event date.
+                (
+                    "B3 retrospective default + calendar conditional",
+                    r"event-anchored.{0,400}\bcalendar[- ]anchored.{0,300}\bonly when\b",
+                ),
+                # B4 — open-text prompts invite all valences (positive +
+                # negative + neutral). Bare 'neutral' is too weak.
+                (
+                    "B4 open-text invites all valences",
+                    r"all valences|positive,? negative,? (?:or|and) neutral",
+                ),
+                # B5 — option lists must enumerate fully (no subsetting).
+                # Bare 'primary-source list' is too weak; require the
+                # subsetting prohibition.
+                (
+                    "B5 enumerate fully / no subsetting",
+                    r"enumerate(?:s|d)?\s+fully\b|no\s+subsetting\b",
+                ),
+            ],
         )
     ]
 
 
 def compiler_agent_checks() -> list[Check]:
     """Spec §6.3 — report_compiler_agent (abstract-only mode) C1-C3 protection."""
-    must = [
-        "PATTERN PROTECTION (v3.6.7)",
-        # C1 — word-count + buffer
-        "whitespace-split",
-        # Compression hedge protection
-        "protected hedging phrases",
-        # C2 — temporal disambiguation
-        "explicit year range",
-        # C3 — anti-fake-audit guard (THE critical clause per feedback_subagent_tool_hallucination.md)
-        "DO NOT simulate",
-        "DO NOT claim to have run",
-    ]
     return [
         Check(
             pattern_id="C1-C3",
             description="report_compiler_agent (abstract-only) carries 3 publication-side protection clauses incl. anti-fake-audit guard",
             target=COMPILER_AGENT,
-            must_contain=must,
+            block_marker=PROTECTION_BLOCK,
+            must_contain=[
+                # C1 — word-count algorithm
+                "whitespace-split",
+                # C2 — temporal disambiguation marker
+                "explicit year range",
+            ],
+            must_contain_regex=[
+                # C1 — protected hedges are budget-protected / non-negotiable.
+                # Bare 'protected hedging phrases' was too weak; require the
+                # obligation that they ride into the abstract verbatim.
+                (
+                    "C1 protected hedges non-negotiable",
+                    r"protected\s+hedg(?:e|ing)\s+phrases.{0,300}\b(?:budget[- ]protected|non-negotiable|verbatim)\b",
+                ),
+                # C3 — anti-fake-audit guard. Both DO NOT clauses must appear,
+                # in either order, within a 400-char window so the guard reads
+                # as one injunction rather than two unrelated sentences.
+                (
+                    "C3 anti-fake-audit guard pair",
+                    r"DO NOT simulate.{0,400}\bDO NOT claim to have run\b"
+                    r"|DO NOT claim to have run.{0,400}\bDO NOT simulate\b",
+                ),
+            ],
         )
     ]
 

--- a/scripts/test_check_v3_6_7_pattern_protection.py
+++ b/scripts/test_check_v3_6_7_pattern_protection.py
@@ -307,5 +307,63 @@ class R5MutationTests(_MutationTestBase):
         self.assert_mutation_fails()
 
 
+class R6MutationTests(_MutationTestBase):
+    """R6-001 (future/conditional modals + advisory adverb weakeners)."""
+
+    def test_r6_001_c1_will_not_preserve_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "Compression must preserve protected hedging phrases",
+            "Compression will not preserve protected hedging phrases",
+        )
+        self.assert_mutation_fails()
+
+    def test_r6_001_c1_would_preserve_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "Compression must preserve protected hedging phrases",
+            "Compression would preserve protected hedging phrases",
+        )
+        self.assert_mutation_fails()
+
+    def test_r6_001_a2_ought_to_wrap_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            'For any source flagged "pending verification" upstream: wrap claims in explicit hedge',
+            'For any source flagged "pending verification" upstream: ought to wrap claims in explicit hedge',
+        )
+        self.assert_mutation_fails()
+
+    def test_r6_001_a3_ideally_include_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "For each substantive claim: include a one-line anchor justification.",
+            "For each substantive claim: ideally include a one-line anchor justification.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r6_001_b5_preferably_enumerate_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/research_architect_agent.md",
+            "Any list-of-options item must declare its primary-source list and enumerate fully.",
+            "Any list-of-options item must declare its primary-source list and preferably enumerate fully.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r6_001_a3_we_recommend_that_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "For each substantive claim: include a one-line anchor justification.",
+            "We recommend that each substantive claim include a one-line anchor justification.",
+        )
+        self.assert_mutation_fails()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_v3_6_7_pattern_protection.py
+++ b/scripts/test_check_v3_6_7_pattern_protection.py
@@ -1,0 +1,307 @@
+"""Unit tests for check_v3_6_7_pattern_protection.py (ARS v3.6.7 lint).
+
+Mutation evidence preserved from codex review rounds R3-R5 (B2 phase). Each
+test mutates a v3.6.7 PATTERN PROTECTION clause in a temporary copy of the
+repo and asserts the lint flags it. This guards against future regressions
+in the lint contract — without these tests, CI would only verify that the
+*current* prompt prose passes, but a checker regression that silently
+accepts weakened obligations would be caught only by ad-hoc mutation runs.
+
+The test suite operates on a sandboxed copy of the repo: each test
+constructs the copy via `git archive HEAD | tar -x`, applies a single
+mutation, and runs `scripts/check_v3_6_7_pattern_protection.py` against
+that copy. The repo's actual files are never modified.
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LINT_SCRIPT_REL = "scripts/check_v3_6_7_pattern_protection.py"
+
+
+def _archive_repo(dest: Path) -> None:
+    """Materialise current `HEAD` into `dest` via git archive | tar."""
+    archive = subprocess.Popen(
+        ["git", "archive", "HEAD"], cwd=REPO_ROOT, stdout=subprocess.PIPE
+    )
+    subprocess.run(
+        ["tar", "-x", "-C", str(dest)], stdin=archive.stdout, check=True
+    )
+    archive.wait()
+    if archive.returncode != 0:
+        raise RuntimeError(f"git archive failed: rc={archive.returncode}")
+
+
+def _run_lint(repo_dir: Path) -> tuple[int, str, str]:
+    """Run the v3.6.7 lint inside `repo_dir`. Returns (rc, stdout, stderr)."""
+    proc = subprocess.run(
+        ["python3", LINT_SCRIPT_REL],
+        cwd=repo_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _mutate(repo_dir: Path, rel_path: str, old: str, new: str) -> None:
+    """Apply a single replace mutation to `repo_dir/rel_path`. Asserts the
+    `old` string is present (so a refactored prompt that no longer matches
+    surfaces as a clear test failure rather than silently-no-op)."""
+    path = repo_dir / rel_path
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        raise AssertionError(
+            f"Mutation source string not found in {rel_path}: "
+            f"{old[:80]!r}..."
+        )
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+class _MutationTestBase(unittest.TestCase):
+    """Each test materialises a fresh repo copy under self._repo_dir."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="ars-v367-test.")
+        self._repo_dir = Path(self._tmpdir.name)
+        _archive_repo(self._repo_dir)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def assert_baseline_passes(self) -> None:
+        rc, _stdout, stderr = _run_lint(self._repo_dir)
+        self.assertEqual(rc, 0, f"baseline lint should pass; stderr={stderr}")
+
+    def assert_mutation_fails(self) -> None:
+        rc, _stdout, _stderr = _run_lint(self._repo_dir)
+        self.assertNotEqual(rc, 0, "mutation should make lint fail")
+
+
+class BaselineTest(_MutationTestBase):
+    def test_unmutated_repo_passes(self) -> None:
+        self.assert_baseline_passes()
+
+
+class R2MutationTests(_MutationTestBase):
+    """R2-001 closure: per-regex allow_prohibition stops C3's `must not`
+    exemption from leaking into C1's assertion-style obligation."""
+
+    def test_c1_inverted_must_not_preserve_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "Compression must preserve protected hedging phrases",
+            "Compression must not preserve protected hedging phrases",
+        )
+        self.assert_mutation_fails()
+
+    def test_c3_audit_passed_sentence_deleted_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "\n- Output metadata must not claim audit-passed state.",
+            "",
+        )
+        self.assert_mutation_fails()
+
+
+class R3MutationTests(_MutationTestBase):
+    """R3-001 (span-restricted prohibition exemption), R3-002 (token →
+    regex), R3-003 (except/unless weakeners)."""
+
+    def test_r3_001_trailing_must_not_be_enforced_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "Output metadata must not claim audit-passed state.",
+            "Output metadata must not claim audit-passed state; this must not be enforced.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r3_001_orchestrator_does_not_run_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "The orchestrator runs codex audit afterward.",
+            "The orchestrator does not run codex audit afterward.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r3_002_a2_pending_verification_optional_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            'wrap claims in explicit hedge ("pending verification of X" / "inferred from upstream Y").',
+            "pending verification language is optional; claims may be written as facts.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r3_002_c2_may_use_year_range_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            'Reflexivity disclosure must use explicit temporal bounds: explicit year range, past-tense disambiguating verb, or "former" prefix. Deictic temporal phrases ("during this period" / "at the time") are forbidden.',
+            'Reflexivity disclosure may use an explicit year range, but deictic temporal phrases ("during this period" / "at the time") are allowed when shorter.',
+        )
+        self.assert_mutation_fails()
+
+    def test_r3_003_no_subsetting_except_when_concise_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/research_architect_agent.md",
+            "No subsetting, no over-setting, no scope cross-contamination.",
+            "No subsetting except when concise, no over-setting, no scope cross-contamination.",
+        )
+        self.assert_mutation_fails()
+
+
+class R4MutationTests(_MutationTestBase):
+    """R4-001 (modal verb scope), R4-002 (sub-clause coverage)."""
+
+    def test_r4_001_a2_may_wrap_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            'For any source flagged "pending verification" upstream: wrap claims in explicit hedge',
+            'For any source flagged "pending verification" upstream: may wrap claims in explicit hedge',
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_001_a3_may_include_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "For each substantive claim: include a one-line anchor justification.",
+            "For each substantive claim: may include a one-line anchor justification.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_001_a1_recommended_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "pre-list the source's effect inventory and run a cross-section consistency self-check before output.",
+            "pre-list the source's effect inventory and cross-section consistency self-check are recommended before output.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_002_a4_may_be_quoted_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "surrounding context paraphrased and unquoted.",
+            "surrounding context may be quoted.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_002_a5_drop_conditional_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            'use conditional language ("if document X argues Y, this chapter could dialogue by Z") or explicit gap acknowledgment. Declarative claims about un-provided documents are forbidden.',
+            "Declarative claims about un-provided documents are forbidden.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_002_b4_allow_chapter_vocab_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/research_architect_agent.md",
+            "Item phrasing must be neutral/balanced. Chapter argument vocabulary is forbidden in instrument items.",
+            "Item phrasing may use chapter argument vocabulary in instrument items.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_002_b5_allow_overset_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/research_architect_agent.md",
+            "No subsetting, no over-setting, no scope cross-contamination.",
+            "No subsetting. Over-setting and scope cross-contamination are allowed.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_002_c1_drop_buffer_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "Word budget uses whitespace-split convention (`body.split()`), not hyphenated-as-1. Reserve 3–5% buffer below hard cap.",
+            "Word budget uses whitespace-split convention (`body.split()`), not hyphenated-as-1.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r4_002_c2_drop_past_tense_form_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            'Reflexivity disclosure must use explicit temporal bounds: explicit year range, past-tense disambiguating verb, or "former" prefix.',
+            "Reflexivity disclosure must use explicit temporal bounds: explicit year range.",
+        )
+        self.assert_mutation_fails()
+
+
+class R5MutationTests(_MutationTestBase):
+    """R5-001 (advisory weakeners: should/can/permitted)."""
+
+    def test_r5_001_a2_should_wrap_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            'For any source flagged "pending verification" upstream: wrap claims in explicit hedge',
+            'For any source flagged "pending verification" upstream: should wrap claims in explicit hedge',
+        )
+        self.assert_mutation_fails()
+
+    def test_r5_001_a3_should_include_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "For each substantive claim: include a one-line anchor justification.",
+            "For each substantive claim: should include a one-line anchor justification.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r5_001_a4_can_be_quoted_tail_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/synthesis_agent.md",
+            "surrounding context paraphrased and unquoted.",
+            "surrounding context paraphrased and unquoted, but can be quoted for flow.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r5_001_b5_overset_permitted_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/research_architect_agent.md",
+            "No subsetting, no over-setting, no scope cross-contamination.",
+            "No subsetting, no scope cross-contamination; over-setting is permitted when concise.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r5_001_b5_should_declare_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/research_architect_agent.md",
+            "Any list-of-options item must declare its primary-source list and enumerate fully.",
+            "Any list-of-options item should declare its primary-source list and enumerate fully.",
+        )
+        self.assert_mutation_fails()
+
+    def test_r5_001_c1_should_preserve_fails(self) -> None:
+        _mutate(
+            self._repo_dir,
+            "deep-research/agents/report_compiler_agent.md",
+            "Compression must preserve protected hedging phrases identified by upstream calibration as budget-protected (the dispatch context carries the list).",
+            "Compression should preserve protected hedging phrases identified by upstream calibration as budget-protected (the dispatch context carries the list).",
+        )
+        self.assert_mutation_fails()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_v3_6_7_pattern_protection.py
+++ b/scripts/test_check_v3_6_7_pattern_protection.py
@@ -28,10 +28,14 @@ def _archive_repo(dest: Path) -> None:
     archive = subprocess.Popen(
         ["git", "archive", "HEAD"], cwd=REPO_ROOT, stdout=subprocess.PIPE
     )
-    subprocess.run(
-        ["tar", "-x", "-C", str(dest)], stdin=archive.stdout, check=True
-    )
-    archive.wait()
+    try:
+        subprocess.run(
+            ["tar", "-x", "-C", str(dest)], stdin=archive.stdout, check=True
+        )
+    finally:
+        if archive.stdout is not None:
+            archive.stdout.close()
+        archive.wait()
     if archive.returncode != 0:
         raise RuntimeError(f"git archive failed: rc={archive.returncode}")
 

--- a/shared/references/irb_terminology_glossary.md
+++ b/shared/references/irb_terminology_glossary.md
@@ -1,0 +1,102 @@
+# IRB Terminology Glossary
+
+**Spec:** v3.6.7 §7.1 — pattern protection reference for `research_architect_agent` (survey designer mode), Pattern B1.
+
+**Audience:** Agents drafting consent / privacy language in survey instruments. Human authors reviewing instrument drafts.
+
+**Why this exists:** In live ARS pipeline runs, survey instrument drafts repeatedly conflated four IRB terms that look adjacent in everyday English but carry distinct operational commitments. Conflation creates legal-effect drift in the consent script and can make the instrument unenforceable as informed consent. This reference is the canonical distinction the survey designer must pass through.
+
+---
+
+## The four terms
+
+The four terms differ along two axes: (1) what is hidden — identity vs. content — and (2) whether re-identification is technically possible.
+
+### Anonymity
+
+**Operational definition:** The respondent's identity cannot be linked to their response by anyone, including the researcher. No identity key is created or stored.
+
+**Necessary conditions:**
+- No name, email, IP, device fingerprint, or directly-identifying field is collected.
+- No code or token is created that could later be matched back to the respondent.
+- Demographic combinations are coarse enough that no respondent is uniquely identifiable from the demographic combination alone (k-anonymity ≥ k for some agreed k, typically k ≥ 5).
+
+**Example consent phrasing (correct):**
+> "Your responses are anonymous. We do not collect your name, email, or any identifier that could link this survey to you. We cannot contact you about your responses, and we cannot remove your responses from the dataset after submission because we cannot identify which responses are yours."
+
+**Common drift to flag:**
+- Claiming "anonymous" while collecting email "for follow-up" — that is **confidential**, not anonymous.
+- Claiming "anonymous" while assigning a respondent code that the researcher holds — that is **pseudonymous**, not anonymous.
+
+### Confidentiality
+
+**Operational definition:** The respondent's identity IS known to the researcher, but the researcher commits not to disclose it. Identity-response linkage exists in the research record.
+
+**Necessary conditions:**
+- A written commitment specifies who can see the identified data, for what purpose, and for how long.
+- Storage and access controls match the commitment (encrypted at rest, access-logged, retention-bounded).
+- Reporting layer aggregates or de-identifies before any external disclosure.
+
+**Example consent phrasing (correct):**
+> "Your responses are confidential. We will know your identity from the email you provide for follow-up. Your name will not appear in any report. Only the named research team will see identified data, and identified data will be deleted within 12 months of project close."
+
+**Common drift to flag:**
+- Promising "confidentiality" without specifying a retention boundary — IRB will reject; respondent cannot evaluate the commitment.
+- Promising "confidentiality" while planning to publish identifiable case-study quotes — that is a contradiction; either the consent script needs an explicit case-study clause or the publication plan needs aggregation.
+
+### De-identification
+
+**Operational definition:** Direct identifiers have been removed from a dataset, and the remaining record cannot be re-linked to the respondent without auxiliary information that has been destroyed or sequestered.
+
+**Necessary conditions:**
+- Direct identifiers (HIPAA Safe Harbor's 18 fields or the project's equivalent list) are removed or transformed into non-reversible categories.
+- Quasi-identifiers (zip + birth-date + gender, etc.) are evaluated for re-identification risk against plausible auxiliary datasets and reduced to acceptable risk threshold.
+- The link key used during data collection is destroyed or held by an independent party who is contractually prohibited from re-linking.
+
+**Example dataset description (correct):**
+> "The released dataset is de-identified. Names, emails, exact dates, and institutional affiliation have been removed. Birth year is generalised to 5-year buckets. The collection-time link key was destroyed at the close of data collection."
+
+**Common drift to flag:**
+- Claiming "de-identified" while keeping the link key for "potential follow-up" — that is **pseudonymized**, not de-identified.
+- Claiming "de-identified" without a quasi-identifier risk evaluation — k-anonymity unverified.
+
+### Pseudonymization
+
+**Operational definition:** Direct identifiers have been replaced by a pseudonym (code, token, hash). The pseudonym is reversible because the link key is preserved somewhere — typically by the data controller.
+
+**Necessary conditions:**
+- A documented pseudonymization scheme specifies the substitution method and the link-key custodian.
+- The link key is held separately from the pseudonymized dataset, with separate access controls.
+- Use cases (longitudinal follow-up, data subject access request, error correction) are pre-specified.
+
+**Example dataset description (correct):**
+> "The dataset is pseudonymized. Each participant is assigned an opaque code (e.g., P-0042). The mapping from code to participant identity is held by the principal investigator and is not shared with the analytic team. The mapping is retained for 24 months to support follow-up surveys, then destroyed."
+
+**Common drift to flag:**
+- Calling pseudonymized data "anonymized" — under GDPR, EU AI Act, and most modern IRB guidance, pseudonymized data remains personal data subject to the full data protection regime.
+
+---
+
+## Quick distinction table
+
+| Term | Identity-response link exists? | Held by whom? | Reversible? |
+|---|---|---|---|
+| **Anonymity** | No | N/A | No |
+| **Confidentiality** | Yes | Researcher | Yes (within research team) |
+| **De-identification** | No (key destroyed) | N/A | No (assuming key destroyed and quasi-identifier risk acceptable) |
+| **Pseudonymization** | Yes (via key) | Researcher / data controller | Yes |
+
+---
+
+## Where this glossary is enforced
+
+The `research_architect_agent` survey designer mode prompt requires consent / privacy language to pass through this glossary before output. The authoritative protection clause lives in `deep-research/agents/research_architect_agent.md` under `PATTERN PROTECTION (v3.6.7)`. This file defines the four regimes and example phrasings; the agent prompt cites this file by path.
+
+---
+
+## References
+
+- HHS HIPAA Safe Harbor de-identification (45 CFR 164.514(b)(2)) — primary source for direct-identifier list.
+- GDPR Art. 4(5) — pseudonymization definition.
+- EU AI Act Recital 27 + Art. 10(5) — pseudonymization vs. anonymization distinction in AI training contexts.
+- ISO/IEC 27559:2022 — privacy-enhancing data de-identification framework.

--- a/shared/references/irb_terminology_glossary.md
+++ b/shared/references/irb_terminology_glossary.md
@@ -46,12 +46,12 @@ The four terms differ along two axes: (1) what is hidden — identity vs. conten
 
 ### De-identification
 
-**Operational definition:** Direct identifiers have been removed from a dataset, and the remaining record cannot be re-linked to the respondent without auxiliary information that has been destroyed or sequestered.
+**Operational definition:** Direct identifiers have been removed from a dataset, and the link key created during data collection has been destroyed. The remaining record cannot be re-linked to the respondent.
 
 **Necessary conditions:**
 - Direct identifiers (HIPAA Safe Harbor's 18 fields or the project's equivalent list) are removed or transformed into non-reversible categories.
 - Quasi-identifiers (zip + birth-date + gender, etc.) are evaluated for re-identification risk against plausible auxiliary datasets and reduced to acceptable risk threshold.
-- The link key used during data collection is destroyed or held by an independent party who is contractually prohibited from re-linking.
+- The link key used during data collection is **destroyed**. Any retained re-link key — even one held by an independent custodian — falls under pseudonymization (next section), not de-identification, because re-identification remains technically possible.
 
 **Example dataset description (correct):**
 > "The released dataset is de-identified. Names, emails, exact dates, and institutional affiliation have been removed. Birth year is generalised to 5-year buckets. The collection-time link key was destroyed at the close of data collection."

--- a/shared/references/protected_hedging_phrases.md
+++ b/shared/references/protected_hedging_phrases.md
@@ -1,0 +1,118 @@
+# Protected Hedging Phrases
+
+**Spec:** v3.6.7 §7.1 — pattern protection reference for `report_compiler_agent` (abstract-only mode), Pattern C1.
+
+**Audience:** Upstream calibration agents (academic-paper Stage 4, deep-research Phase 3 abstract handoff). The downstream `report_compiler_agent` reads this reference indirectly through the dispatch context that upstream calibration produces.
+
+**Why this exists:** Live ARS pipeline runs surfaced a recurring failure where the abstract compiler, under hard word-count pressure (i.e., a fixed word budget set by the publisher), dropped epistemic hedges that the body of the paper depended on. The fix routes through a roster of protected hedging phrases that ride in the dispatch context to the compiler. A claim qualified by "may," "tentative," "preliminary," or "in this institutional context" in the body became unconditional in the abstract. The compression-driven drift created compression overclaim — the abstract no longer accurately represented the paper's epistemic stance, which is a publication-integrity failure.
+
+The fix is to make hedging phrases **budget-protected**: upstream calibration marks specific phrases as protected, the protected list rides in the dispatch context to the abstract compiler, and the compiler honours the protection ahead of any other compression target.
+
+---
+
+## What counts as a protected hedging phrase
+
+A phrase qualifies as protected when **dropping it changes the paper's truth-claim**, not merely its rhetorical register. Three categories cover most cases:
+
+### 1. Epistemic hedges that bound the claim
+
+Words and phrases that mark a claim as conditional, tentative, or under-evidenced. Removing them upgrades the claim to assertion.
+
+**Examples:**
+- "may," "might," "could" (modal hedges on causal or predictive claims)
+- "tentative," "preliminary," "exploratory" (status hedges on findings)
+- "suggests," "indicates," "is consistent with" (inferential hedges, distinct from "demonstrates," "proves," "establishes")
+- "in our sample," "for this cohort," "under the conditions tested" (scope hedges)
+
+**Why protected:** A reader who acts on an unconditional version of the claim takes on more risk than the evidence justifies. In academic abstracts this is overclaim; in policy abstracts this is misinformation.
+
+### 2. Reflexivity / positionality markers
+
+Phrases that disclose the author's relationship to the studied phenomenon. Removing them obscures the position from which the work was done.
+
+**Examples:**
+- "from a former evaluator's perspective" (positional)
+- "as participants in the [year-range] reform" (involvement)
+- "the authors served on the [committee] from [year] to [year]" (institutional role)
+- "this analysis draws on the first author's experience as [role]" (experiential)
+
+**Why protected:** Disclosure obligations under most journal policies (BMJ, Nature, social-science conventions) require positionality to ride in the abstract when it materially shapes interpretation. Stripping disclosure for word count violates the policy, not just the rhetorical norm.
+
+### 3. Temporal disambiguation markers
+
+Phrases that pin a claim or a positional statement to a specific time window. Removing them creates temporal ambiguity that downstream readers cannot resolve.
+
+**Examples:**
+- "between 2020 and 2024" (explicit year range)
+- "during their term as [role] in [year]" (role-bounded period)
+- "former [role]" (closed temporal status)
+- "at the time of the [event]" — only protected when the event is named immediately adjacent; otherwise the deictic phrase is itself the failure mode (see `feedback_ars_phase2_phase3_downstream_agent_patterns.md`).
+
+**Why protected:** Deictic temporal phrases ("during this period," "at the time," "currently") read differently when separated from their anchoring context. The abstract has no neighbouring context; an abstract-level deictic is unresolvable.
+
+---
+
+## Upstream calibration: how to mark phrases as protected
+
+Upstream calibration runs at the end of paper drafting, after the body text is stable but before abstract compilation. The calibration agent walks the paper and identifies phrases in the three categories above, then emits a `protected_hedges` block in the dispatch payload to the abstract compiler.
+
+### Dispatch block shape
+
+```yaml
+protected_hedges:
+  epistemic:
+    - phrase: "may"
+      anchored_at: "Section 4, claim about institutional adoption rate"
+      why: "claim is observational, not causal"
+    - phrase: "tentative"
+      anchored_at: "Section 5, conclusion about policy effect"
+      why: "n=12 sites, no comparison group"
+  reflexivity:
+    - phrase: "as a former evaluator on the [committee] between 2020 and 2024"
+      anchored_at: "Author note + Section 1"
+      why: "BMJ-equivalent disclosure obligation; informs how reader weights argument"
+  temporal:
+    - phrase: "between 2020 and 2024"
+      anchored_at: "Section 1, paragraph 2; Section 6, conclusion"
+      why: "abstract-level deictic ('at the time') would be unresolvable"
+```
+
+### Calibration rules
+
+1. **Conservative inclusion.** When in doubt, include the phrase. The abstract compiler can decide to spend budget on a less-protected phrase first; it cannot recover a hedge that calibration omitted.
+2. **Anchor every entry.** Each protected phrase must cite where in the paper it operates and one-line why. Without the anchor, the abstract compiler cannot judge replacement-vs-preservation when budget is tight.
+3. **No duplicates.** One entry per phrase. The compiler counts protected phrases against the budget once.
+4. **Calibration is mode-specific.** Deep-research INSIGHT abstracts and academic-paper journal abstracts have different convention (see `word_count_conventions.md`). Calibration runs once per target mode, not once per paper.
+
+---
+
+## Abstract compiler: how protection is honoured
+
+The `report_compiler_agent` abstract-only mode treats protected hedges as **non-negotiable budget**. Concretely:
+
+1. **Budget allocation order.**
+   - Step 1: Compute hard cap (whitespace-split, see `word_count_conventions.md`).
+   - Step 2: Reserve 3–5% buffer.
+   - Step 3: Allocate words to required structural slots (research question, method, finding, implication).
+   - Step 4: **Allocate words to protected hedges.** Every entry in `protected_hedges` rides in unmodified or with calibration-approved synonym.
+   - Step 5: Spend remaining words on rhetorical polish, transitions, secondary findings.
+
+2. **Synonym substitution rule.** A protected phrase may be replaced by a calibration-approved synonym **only if** (a) the synonym is shorter, (b) the truth-claim is preserved, and (c) calibration explicitly listed the synonym as acceptable. Without an explicit synonym list, the original phrase rides verbatim.
+
+3. **Cut order under budget pressure.** When the draft exceeds budget after Step 4, cuts come from Step 5 first (rhetorical polish), then Step 3 (compress structural slots), **never** from Step 4 (protected hedges).
+
+4. **Failure surface.** If the abstract cannot fit Steps 1–4 within hard cap, the compiler **reports the conflict** rather than dropping a protected hedge. The conflict goes back to upstream calibration to either renegotiate the protected list or the publisher's word cap.
+
+---
+
+## Where this protocol is enforced
+
+The `report_compiler_agent` abstract-only mode prompt enforces the dispatch-context protocol and the budget allocation order. The authoritative protection clause lives in `deep-research/agents/report_compiler_agent.md` under `PATTERN PROTECTION (v3.6.7)`. This file defines what counts as a protected hedge, the upstream calibration shape, and the compiler's budget allocation order; the agent prompt cites this file by path. Cross-model audit follows `shared/templates/codex_audit_multifile_template.md` (dimension §3.7).
+
+---
+
+## Cross-references
+
+- `shared/references/word_count_conventions.md` — whitespace-split standard, 3–5% buffer rule, publisher conventions.
+- `shared/templates/codex_audit_multifile_template.md` — audit dimensions including compression overclaim detection.
+- ARS feedback memory `feedback_ars_phase2_phase3_downstream_agent_patterns.md` — original empirical observation of compression overclaim in HEEACT chapter run.

--- a/shared/references/protected_hedging_phrases.md
+++ b/shared/references/protected_hedging_phrases.md
@@ -115,4 +115,4 @@ The `report_compiler_agent` abstract-only mode prompt enforces the dispatch-cont
 
 - `shared/references/word_count_conventions.md` — whitespace-split standard, 3–5% buffer rule, publisher conventions.
 - `shared/templates/codex_audit_multifile_template.md` — audit dimensions including compression overclaim detection.
-- ARS feedback memory `feedback_ars_phase2_phase3_downstream_agent_patterns.md` — original empirical observation of compression overclaim in HEEACT chapter run.
+- `docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md` §3.3 (C1) — pattern definition and provenance.

--- a/shared/references/protected_hedging_phrases.md
+++ b/shared/references/protected_hedging_phrases.md
@@ -79,7 +79,7 @@ protected_hedges:
 
 ### Calibration rules
 
-1. **Conservative inclusion.** When in doubt, include the phrase. The abstract compiler can decide to spend budget on a less-protected phrase first; it cannot recover a hedge that calibration omitted.
+1. **Conservative inclusion.** When in doubt, include the phrase. Calibration cannot recover a hedge it did not list — the compiler treats every entry on the list as non-negotiable, so omitting a phrase removes that protection regardless of intent.
 2. **Anchor every entry.** Each protected phrase must cite where in the paper it operates and one-line why. Without the anchor, the abstract compiler cannot judge replacement-vs-preservation when budget is tight.
 3. **No duplicates.** One entry per phrase. The compiler counts protected phrases against the budget once.
 4. **Calibration is mode-specific.** Deep-research INSIGHT abstracts and academic-paper journal abstracts have different convention (see `word_count_conventions.md`). Calibration runs once per target mode, not once per paper.
@@ -90,16 +90,16 @@ protected_hedges:
 
 The `report_compiler_agent` abstract-only mode treats protected hedges as **non-negotiable budget**. Concretely:
 
-1. **Budget allocation order.**
+1. **Budget allocation order.** Protected hedges are reserved before any other content competes for budget, because they are non-negotiable.
    - Step 1: Compute hard cap (whitespace-split, see `word_count_conventions.md`).
    - Step 2: Reserve 3–5% buffer.
-   - Step 3: Allocate words to required structural slots (research question, method, finding, implication).
-   - Step 4: **Allocate words to protected hedges.** Every entry in `protected_hedges` rides in unmodified or with calibration-approved synonym.
-   - Step 5: Spend remaining words on rhetorical polish, transitions, secondary findings.
+   - Step 3: **Reserve words for protected hedges.** Sum the word count of every entry in `protected_hedges` (verbatim). This subtotal is non-negotiable budget.
+   - Step 4: Allocate the remaining words to required structural slots (research question, method, finding, implication).
+   - Step 5: Spend any words still remaining on rhetorical polish, transitions, secondary findings.
 
-2. **Synonym substitution rule.** A protected phrase may be replaced by a calibration-approved synonym **only if** (a) the synonym is shorter, (b) the truth-claim is preserved, and (c) calibration explicitly listed the synonym as acceptable. Without an explicit synonym list, the original phrase rides verbatim.
+2. **Verbatim preservation rule.** A protected phrase rides verbatim into the abstract. The compiler does not paraphrase, compress, or substitute a synonym for a protected phrase. (A future v3.6.7+ extension may add an optional `approved_synonyms` field to the dispatch block; until then, verbatim only.)
 
-3. **Cut order under budget pressure.** When the draft exceeds budget after Step 4, cuts come from Step 5 first (rhetorical polish), then Step 3 (compress structural slots), **never** from Step 4 (protected hedges).
+3. **Cut order under budget pressure.** When the draft exceeds budget, cuts come from Step 5 first (rhetorical polish), then Step 4 (compress structural slots), **never** from Step 3 (protected hedges).
 
 4. **Failure surface.** If the abstract cannot fit Steps 1–4 within hard cap, the compiler **reports the conflict** rather than dropping a protected hedge. The conflict goes back to upstream calibration to either renegotiate the protected list or the publisher's word cap.
 

--- a/shared/references/protected_hedging_phrases.md
+++ b/shared/references/protected_hedging_phrases.md
@@ -107,7 +107,7 @@ The `report_compiler_agent` abstract-only mode treats protected hedges as **non-
 
 ## Where this protocol is enforced
 
-The `report_compiler_agent` abstract-only mode prompt enforces the dispatch-context protocol and the budget allocation order. The authoritative protection clause lives in `deep-research/agents/report_compiler_agent.md` under `PATTERN PROTECTION (v3.6.7)`. This file defines what counts as a protected hedge, the upstream calibration shape, and the compiler's budget allocation order; the agent prompt cites this file by path. Cross-model audit follows `shared/templates/codex_audit_multifile_template.md` (dimension §3.7).
+The `report_compiler_agent` abstract-only mode prompt enforces the dispatch-context protocol and the budget allocation order. The authoritative protection clause lives in `deep-research/agents/report_compiler_agent.md` under `PATTERN PROTECTION (v3.6.7)`. This file defines what counts as a protected hedge, the upstream calibration shape, and the compiler's budget allocation order; the agent prompt cites this file by path. Cross-model audit covers protected-hedge preservation under the report_compiler bundle's Section 4(f) check in `shared/templates/codex_audit_multifile_template.md`.
 
 ---
 

--- a/shared/references/psychometric_terminology_glossary.md
+++ b/shared/references/psychometric_terminology_glossary.md
@@ -1,0 +1,109 @@
+# Psychometric Terminology Glossary
+
+**Spec:** v3.6.7 §7.1 — pattern protection reference for `research_architect_agent` (survey designer mode), Pattern B2.
+
+**Audience:** Agents drafting Likert / rating-scale items in survey instruments. Human authors reviewing instrument drafts before pilot testing.
+
+**Why this exists:** Live ARS pipeline runs surfaced two recurring failures in instrument design: (a) items labelled "reverse-coded" that were actually contrast items measuring a different construct, and (b) acquiescence- and recall-bias mitigations that look in place but do not operate. Both failures pass casual peer review and surface only at scale validation, by which point the instrument has already been deployed. This reference defines the operational distinctions the survey designer must respect.
+
+---
+
+## True reverse-coded item vs. contrast item
+
+These are distinct instrument-design tools that look identical to a casual reader. Conflating them invalidates the construct.
+
+### True reverse-coded item
+
+**Operational definition:** A negatively-keyed statement of the **same construct** along the **same Likert dimension**. After numeric reversal of the response value, it contributes to the same scale score as positively-keyed items.
+
+**Necessary conditions:**
+- Same construct: if the positive item probes "perceived institutional support," the reverse item probes the absence of perceived institutional support, not a different construct.
+- Same dimension: agreement-disagreement remains the response axis; frequency or intensity does not get substituted in.
+- Reverse-scoring is mechanically valid: a respondent with high construct standing should give high agreement on positive items and low agreement on the reverse item, such that the reverse item's reversed score aligns with the positive items.
+
+**Correct example pair (construct: perceived institutional support):**
+- Positive: "My institution provides the resources I need to do my work well." (1=strongly disagree → 5=strongly agree)
+- True reverse: "My institution leaves me without the resources I need to do my work." (same scale; respondents high in perceived support disagree with this)
+
+**Why this works:** Both items load on a single latent factor. Confirmatory factor analysis on a piloted dataset will show comparable factor loadings (after sign reversal) and similar item-total correlations.
+
+### Contrast item
+
+**Operational definition:** A statement that probes a **different construct** (or a different dimension of the same construct) and is included to measure something else — discriminant validity, related-but-distinct construct, social-desirability check.
+
+**Why it is not reverse-coding:**
+- A contrast item's score should NOT be combined with the focal scale's score. It belongs on its own scale or its own analysis.
+- Reverse-scoring a contrast item produces a meaningless number.
+- Treating a contrast item as a reverse-coded item dilutes the focal scale's reliability (Cronbach's alpha drops; factor loadings become incoherent).
+
+**Example contrast (NOT a reverse-coded support item):**
+- "I find my work intrinsically meaningful." — This probes intrinsic motivation, not perceived institutional support. It is contrast / divergent-validity, not a reverse item.
+
+### Decision rule for the survey designer
+
+For every item labelled "reverse-coded," the agent must produce a one-line construct-equivalence justification:
+
+> "Item X is true reverse-coded relative to focal items Y because it probes the same construct (perceived institutional support) on the same Likert dimension (agreement). It is not a contrast item probing a related construct."
+
+If that justification cannot be written without slipping into a different construct, the item is **not** reverse-coded — it is a contrast item, and it must either move to its own scale or be removed.
+
+---
+
+## Acquiescence-bias mitigation
+
+**The bias:** Respondents systematically agree with statements regardless of content. Pure-positive scales over-estimate construct standing.
+
+**The standard mitigation:** Mix positive and true-reverse-coded items so that an acquiescing respondent cannot maximise scale score by agreeing throughout.
+
+**The failure mode flagged in v3.6.7 patterns:** "Pseudo-reverse" items that look reverse-coded but are actually contrast items, leaving the scale effectively pure-positive. The pseudo-mitigation is worse than no mitigation because it gives the appearance of having addressed acquiescence while leaving it operative.
+
+**Designer requirement:** Apply the construct-equivalence justification rule (above) to every reverse-coded item. If half the "reverse-coded" items fail the justification, the acquiescence-bias mitigation is broken and the scale needs redesign before pilot.
+
+---
+
+## Recall-bias mitigation
+
+**The bias:** Respondents misremember the timing or details of past events. Two failure modes are common:
+
+1. **Calendar drift:** Asking "in the last 12 months" without anchoring to a salient event produces noisy recall — respondents reconstruct an approximate window, not a true 12-month boundary.
+2. **Telescoping:** Memorable events get pulled forward in time ("that happened last year" when it happened 18 months ago), inflating recent-period rates.
+
+**The standard mitigation:** Event-anchored phrasing — anchor the recall window to a salient, datable event the respondent's unit shares.
+
+**Correct phrasing (event-anchored, generic):**
+> "Thinking about the period immediately before [the unit-specific event] happened to your unit, how often did X occur?"
+
+**Correct phrasing (event-anchored, project-specific):**
+> "Thinking about the period before your institution announced the merger in [month-year], how often did you experience X?"
+
+**Calendar-anchored phrasing — only acceptable when the entire sample shares a common event date:**
+> "In the 6 months following the [common event] of [specific date], how often did you experience X?"
+
+**Wrong phrasing (calendar-only, no event anchor):**
+> "In the last 12 months, how often did X occur?" — This invites calendar drift and telescoping; the respondent has no shared anchor.
+
+**Designer requirement:** Default retrospective items to event-anchored phrasing. Only use calendar-anchored phrasing when the sample provably shares a common event date and that date is named in the item. When the event-anchor is absent, the item is not recall-bias-mitigated, even if it superficially looks like a retrospective survey item.
+
+---
+
+## Quick decision table
+
+| Designer choice | Operational test | Failure flag |
+|---|---|---|
+| Item is reverse-coded | One-line construct-equivalence justification holds | Pseudo-reverse (contrast item mislabeled) |
+| Acquiescence mitigated | ≥1/3 items reverse-coded AND all reverse items pass construct-equivalence test | Pure-positive scale or pseudo-reverse mitigation |
+| Recall-bias mitigated | Item anchors recall to a salient event the unit shares | Calendar-anchored without shared event date |
+
+---
+
+## Where this glossary is enforced
+
+The `research_architect_agent` survey designer mode prompt enforces construct-equivalence justification, acquiescence-bias counting, and event-anchored phrasing. The authoritative protection clause lives in `deep-research/agents/research_architect_agent.md` under `PATTERN PROTECTION (v3.6.7)`. This file defines the construct-equivalence test, the acquiescence-mitigation rule, and the event-anchoring decision rule; the agent prompt cites this file by path.
+
+---
+
+## References
+
+- DeVellis, R. F. (2017). *Scale Development: Theory and Applications* (4th ed.). Sage. — reverse-coding and acquiescence bias.
+- Tourangeau, R., Rips, L. J., & Rasinski, K. (2000). *The Psychology of Survey Response*. Cambridge. — recall bias and event anchoring.
+- Loftus, E. F., & Marburger, W. (1983). Since the eruption of Mt. St. Helens, has anyone beaten you up? Improving the accuracy of retrospective reports with landmark events. *Memory & Cognition*, 11(2), 114–120. — primary empirical source for event-anchoring effect.

--- a/shared/references/psychometric_terminology_glossary.md
+++ b/shared/references/psychometric_terminology_glossary.md
@@ -57,7 +57,7 @@ If that justification cannot be written without slipping into a different constr
 
 **The failure mode flagged in v3.6.7 patterns:** "Pseudo-reverse" items that look reverse-coded but are actually contrast items, leaving the scale effectively pure-positive. The pseudo-mitigation is worse than no mitigation because it gives the appearance of having addressed acquiescence while leaving it operative.
 
-**Designer requirement:** Apply the construct-equivalence justification rule (above) to every reverse-coded item. If half the "reverse-coded" items fail the justification, the acquiescence-bias mitigation is broken and the scale needs redesign before pilot.
+**Designer requirement:** Apply the construct-equivalence justification rule (above) to every reverse-coded item. If any "reverse-coded" item fails the justification, that item is mislabelled — it is a contrast item and must either move to its own scale or be removed. A scale that ends up with no surviving reverse-coded item after this filter has not mitigated acquiescence bias and needs redesign before pilot.
 
 ---
 
@@ -91,7 +91,7 @@ If that justification cannot be written without slipping into a different constr
 | Designer choice | Operational test | Failure flag |
 |---|---|---|
 | Item is reverse-coded | One-line construct-equivalence justification holds | Pseudo-reverse (contrast item mislabeled) |
-| Acquiescence mitigated | ≥1/3 items reverse-coded AND all reverse items pass construct-equivalence test | Pure-positive scale or pseudo-reverse mitigation |
+| Acquiescence mitigated | At least one true reverse-coded item per scale AND every item labelled reverse-coded passes the construct-equivalence test | Pure-positive scale or pseudo-reverse mitigation |
 | Recall-bias mitigated | Item anchors recall to a salient event the unit shares | Calendar-anchored without shared event date |
 
 ---

--- a/shared/references/word_count_conventions.md
+++ b/shared/references/word_count_conventions.md
@@ -1,0 +1,119 @@
+# Word Count Conventions
+
+**Spec:** v3.6.7 §7.1 — pattern protection reference for `report_compiler_agent` (abstract-only mode).
+
+**Audience:** Agents budgeting word counts under a hard cap (abstract, executive summary, INSIGHT block). Human authors verifying that an agent's word count matches the publisher's.
+
+**Why this exists:** Different word-count algorithms produce different totals on the same text. The differential is small per sentence but compounds: on a 250-word abstract, the choice between whitespace-split and hyphenated-as-1 can swing the total by ~12 words. An agent that uses a different algorithm than the publisher believes it is meeting the cap when it is over by 5%. This reference fixes a single canonical algorithm for ARS pipelines, documents how publishers diverge, and specifies the buffer rule that makes minor publisher variation safe.
+
+---
+
+## The canonical algorithm: whitespace-split
+
+ARS pipelines count words as `len(body.split())` in Python — that is, splits on any whitespace run and counts the resulting non-empty tokens.
+
+### Why whitespace-split
+
+1. **Reproducible.** Anyone running `len(body.split())` on the same UTF-8 text gets the same number. No hidden tokenizer state.
+2. **Matches Microsoft Word default.** Most authors check word count in Word, which uses a whitespace-equivalent algorithm. Aligning with the dominant authoring environment minimises surprise.
+3. **Conservative under hyphenation.** "State-of-the-art" counts as 1 token under whitespace-split. Under hyphenated-as-N this would count as 4. Whitespace-split therefore systematically reports a lower total than hyphenated-as-N — which is the safer direction when chasing a hard cap.
+4. **Language-neutral.** CJK text without spaces is a separate problem (see "Non-space-delimited languages" below), but for English / European languages, whitespace-split is the universal lower bound.
+
+### What whitespace-split counts
+
+| Token | Whitespace-split count |
+|---|---|
+| `state-of-the-art` | 1 |
+| `2020-2024` | 1 |
+| `Wu, Cheng-I` | 2 (`Wu,` and `Cheng-I`) |
+| `e.g.,` | 1 |
+| `123,456` | 1 |
+| `(n=42)` | 1 |
+| `https://example.org/path` | 1 |
+
+### What whitespace-split does NOT count
+
+- Whitespace runs collapse to one delimiter; they do not contribute tokens.
+- Empty strings between consecutive whitespace characters are filtered by `split()` with no argument.
+- Markdown formatting (`**bold**`, `*italic*`, `` `code` ``) is part of the surrounding token; the asterisks and backticks are not separate tokens.
+
+---
+
+## Publisher conventions and how to adapt
+
+Most publishers use a whitespace-equivalent algorithm in practice but state different conventions in their author guidelines. The 3–5% buffer rule (below) makes ARS pipelines robust to the convention divergence without per-publisher adapters.
+
+### Common publisher families
+
+| Publisher / venue | Stated algorithm | Practical effect |
+|---|---|---|
+| Springer / Nature | whitespace-equivalent for abstract, no explicit definition | matches ARS canonical |
+| IEEE | "approximately N words" — whitespace-equivalent in their submission tool | matches ARS canonical |
+| ACM | whitespace-equivalent in CCS submission | matches ARS canonical |
+| Elsevier (Cell, Lancet families) | whitespace-equivalent in EM submission | matches ARS canonical |
+| Wiley | whitespace-equivalent | matches ARS canonical |
+| arXiv | no hard cap on abstract; advisory ~250 words | guideline only |
+| ICLR / NeurIPS / ACL workshop tracks | hyphenated-as-1 in their LaTeX `\abstract{}` counter | matches ARS canonical |
+| Some social-science journals (variable) | "page-based" — abstract must fit visually on submission template | not a true word count; check template |
+
+### When the publisher uses a stricter algorithm
+
+Some non-English-medium publishers and a small number of style guides count hyphenated compounds as multiple words. If the publisher explicitly states "hyphenated words count as separate words":
+
+1. Calibration should compute both totals: `len(body.split())` and the hyphenated-as-N variant.
+2. The dispatch context to the abstract compiler should carry both numbers.
+3. The compiler should use the stricter (higher) total when budgeting.
+
+If the publisher's algorithm is ambiguous, default to ARS canonical (whitespace-split) plus the 3–5% buffer.
+
+---
+
+## The 3–5% buffer rule
+
+ARS pipelines reserve **3–5% below the publisher's stated hard cap** as buffer. For a 250-word abstract:
+
+- 3% buffer → target 242 words
+- 5% buffer → target 237 words
+
+### Why this range
+
+1. **Algorithm divergence absorbs into the buffer.** Even if the publisher's tool counts ~3% higher than `len(body.split())`, the abstract still meets the cap.
+2. **Editor-side trimming room.** Reviewers and copy editors occasionally request a phrase change that adds 2–3 words. Abstract that lands at exactly the cap forces a downstream cut; abstract that lands at cap minus 5% accommodates the change without cut.
+3. **Title plus abstract pages.** Some publishers count the running title or running header; the buffer absorbs that too.
+
+### When to use 3% vs. 5%
+
+- **3%** when the calibration's `protected_hedges` block is large (≥10% of cap word budget). Tighter buffer keeps room for substantive content.
+- **5%** when the publisher's algorithm is unstated or the protected hedges are minimal. Looser buffer absorbs more uncertainty.
+
+### When NOT to use buffer
+
+If the publisher imposes a strict character count instead of word count (rare, but happens with some Asian-language journals), the buffer rule does not apply directly. Calibration should compute character count under the publisher's stated encoding and apply a 1–2% buffer at the character level.
+
+---
+
+## Non-space-delimited languages
+
+Mandarin, Japanese, Korean, Thai, and Lao do not delimit words with whitespace. ARS canonical algorithm produces meaningless totals on these texts.
+
+For abstracts in non-space-delimited languages:
+
+1. Use **character count**, not word count. Most publishers serving these languages specify character caps (e.g., Mandarin abstract often capped at 300 or 500 characters).
+2. Apply 1–2% buffer at the character level.
+3. The dispatch context to the abstract compiler should carry both `cap_unit: "character"` and the character cap, so the compiler does not erroneously apply word-budget logic.
+
+For mixed-language abstracts (e.g., Mandarin abstract with English technical terms), count each segment in its native unit and report both numbers; the publisher's authoritative count usually applies the language-specific rule per segment.
+
+---
+
+## Where this convention is enforced
+
+The `report_compiler_agent` abstract-only mode prompt enforces the canonical algorithm, the 3–5% buffer, and the post-draft re-verification step. The authoritative protection clause lives in `deep-research/agents/report_compiler_agent.md` under `PATTERN PROTECTION (v3.6.7)`. This file defines the algorithm, the buffer rationale, and the publisher-convention escape hatches; the agent prompt cites this file by path.
+
+---
+
+## Cross-references
+
+- `shared/references/protected_hedging_phrases.md` — protected hedging phrases share the abstract budget; budget allocation order specified there.
+- `shared/templates/codex_audit_multifile_template.md` — audit dimensions including word-count verification.
+- ARS feedback memory `feedback_word_count_convention_mismatch.md` — original empirical observation of whitespace-split vs. hyphenated-as-1 differential (~12 words on a 250-word abstract).

--- a/shared/references/word_count_conventions.md
+++ b/shared/references/word_count_conventions.md
@@ -25,7 +25,7 @@ ARS pipelines count words as `len(body.split())` in Python — that is, splits o
 |---|---|
 | `state-of-the-art` | 1 |
 | `2020-2024` | 1 |
-| `Wu, Cheng-I` | 2 (`Wu,` and `Cheng-I`) |
+| `Smith, John-Paul` | 2 (`Smith,` and `John-Paul`) |
 | `e.g.,` | 1 |
 | `123,456` | 1 |
 | `(n=42)` | 1 |

--- a/shared/templates/codex_audit_multifile_template.md
+++ b/shared/templates/codex_audit_multifile_template.md
@@ -121,7 +121,7 @@ Note: word-count convention, 3–5% buffer adherence, and protected-hedge preser
 Round {N} job:
 (a) Verify each round-{N-1} finding closed correctly. List by ID.
 (b) Audit for new issues introduced by round-{N-1} corrections (cascade audit per feedback_cross_model_review_cascade_inconsistency.md).
-(c) Run the 7 audit dimensions (§3.1–§3.7) on the primary deliverables. Report each finding with the dimension that surfaced it.
+(c) Run the 7 audit dimensions (§3.1–§3.7) plus the bundle-specific Section 4(f) check on the primary deliverables. Report each finding with the dimension or `4(f)` that surfaced it.
 (d) Anchoring-bias residual check: for each finding closed in prior rounds, confirm the closure is not a wording change that left the failure mode operative (per feedback_lint_passes_but_prompt_silent.md).
 (e) PARTIAL-vs-CLOSED check: every finding marked PARTIAL in prior rounds is either fully closed or remains open with a concrete remaining-work description.
 (f) {bundle-specific check, e.g. "compression overclaim check: every claim in the abstract is at least as hedged as its anchor in the body"}
@@ -155,7 +155,7 @@ Per feedback_codex_iterative_spec_review_to_zero.md: goal = 0 findings in a sing
 ```
 Output:
 - Cumulative numbered findings (carry forward IDs from round 1; new findings get next available ID).
-- For each finding: ID, severity (P1/P2/P3), dimension (one of §3.1–§3.7), file:line anchor, one-line description, suggested fix.
+- For each finding: ID, severity (P1/P2/P3), dimension (one of §3.1–§3.7 or `4(f)` for bundle-specific failures), file:line anchor, one-line description, suggested fix.
 - Do NOT propose fixes that change the spec; the spec is authoritative. Suggested fixes operate on the deliverables only.
 - End with severity-bucket count summary: "Round {N}: P1×{n1} / P2×{n2} / P3×{n3} ({total} total)".
 - If zero findings, end with: "Round {N}: 0 findings of any severity. Convergence reached."
@@ -226,8 +226,8 @@ DO NOT simulate any audit step. [+ standard Section 7 anti-fake-audit guard]
 
 - `shared/references/irb_terminology_glossary.md` — referenced by dimension §3.5.
 - `shared/references/psychometric_terminology_glossary.md` — referenced by dimension §3.5.
-- `shared/references/protected_hedging_phrases.md` — referenced by dimension §3.7.
-- `shared/references/word_count_conventions.md` — referenced by dimension §3.7.
+- `shared/references/protected_hedging_phrases.md` — referenced by Section 4(f) report_compiler bundle check (sub-checks ii + iii).
+- `shared/references/word_count_conventions.md` — referenced by Section 4(f) report_compiler bundle check (sub-check i).
 - ARS feedback memory `feedback_codex_iterative_spec_review_to_zero.md` — convergence target rationale.
 - ARS feedback memory `feedback_cross_model_review_cascade_inconsistency.md` — round-N+1 cascade audit rationale.
 - ARS feedback memory `feedback_subagent_tool_hallucination.md` — anti-fake-audit guard rationale.

--- a/shared/templates/codex_audit_multifile_template.md
+++ b/shared/templates/codex_audit_multifile_template.md
@@ -1,0 +1,231 @@
+# Codex Multi-File Audit Prompt Template
+
+**Spec:** v3.6.7 §7.2 — audit prompt template for downstream-agent deliverable cross-model audit.
+
+**Audience:** ARS pipeline orchestrator (academic-pipeline, deep-research, academic-paper) producing codex audit prompts for Phase 2 / Phase 3 deliverables. Human authors running ad-hoc cross-model review on a deliverable bundle.
+
+**Why this template exists:** Live ARS pipeline runs surfaced 18 downstream-agent hallucination/drift patterns (spec §3) that single-file or single-dimension audit could not catch. The patterns interact across files (synthesis_agent's effect-inventory drift surfaces only when comparing two narrative sections; report_compiler_agent's compression overclaim surfaces only when comparing abstract against body). A multi-file audit prompt with explicit dimensions makes the cross-file checks first-class. Spec §4.1 (Lesson D1) records the empirical observation that multi-file parallel audit catches more findings per round than sequential single-file audit at comparable token cost.
+
+This template fixes a single audit-prompt structure so the orchestrator's audit hooks (spec §5) generate consistent, reproducible prompts.
+
+---
+
+## Template structure
+
+A v3.6.7 multi-file audit prompt has six sections in this order:
+
+1. Round metadata
+2. Bundle inventory
+3. Audit dimensions (the 7 specified below)
+4. Round-specific job
+5. Convergence target
+6. Output format
+
+The orchestrator fills the placeholders in `{curly_braces}`. Everything else rides verbatim.
+
+---
+
+## Section 1 — Round metadata
+
+```
+Audit round: {N} of {target_rounds}
+Previous rounds: {summary_of_prior_findings_or "none (first round)"}
+Bundle scope: {phase or stage label, e.g. "Phase 2 chapter deliverables" or "Phase 3 abstract + reflexivity disclosure"}
+```
+
+**Fill rules:**
+- `target_rounds` defaults to 3 per spec §4.2 (Lesson D2: convergence requires 3+ rounds, not 1 or 2). Increase to 4–5 when prior round count exceeded 3 without convergence.
+- `summary_of_prior_findings` cites finding counts by severity for each prior round, e.g. "Round 1: P1×4 / P2×5 / P3×1 (10 total). Round 2: P1×0 / P2×3 / P3×1 (4 total)."
+- For first round, `Previous rounds: none (first round, baseline audit)`.
+
+---
+
+## Section 2 — Bundle inventory
+
+```
+Authoritative context (commit {git_sha}):
+
+Primary deliverables (audit target):
+- {file path 1 with one-line description}
+- {file path 2 ...}
+
+Supporting context (do not audit; reference only):
+- {file path A with one-line role}
+- {file path B ...}
+
+Out-of-scope (do not read):
+- {explicit exclusions, if any}
+```
+
+**Fill rules:**
+- Pin the audit to a commit SHA so the audit is reproducible. Codex sometimes reads files at a slightly different state than the human reviewer expects; the SHA pins the boundary.
+- Distinguish primary deliverables from supporting context. Primary gets audited; supporting answers questions but is not the audit target.
+- Out-of-scope is optional but useful when the bundle sits inside a larger directory with files that look adjacent but are not part of this audit.
+
+---
+
+## Section 3 — Audit dimensions (the 7)
+
+Codex evaluates the bundle along seven dimensions. Each dimension surfaces a specific class of pattern from spec §3:
+
+### 3.1 Cross-reference integrity
+
+**What to check:** Every claim cited to file X actually appears in file X at the cited location. Every back-pointer (file Y references file X) terminates at a real anchor. Wikilink-style references (`[[file]]` or `(file.md)`) resolve.
+
+**Patterns surfaced:** Pattern A3 (mis-anchored citation), Pattern B5 (primary-source list mismatch).
+
+### 3.2 Hallucination detection
+
+**What to check:** Declarative claims about external entities (laws, decisions, sibling documents, prior studies) are checkable against ground truth provided in the bundle. Conditional claims about un-provided documents use conditional language, not declarative.
+
+**Patterns surfaced:** Pattern A5 (sibling-document fabrication), Pattern A2 (pending-source assumed as fact), Pattern B5 (option-list overclaim), Pattern C1 (compression overclaim).
+
+### 3.3 Primary-source integrity
+
+**What to check:** Verbatim quotes match the primary source character-for-character within marked phrase boundaries. Quote scope does not creep beyond the verified anchor. Translations of foreign-language primary sources are independently verifiable.
+
+**Patterns surfaced:** Pattern A4 (quote scope creep), and the cross-reference half of Pattern A3.
+
+### 3.4 Internal coherence
+
+**What to check:** A source cited in multiple sections receives compatible characterizations across sections. A claim qualified at one anchor is not contradicted at another anchor without explicit reconciliation. The bundle does not contain mutually-incompatible statements about the same proposition.
+
+**Patterns surfaced:** Pattern A1 (legal-effect drift / cross-section internal contradiction).
+
+### 3.5 Instrument quality (survey designer mode bundles only)
+
+**What to check:** Items labelled "reverse-coded" pass the construct-equivalence test (see `psychometric_terminology_glossary.md`). IRB terminology in consent script matches the operational reality of data handling (see `irb_terminology_glossary.md`). Retrospective items use event-anchored phrasing when sample lacks a common date. Item phrasing is neutral and balanced.
+
+**Patterns surfaced:** Pattern B1 (anonymity / confidentiality conflation), Pattern B2 (pseudo-reverse), Pattern B3 (calendar-anchored without shared event), Pattern B4 (leading items / chapter-vocabulary contamination).
+
+### 3.6 Round-N framing
+
+**What to check:** The audit's own framing is consistent with prior rounds. Findings closed in earlier rounds remain closed (no regression). New findings introduced by prior-round corrections are surfaced. Anchoring bias is named when the bundle has converged to a structure that resists fresh critique.
+
+**Patterns surfaced:** Pattern D2 (convergence requires 3+ rounds), Pattern D3 (PARTIAL ≠ CLOSED).
+
+### 3.7 COI adequacy (conflict-of-interest / disclosure adequacy)
+
+**What to check:** Conflict-of-interest and reflexivity disclosures use explicit temporal bounds (year ranges, role-bounded periods, "former" prefix). Deictic temporal phrases ("during this period," "at the time," "currently") are absent or fully resolved by adjacent context. Disclosure obligations under publisher policy are met at abstract / executive-summary level, not only at body level.
+
+**Patterns surfaced:** Pattern C2 (temporal ambiguity), Pattern C1 (when compression strips disclosure).
+
+---
+
+## Section 4 — Round-specific job
+
+```
+Round {N} job:
+(a) Verify each round-{N-1} finding closed correctly. List by ID.
+(b) Audit for new issues introduced by round-{N-1} corrections (cascade audit per feedback_cross_model_review_cascade_inconsistency.md).
+(c) Run the 7 audit dimensions (§3.1–§3.7) on the primary deliverables. Report each finding with the dimension that surfaced it.
+(d) Anchoring-bias residual check: for each finding closed in prior rounds, confirm the closure is not a wording change that left the failure mode operative (per feedback_lint_passes_but_prompt_silent.md).
+(e) PARTIAL-vs-CLOSED check: every finding marked PARTIAL in prior rounds is either fully closed or remains open with a concrete remaining-work description.
+(f) {bundle-specific check, e.g. "compression overclaim check: every claim in the abstract is at least as hedged as its anchor in the body"}
+```
+
+**Fill rules:**
+- (a)–(e) ride verbatim every round (with N substitution).
+- (f) is bundle-specific. The orchestrator picks the bundle-specific check based on which downstream agent produced the deliverable. Examples:
+  - synthesis_agent bundle: cross-section consistency check on every source cited in 2+ sections.
+  - research_architect_agent bundle: construct-equivalence test on every reverse-coded item.
+  - report_compiler_agent bundle: protected-hedge preservation check (abstract vs. body).
+
+---
+
+## Section 5 — Convergence target
+
+```
+Convergence target: ZERO findings of ANY severity in one round.
+
+Per feedback_codex_iterative_spec_review_to_zero.md: goal = 0 findings in a single round, NOT N rounds of "0 P1." A round with P2/P3 only still counts as un-converged. Iterate until one full round produces zero findings or until {fallback condition, e.g. "round 5 is reached and remaining findings are 'add counter, do not change rule' per feedback_codex_review_vs_resume_audit_scope.md"}.
+```
+
+**Fill rules:**
+- The fallback condition is part of spec §5.2 stop conditions. Default fallback: "after 5 rounds, escalate remaining findings to user for ship-or-iterate decision."
+- Do NOT loosen convergence to "0 P1+P2 findings" or "0 P1 findings" — those are weaker stop conditions that v3.6.7 replaces with the strict 0-anything bar.
+
+---
+
+## Section 6 — Output format
+
+```
+Output:
+- Cumulative numbered findings (carry forward IDs from round 1; new findings get next available ID).
+- For each finding: ID, severity (P1/P2/P3), dimension (one of §3.1–§3.7), file:line anchor, one-line description, suggested fix.
+- Do NOT propose fixes that change the spec; the spec is authoritative. Suggested fixes operate on the deliverables only.
+- End with severity-bucket count summary: "Round {N}: P1×{n1} / P2×{n2} / P3×{n3} ({total} total)".
+- If zero findings, end with: "Round {N}: 0 findings of any severity. Convergence reached."
+```
+
+**Fill rules:**
+- The "do NOT propose fixes that change the spec" clause prevents codex from drifting into spec critique when the audit target is deliverables. If codex finds a spec issue, it should be raised separately, not folded into the deliverable audit.
+- Severity bucket summary at the end is what the orchestrator parses to decide round-N+1 vs. ship.
+
+---
+
+## Anti-fake-audit guard (Pattern C3)
+
+**Critical clause that rides in every audit dispatch context:**
+
+```
+DO NOT simulate any audit step. DO NOT claim to have run codex/external review on your own output. The orchestrator runs codex audit afterward; output metadata must not claim audit-passed state. If you cannot complete a step, surface the gap explicitly rather than reporting a simulated pass.
+```
+
+**Why:** Sub-agents have been observed (see `feedback_subagent_tool_hallucination.md`) reporting that they ran codex audit and surfacing simulated findings, when in fact no audit ran. The deliverable then carries a fake audit-passed marker that downstream consumers trust. The guard above is verbatim what the agent prompts say, plus the orchestrator-side post-verification (spec §5.3) that reads audit transcript metadata and rejects deliverables claiming audit completion without matching transcript.
+
+This guard rides in agent prompts AND in audit dispatch. The agent prompt forbids fake claims; the dispatch reminds the auditor not to accept fake claims at face value.
+
+---
+
+## Worked example: synthesis_agent Phase 2 audit, round 2
+
+```
+Audit round: 2 of 3
+Previous rounds: Round 1: P1×3 / P2×7 / P3×2 (12 total); all P1 closed; 4 P2 closed; 3 P2 + 2 P3 carried.
+
+Bundle scope: Phase 2 chapter deliverables — synthesis output for chapter 4
+
+Authoritative context (commit a1b2c3d):
+
+Primary deliverables (audit target):
+- chapter4_synthesis.md (synthesis_agent output, 14k words across 6 sections)
+- chapter4_evidence_inventory.md (effect inventory per source, synthesis_agent companion artefact)
+
+Supporting context (do not audit; reference only):
+- shared/contracts/passport/literature_corpus_entry.schema.json
+- deep-research/agents/synthesis_agent.md (the agent prompt — for understanding patterns, not for audit)
+- chapter4_bibliography.json (bibliography_agent output, V2_CLEAN — verified upstream)
+
+Out-of-scope (do not read):
+- chapter1-3 / chapter5+ deliverables (separate bundles)
+
+Round 2 job:
+(a) Verify each round-1 finding closed correctly. List by ID.
+(b) Audit for new issues introduced by round-1 corrections.
+(c) Run the 7 audit dimensions on the two primary deliverables.
+(d) Anchoring-bias residual check on closed findings.
+(e) PARTIAL-vs-CLOSED check.
+(f) Cross-section consistency check: for every source cited in 2+ sections of chapter4_synthesis.md, verify the source's characterization is compatible across sections; flag any pair of sections that pull the source's effect in incompatible directions (Pattern A1).
+
+Convergence target: ZERO findings of ANY severity in one round.
+[+ standard fallback]
+
+DO NOT simulate any audit step. [+ standard anti-fake-audit guard]
+
+Output:
+[+ standard output format]
+```
+
+---
+
+## Cross-references
+
+- `shared/references/irb_terminology_glossary.md` — referenced by dimension §3.5.
+- `shared/references/psychometric_terminology_glossary.md` — referenced by dimension §3.5.
+- `shared/references/protected_hedging_phrases.md` — referenced by dimension §3.7.
+- `shared/references/word_count_conventions.md` — referenced by dimension §3.7.
+- ARS feedback memory `feedback_codex_iterative_spec_review_to_zero.md` — convergence target rationale.
+- ARS feedback memory `feedback_cross_model_review_cascade_inconsistency.md` — round-N+1 cascade audit rationale.
+- ARS feedback memory `feedback_subagent_tool_hallucination.md` — anti-fake-audit guard rationale.
+- ARS feedback memory `feedback_codex_xhigh_for_drift_audit.md` — model + reasoning-effort selection (gpt-5.5 + xhigh for high-blast-radius bundles).

--- a/shared/templates/codex_audit_multifile_template.md
+++ b/shared/templates/codex_audit_multifile_template.md
@@ -12,7 +12,7 @@ This template fixes a single audit-prompt structure so the orchestrator's audit 
 
 ## Template structure
 
-A v3.6.7 multi-file audit prompt has six sections in this order:
+A v3.6.7 multi-file audit prompt has seven sections in this order:
 
 1. Round metadata
 2. Bundle inventory
@@ -20,8 +20,9 @@ A v3.6.7 multi-file audit prompt has six sections in this order:
 4. Round-specific job
 5. Convergence target
 6. Output format
+7. Anti-fake-audit guard (mandatory; rides verbatim in every audit dispatch)
 
-The orchestrator fills the placeholders in `{curly_braces}`. Everything else rides verbatim.
+The orchestrator fills the placeholders in `{curly_braces}`. Everything else rides verbatim. Section 7 is non-negotiable — omitting it leaves sub-agents free to fake audit-passed metadata, which is the failure mode v3.6.7 spec §5.3 + Pattern C3 + `feedback_subagent_tool_hallucination.md` exist to prevent.
 
 ---
 
@@ -108,7 +109,9 @@ Codex evaluates the bundle along seven dimensions. Each dimension surfaces a spe
 
 **What to check:** Conflict-of-interest and reflexivity disclosures use explicit temporal bounds (year ranges, role-bounded periods, "former" prefix). Deictic temporal phrases ("during this period," "at the time," "currently") are absent or fully resolved by adjacent context. Disclosure obligations under publisher policy are met at abstract / executive-summary level, not only at body level.
 
-**Patterns surfaced:** Pattern C2 (temporal ambiguity), Pattern C1 (when compression strips disclosure).
+**Patterns surfaced:** Pattern C2 (temporal ambiguity).
+
+Note: word-count convention, 3–5% buffer adherence, and protected-hedge preservation against compression are **not** covered by §3.7. They are handled by the bundle-specific check in Section 4 (f) below — see the report_compiler_agent example for the expected `(f)` clause.
 
 ---
 
@@ -126,10 +129,10 @@ Round {N} job:
 
 **Fill rules:**
 - (a)–(e) ride verbatim every round (with N substitution).
-- (f) is bundle-specific. The orchestrator picks the bundle-specific check based on which downstream agent produced the deliverable. Examples:
+- (f) is bundle-specific. The orchestrator picks the bundle-specific check based on which downstream agent produced the deliverable. For report_compiler_agent bundles, (f) is mandatory and combines three sub-checks; the others are single-check. Examples:
   - synthesis_agent bundle: cross-section consistency check on every source cited in 2+ sections.
   - research_architect_agent bundle: construct-equivalence test on every reverse-coded item.
-  - report_compiler_agent bundle: protected-hedge preservation check (abstract vs. body).
+  - report_compiler_agent bundle (mandatory three-part check): (i) word count = `len(body.split())` ≤ publisher cap minus 3–5% buffer per `word_count_conventions.md`; (ii) every entry of upstream `protected_hedges` block per `protected_hedging_phrases.md` appears verbatim in the abstract; (iii) no claim in the abstract is less hedged than its anchor in the body. Failure of any sub-check is a P1 finding.
 
 ---
 
@@ -164,7 +167,7 @@ Output:
 
 ---
 
-## Anti-fake-audit guard (Pattern C3)
+## Section 7 — Anti-fake-audit guard (Pattern C3, mandatory)
 
 **Critical clause that rides in every audit dispatch context:**
 
@@ -211,10 +214,10 @@ Round 2 job:
 Convergence target: ZERO findings of ANY severity in one round.
 [+ standard fallback]
 
-DO NOT simulate any audit step. [+ standard anti-fake-audit guard]
-
 Output:
 [+ standard output format]
+
+DO NOT simulate any audit step. [+ standard Section 7 anti-fake-audit guard]
 ```
 
 ---


### PR DESCRIPTION
## Summary

Ships **Steps 1 + 2 of ARS v3.6.7** — downstream-agent pattern protection. Hardens three downstream agents (`synthesis_agent`, `research_architect_agent` survey-designer mode, `report_compiler_agent` abstract-only mode) against 18 hallucination/drift patterns documented in [`docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md`](docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md).

### Step 1 — references + audit template + lint
- 4 reference files in `shared/references/` (IRB terminology glossary, psychometric terminology glossary, protected hedging phrases protocol, word count conventions)
- `shared/templates/codex_audit_multifile_template.md` — multi-file audit prompt template with 7 audit dimensions and a mandatory three-part Section 4(f) check for `report_compiler_agent` bundles
- `scripts/check_v3_6_7_pattern_protection.py` — static lint enforcing protection-clause presence + obligation-phrase shape

### Step 2 — agent-prompt PATTERN PROTECTION blocks
- `synthesis_agent.md` carries A1–A5 (effect inventory cross-section consistency, pending-verification hedge, anchor justification, verbatim phrase boundary, declarative claims about un-provided documents forbidden)
- `research_architect_agent.md` (survey-designer mode) carries B1–B5 (IRB terminology pass-through, reverse-coded construct equivalence, event-anchored retrospective default, neutral all-valences phrasing, primary-source list enumerate-fully + no subsetting)
- `report_compiler_agent.md` (abstract-only mode) carries C1–C3 (whitespace-split word budget + 3–5% buffer + protected hedges budget-protected, explicit year range temporal disambiguation, anti-fake-audit guard + audit-passed metadata prohibition)

### Lint contract
- `scripts/check_v3_6_7_pattern_protection.py` — 9/9 PASS at baseline
- `scripts/test_check_v3_6_7_pattern_protection.py` — 29 mutation tests preserving codex review evidence (R2–R6) so future checker regressions surface in CI
- Both wired into `.github/workflows/spec-consistency.yml`
- Per-regex `allow_prohibition` flag (not per-Check) so prohibition-style obligations (`DO NOT simulate`, `must not claim audit-passed state`, `does not paraphrase`) don't leak the exemption to assertion-style obligations (`Compression must preserve …`)
- Span-restricted exemption: prohibition tokens inside the matched obligation span are exempted, but a second prohibition elsewhere in the bullet still triggers
- Modal/advisory weakeners cover `may` / `should` / `can` / `will` / `would` / `ought to` / `ideally` / `preferably` / `We recommend that` / `is/are recommended` / `is/are allowed` / `is/are permitted`, plus exception qualifiers (`except`, `unless`, `save when`)

### Out of scope (deferred to follow-up PR)
- **Step 6** orchestrator hooks — automatic per-agent audit + anti-fake-audit guard wiring (R6-002 from codex review)
- **Step 7** CHANGELOG entry for v3.6.7
- **Step 8** synthetic evaluation case demonstrating all 18 patterns triggered + protected

These need cross-agent runtime work and a separate spec discussion; pulling them into this PR would couple prompt-level changes with orchestrator-level changes.

## Codex review history

7 rounds of `gpt-5.5` + `xhigh` cross-model review reached SHIP-OK with 0 P1+P2 findings; only one P3 add-counter signal (`try to` / `generally` / `where relevant` weakeners) remains, which is non-blocking polish.

| Round | Findings | Status |
|---|---|---|
| R1 | 10 findings (Step 1 reference files) | Closed |
| R2 | 4 cascade gaps + R2-001 P2 (per-Check `allow_prohibition` leak) | Closed |
| R3 | 3 P2 (span-restricted exemption / token→regex / except-unless) | Closed |
| R4 | 3 P2 (modal verb scope / §6 sub-clause coverage / CI wiring) | Closed |
| R5 | 1 P2 + 1 P3 (`should/can/permitted` modals / mutation test suite) | Closed |
| R6 | 2 P2 (`will/would/ought to/ideally/preferably/We-recommend-that` / R6-002 runtime orchestration) | R6-001 closed; R6-002 explicitly out of scope for B2 |
| R7 | 1 P3 only (`try to` / `generally` add-counter signal) | **SHIP-OK** |

## Test plan

- [ ] CI green: `Validate v3.6.7 downstream-agent pattern protection` step passes
- [ ] CI green: `Run v3.6.7 pattern-protection mutation tests` step passes (29/29 tests)
- [ ] No regression in adjacent lints (`spec-consistency.yml` is sequential)
- [ ] Spot-check that the three agent prompts read cleanly at runtime — pattern protection blocks are not over-constrained prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)