### PR TITLE
v3.6.7 Step 7: CHANGELOG entry + version sweep

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,10 +6,18 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 
 | Skill | Purpose | Key Modes |
 |-------|---------|-----------|
-| `deep-research` v2.9.2 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
+| `deep-research` v2.9.3 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
 | `academic-paper` v3.1.1 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.9.0 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.6.5 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.6.7 | Full pipeline orchestrator | (coordinates all above) |
+
+## v3.6.7 Key Additions
+
+- **Downstream-agent pattern protection layer (Step 1+2)**: `synthesis_agent`, `research_architect_agent` (survey-designer mode), and `report_compiler_agent` (abstract-only mode) carry a `PATTERN PROTECTION (v3.6.7)` block hardening 13 of 18 documented hallucination/drift patterns (A1–A5 narrative-side, B1–B5 instrument-side, C1–C3 publication-side). Step 6 (orchestrator runtime hooks) and Step 8 (synthetic eval case) ship in a follow-up PR.
+- **Four reference files in `shared/references/`**: `irb_terminology_glossary.md` (anonymity/confidentiality/de-identification/pseudonymization), `psychometric_terminology_glossary.md` (true reverse-coded vs contrast item), `protected_hedging_phrases.md` (five-rule contract for upstream-marked hedges), `word_count_conventions.md` (whitespace-split + 3–5% buffer).
+- **Cross-model audit prompt template** at `shared/templates/codex_audit_multifile_template.md` covering seven audit dimensions plus a mandatory three-part Section 4(f) check for `report_compiler_agent` bundles.
+- **Static lint + 29-test mutation suite** at `scripts/check_v3_6_7_pattern_protection.py` and `scripts/test_check_v3_6_7_pattern_protection.py`, both wired into `.github/workflows/spec-consistency.yml`.
+- **Ship-quality target update**: per spec §10, ARS pipeline target moves from "each agent produces a clean v1" to "end-to-end deliverable set passes independent xhigh cross-model audit at 0 P1+P2 finding within three rounds."
 
 ## v3.6.5 Key Additions
 
@@ -124,7 +132,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.6.5 (per CHANGELOG.md)
-- **Last Updated**: 2026-04-27
+- **Suite version**: 3.6.7 (per CHANGELOG.md)
+- **Last Updated**: 2026-04-30
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,108 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.6.7] - 2026-04-30
+
+### Added
+
+- **Downstream-agent pattern protection layer** (`docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md`).
+  Hardens three downstream agents against 18 hallucination/drift patterns
+  documented in the spec: `synthesis_agent` (A1–A5 narrative-side), the
+  survey-designer mode of `research_architect_agent` (B1–B5 instrument-side),
+  and the abstract-only mode of `report_compiler_agent` (C1–C3 publication-
+  side), plus four cross-cutting patterns (D1–D4). Patterns observed in
+  production output across multiple chapter-length runs.
+- **Four reference files in `shared/references/`** carrying the operational
+  contracts that protection clauses cite:
+  - `irb_terminology_glossary.md` — anonymity vs confidentiality vs
+    de-identification vs pseudonymization (B1).
+  - `psychometric_terminology_glossary.md` — true reverse-coded vs contrast
+    item, with construct-equivalence rule (B2).
+  - `protected_hedging_phrases.md` — five-rule contract for upstream-marked
+    hedge protocol (conservative inclusion, anchor every entry, no
+    duplicates, verbatim preservation, conflict reporting) (C1).
+  - `word_count_conventions.md` — whitespace-split standard (`body.split()`),
+    3–5% buffer below hard cap, publisher conventions (C1).
+- **Cross-model audit prompt template** at
+  `shared/templates/codex_audit_multifile_template.md` — seven audit
+  dimensions (cross-ref, hallucination, primary-source integrity, internal
+  coherence, instrument quality, Round-N framing, COI adequacy) plus a
+  mandatory three-part Section 4(f) check for `report_compiler_agent`
+  bundles (whitespace-split cap-minus-buffer, protected-hedge verbatim,
+  abstract no less hedged than body — failure of any sub-check is P1).
+- **Static lint** at `scripts/check_v3_6_7_pattern_protection.py` enforcing
+  protection-clause presence and obligation-phrase shape across the
+  reference files, audit template, and three downstream agent prompts.
+  Per-regex `allow_prohibition` flag scopes the prohibition exemption so
+  prohibition-style obligations (`DO NOT simulate`, `must not claim
+  audit-passed state`, `does not paraphrase`) do not leak the exemption to
+  assertion-style obligations on the same Check. Span-restricted exemption
+  rejects a second prohibition elsewhere in the bullet. Modal/advisory
+  weakener coverage: `may`, `should`, `can`, `will`, `would`, `ought to`,
+  `ideally`, `preferably`, `We recommend that`, `is/are recommended`,
+  `is/are allowed`, `is/are permitted`, plus exception qualifiers
+  (`except`, `unless`, `save when`).
+- **Mutation test suite** at
+  `scripts/test_check_v3_6_7_pattern_protection.py` with 29 tests
+  preserving codex review evidence (R2–R6). Future checker regressions
+  surface in CI rather than only in ad-hoc mutation runs.
+- **CI wiring** in `.github/workflows/spec-consistency.yml` runs both the
+  static lint and the mutation suite on every push and pull request.
+
+### Changed
+
+- **`deep-research/agents/synthesis_agent.md`** carries a `PATTERN
+  PROTECTION (v3.6.7)` block with five clauses covering effect-inventory
+  cross-section consistency self-check, pending-verification hedge wrap,
+  one-line anchor justification, verbatim phrase boundary on quotes, and
+  the prohibition on declarative claims about un-provided documents
+  (with conditional-language fallback).
+- **`deep-research/agents/research_architect_agent.md`** survey-designer
+  mode carries a `PATTERN PROTECTION (v3.6.7)` block with five clauses
+  covering IRB terminology pass-through, reverse-coded construct-
+  equivalence justification, event-anchored retrospective default
+  (calendar-anchored only when sample shares a common event date),
+  neutral-balanced item phrasing with chapter argument vocabulary
+  forbidden, and primary-source list enumerate-fully (no subsetting,
+  no over-setting, no scope cross-contamination).
+- **`deep-research/agents/report_compiler_agent.md`** abstract-only mode
+  carries a `PATTERN PROTECTION (v3.6.7)` block with three clauses
+  covering whitespace-split word budget plus 3–5% buffer with budget-
+  protected hedges, explicit-temporal-bounds reflexivity disclosure
+  (year range / past-tense disambiguating verb / "former" prefix; deictic
+  phrases forbidden), and the anti-fake-audit guard (DO NOT simulate any
+  audit step; DO NOT claim to have run codex/external review; output
+  metadata must not claim audit-passed state).
+
+### Notes
+
+- v3.6.7 ships in two stages. **Step 1 + Step 2** (this entry) include
+  the four reference files, the audit template, the static lint, the
+  mutation test suite, the CI wiring, and the three agent-prompt
+  protection blocks. **Step 6** (orchestrator hooks for automatic
+  per-agent audit and anti-fake-audit guard wiring) and **Step 8**
+  (synthetic evaluation case demonstrating all 18 patterns triggered +
+  protected) ship in a follow-up PR. Step 6 is cross-agent runtime work
+  that warrants its own design discussion and is intentionally decoupled
+  from this prompt-and-lint PR.
+- Codex review history: seven rounds of `gpt-5.5` + `xhigh` cross-model
+  review reached SHIP-OK with zero P1 + P2 findings. R1 closed ten
+  Step-1 findings; R2 closed four cascade gaps plus the per-Check
+  `allow_prohibition` leak; R3 closed three P2 findings (span-restricted
+  exemption, token→regex with imperative anchoring, `except/unless/
+  save when` weakeners); R4 closed three P2 findings (modal verb scope
+  expansion, §6 sub-clause coverage, lint→CI wiring); R5 closed one P2
+  plus one P3 (`should/can/permitted` modals and the mutation test
+  suite); R6 closed one P2 (`will/would/ought to/ideally/preferably/
+  We-recommend-that` weakeners) and explicitly deferred orchestrator
+  runtime hooks to the Step 6 follow-up PR. R7 surfaced only one P3
+  add-counter signal (`try to / generally / where relevant` weakeners),
+  which is non-blocking polish.
+- ARS pipeline ship-quality target updates from "each agent produces a
+  clean v1" to "end-to-end deliverable set passes independent xhigh
+  cross-model audit at 0 P1 + P2 finding within three rounds" (per spec
+  §10).
+
 ## [3.6.5.2] - 2026-04-27
 
 ### Changed

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.6.5 (2026-04-27)
+Last updated: v3.6.7 (2026-04-30)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.6.5-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.5)
+[![Version](https://img.shields.io/badge/version-v3.6.7-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.7)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -288,6 +288,14 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.6.7 (2026-04-30) — Downstream-Agent Pattern Protection (Step 1+2)
+
+- **Three downstream agents hardened against 13 of 18 documented hallucination/drift patterns**: `synthesis_agent` (A1–A5 narrative-side), the survey-designer mode of `research_architect_agent` (B1–B5 instrument-side), and the abstract-only mode of `report_compiler_agent` (C1–C3 publication-side). Each agent prompt now carries a `PATTERN PROTECTION (v3.6.7)` block.
+- **Four reference files in `shared/references/`**: `irb_terminology_glossary.md`, `psychometric_terminology_glossary.md`, `protected_hedging_phrases.md`, `word_count_conventions.md`. The reference files carry operational contracts that the agent prompts cite by path.
+- **Cross-model audit prompt template** at `shared/templates/codex_audit_multifile_template.md` with seven audit dimensions and a mandatory three-part Section 4(f) check for `report_compiler_agent` bundles. Failure of any sub-check is a P1 finding.
+- **Static lint + 29-test mutation suite**: `scripts/check_v3_6_7_pattern_protection.py` enforces protection-clause presence and obligation-phrase shape; `scripts/test_check_v3_6_7_pattern_protection.py` preserves codex review evidence so future checker regressions surface in CI. Both are wired into `.github/workflows/spec-consistency.yml`.
+- **Codex review history**: seven rounds of `gpt-5.5` + `xhigh` cross-model review reached SHIP-OK with zero P1+P2 findings. Step 6 (orchestrator runtime hooks) and Step 8 (synthetic eval case) ship in a follow-up PR.
 
 ### v3.6.5 (2026-04-27) — Material Passport `literature_corpus[]` Consumer Integration
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.6.5-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.5)
+[![Version](https://img.shields.io/badge/version-v3.6.7-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.7)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -269,6 +269,14 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.6.7（2026-04-30）— 下游 agent pattern protection（Step 1+2）
+
+- **三個下游 agent 收緊 13 / 18 個已知幻覺與漂移 pattern**：`synthesis_agent`（A1–A5 敘事側）、`research_architect_agent` survey-designer 模式（B1–B5 工具側）、`report_compiler_agent` abstract-only 模式（C1–C3 出版側）。三個 agent prompt 各自加上 `PATTERN PROTECTION (v3.6.7)` 區塊。
+- **`shared/references/` 增加四份 reference 文件**：`irb_terminology_glossary.md`、`psychometric_terminology_glossary.md`、`protected_hedging_phrases.md`、`word_count_conventions.md`。protection 條款引用這些檔案路徑做為 operational contract。
+- **跨模型 audit prompt 模板** 在 `shared/templates/codex_audit_multifile_template.md`，含七個 audit dimension 與 `report_compiler_agent` bundle 必跑的三段式 Section 4(f) 檢查。任一 sub-check 失敗即 P1 finding。
+- **靜態 lint + 29 條 mutation 測試**：`scripts/check_v3_6_7_pattern_protection.py` 強制 protection 條款存在性與 obligation phrase 形狀；`scripts/test_check_v3_6_7_pattern_protection.py` 把 codex review 的 mutation 證據封存為 unit test，未來 lint 退化會在 CI 浮上來。兩者都接進 `.github/workflows/spec-consistency.yml`。
+- **Codex review 紀錄**：七輪 `gpt-5.5` + `xhigh` 跨模型 review 收斂到 0 P1+P2 finding 才 SHIP。Step 6（orchestrator runtime hook）與 Step 8（合成 eval case）走 follow-up PR。
 
 ### v3.6.5（2026-04-27）— Material Passport `literature_corpus[]` Consumer 整合
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.6.5"
-  last_updated: "2026-04-27"
+  version: "3.6.7"
+  last_updated: "2026-04-30"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only
@@ -579,8 +579,8 @@ Stage 5: academic-paper (format-convert mode)
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.6.5 |
-| Last Updated | 2026-04-27 |
+| Skill Version | 3.6.7 |
+| Last Updated | 2026-04-30 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v2.0+, academic-paper v2.0+, academic-paper-reviewer v1.1+ |
 | Role | Full academic research workflow orchestrator |

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -2,8 +2,8 @@
 name: deep-research
 description: "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題."
 metadata:
-  version: "2.9.2"
-  last_updated: "2026-04-27"
+  version: "2.9.3"
+  last_updated: "2026-04-30"
   status: active
   data_access_level: raw
   task_type: open-ended
@@ -476,8 +476,8 @@ deep-research (systematic-review) + academic-paper -> PRISMA systematic review p
 
 | Item | Content |
 |------|---------|
-| Skill Version | 2.9.2 |
-| Last Updated | 2026-04-27 |
+| Skill Version | 2.9.3 |
+| Last Updated | 2026-04-30 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | academic-paper v1.0+ (downstream) |
 

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.6.5 (2026-04-27)")
+    expect_contains(rel_path, "Last updated: v3.6.7 (2026-04-30)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.6.5")
+    expect_contains(rel_path, "**Suite version**: 3.6.7")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.6.5-blue")
-    expect_contains(rel_path, "releases/tag/v3.6.5")
+    expect_contains(rel_path, "version-v3.6.7-blue")
+    expect_contains(rel_path, "releases/tag/v3.6.7")
+    expect_contains(rel_path, "### v3.6.7 (2026-04-30)")
     expect_contains(rel_path, "### v3.6.5 (2026-04-27)")
     expect_contains(rel_path, "### v3.6.4 (2026-04-25)")
     expect_contains(rel_path, "### v3.6.3 (2026-04-23)")
@@ -200,8 +201,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.6.5-blue")
-    expect_contains(rel_path, "releases/tag/v3.6.5")
+    expect_contains(rel_path, "version-v3.6.7-blue")
+    expect_contains(rel_path, "releases/tag/v3.6.7")
+    expect_contains(rel_path, "### v3.6.7（2026-04-30）")
     expect_contains(rel_path, "### v3.6.5（2026-04-27）")
     expect_contains(rel_path, "### v3.6.4（2026-04-25）")
     expect_contains(rel_path, "### v3.6.3（2026-04-23）")


### PR DESCRIPTION
## Summary

Step 7 of v3.6.7. Documents the Step 1+2 work that landed in #48 and propagates the version bump across the seven canonical sweep targets.

### Changes

- `CHANGELOG.md`: new `[3.6.7] - 2026-04-30` entry documenting Added (4 reference files / audit template / static lint / 29-test mutation suite / CI wiring) + Changed (three agent prompts) + Notes (split rationale for Step 6+8 follow-up, full codex R1–R7 review history, ship-quality target update from spec §10).
- `.claude/CLAUDE.md`: Suite version 3.6.5 → 3.6.7. Skills Overview table bumps `academic-pipeline` 3.6.5 → 3.6.7 (suite-version invariant) and `deep-research` 2.9.2 → 2.9.3 (patch — three agent prompts gained `PATTERN PROTECTION (v3.6.7)` blocks). New `v3.6.7 Key Additions` section above the existing `v3.6.5 Key Additions`.
- `README.md` / `README.zh-TW.md`: version badges 3.6.5 → 3.6.7; new changelog entry above the v3.6.5 entry.
- `academic-pipeline/SKILL.md`: frontmatter `version` + `last_updated`; Version Info table row.
- `deep-research/SKILL.md`: frontmatter `version` + `last_updated`; Version Info table row.
- `MODE_REGISTRY.md`: `Last updated` line.
- `scripts/check_spec_consistency.py`: bumped four pinned text checks (suite version line, `Last updated` line, English README badge + tag + changelog heading, Chinese README badge + tag + changelog heading). The v3.6.5 changelog heading checks are kept as regression guards so future work cannot silently delete the entry.

### Why `academic-paper` and `academic-paper-reviewer` are NOT bumped

Their behavior was not changed by v3.6.7. Suite-level coordination is the `academic-pipeline` orchestrator's invariant; per-skill semver moves only when that skill's behavior changes.

### Test plan

- [x] `python3 scripts/check_version_consistency.py` → PASS
- [x] `python3 scripts/check_spec_consistency.py` → PASS
- [x] `python3 -m unittest scripts.test_check_version_consistency` → 8/8 OK
- [x] `python3 scripts/check_v3_6_7_pattern_protection.py` → 9/9 PASS
- [x] `python3 -m unittest scripts.test_check_v3_6_7_pattern_protection` → 29/29 OK
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)