### PR TITLE
feat(v3.6.7 Step 6): Phase 6.2 + 6.4 — audit schemas + monotonic helper

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -107,3 +107,8 @@ jobs:
           PYTHONPATH: .
         run: python3 -m unittest scripts.test_check_v3_6_7_pattern_protection -v
 
+      - name: Run v3.6.7 Step 6 audit schema + helper tests (Phase 6.2 + 6.4)
+        env:
+          PYTHONPATH: .
+        run: python3 -m unittest scripts.test_audit_schemas scripts.test__next_verified_at_ms -v
+

--- a/scripts/_next_verified_at_ms.py
+++ b/scripts/_next_verified_at_ms.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Strict-monotonic verified_at helper for ARS v3.6.7 Step 6 (spec §5.4).
+
+Every orchestrator-side verdict.verified_at write — Path B8d normal merges,
+another_round re-merges, ship_with_known_residue acknowledgement appends —
+goes through next_verified_at_ms() so the new value is strictly greater
+than every prior persisted entry's verified_at regardless of clock
+granularity. This is what makes Path A latest-by-verified_at selection
+total-order deterministic at passport scope (§3.7 family D row D3).
+
+Reference pseudocode from spec §5.4:
+
+    def _next_verified_at_ms(passport_audit_artifacts: list) -> str:
+        now_ms = utc_now_ms()
+        if not passport_audit_artifacts:
+            return now_ms
+        latest_ms = max(entry["verdict"]["verified_at"] for entry in passport_audit_artifacts)
+        return max(now_ms, increment_ms(latest_ms, 1))
+
+`latest_ms` spans ALL prior persisted entries (not filtered by tuple) so
+total ordering holds passport-wide.
+
+Run as a CLI:
+    python scripts/_next_verified_at_ms.py --passport <path>
+        Reads passport YAML/JSON, prints the next verified_at value.
+
+Importable API:
+    from scripts._next_verified_at_ms import next_verified_at_ms
+    next_verified_at_ms(passport["audit_artifact"])  # -> "2026-...Z"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as e:  # pragma: no cover
+    print(f"Missing dependency: {e}. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+_RFC3339_MS_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
+
+def utc_now_ms() -> str:
+    """Current UTC time as RFC 3339 with millisecond precision (Z suffix)."""
+    return rfc3339_ms(datetime.now(timezone.utc))
+
+
+def parse_rfc3339_ms(s: str) -> datetime:
+    """Parse a strict RFC 3339 UTC ms-precision timestamp ('...Z' suffix).
+
+    Raises ValueError if the input does not match the exact shape
+    YYYY-MM-DDTHH:MM:SS.mmmZ — accepting other RFC 3339 variants would
+    let drift in (the schema's regex pattern enforces ms-precision).
+    """
+    if not (len(s) == 24 and s.endswith("Z") and s[-5] == "." and s[10] == "T"):
+        raise ValueError(f"not RFC 3339 ms UTC ('...Z' with .NNN): {s!r}")
+    return datetime.strptime(s[:-1] + "000", _RFC3339_MS_FORMAT).replace(tzinfo=timezone.utc)
+
+
+def rfc3339_ms(dt: datetime) -> str:
+    """Format a UTC datetime as RFC 3339 with millisecond precision."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime(_RFC3339_MS_FORMAT)[:-3] + "Z"
+
+
+def bump_ms(dt: datetime, n: int = 1) -> datetime:
+    """Advance dt by n milliseconds (carries into seconds / minutes / etc.)."""
+    return dt + timedelta(milliseconds=n)
+
+
+def next_verified_at_ms(passport_audit_artifacts: list[dict[str, Any]] | None) -> str:
+    """Return the next verified_at value strictly greater than every prior entry.
+
+    Implements §5.4 pseudocode. None / [] is the empty-ledger base case
+    and returns the current UTC clock value.
+
+    Picks `latest` via lexicographic max over the prior verified_at strings.
+    For ms-precision RFC 3339 UTC strings (`YYYY-MM-DDTHH:MM:SS.NNNZ`,
+    fixed width) lex-max coincides with chronological max — this relies on
+    the schema regex (§3.2 audit_artifact_entry verified_at constraint)
+    rejecting non-canonical shapes upstream so no malformed entry can
+    sneak in and reorder the comparison.
+    """
+    now = parse_rfc3339_ms(utc_now_ms())
+    if not passport_audit_artifacts:
+        return rfc3339_ms(now)
+
+    latest_str = max(
+        entry["verdict"]["verified_at"] for entry in passport_audit_artifacts
+    )
+    latest = parse_rfc3339_ms(latest_str)
+    bumped = bump_ms(latest, 1)
+    return rfc3339_ms(max(now, bumped))
+
+
+def _load_passport_audit_artifacts(path: Path) -> list[dict[str, Any]]:
+    """Read passport YAML or JSON, return audit_artifact[] (or [] if absent).
+
+    Raises ValueError if the file cannot be parsed; CLI main() catches and
+    exits 2. The three "absent" cases (top-level not a dict, key missing,
+    value not a list) all coerce to [] for v3.6.7 — the helper is a
+    monotonic-bump primitive, not a passport validator.
+
+    TODO(Phase 6.3): scripts/check_audit_artifact_consistency.py should
+    treat `audit_artifact` present-but-not-a-list as malformed and reject,
+    not coerce silently. Lifecycle ownership rule §3.7 E2.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ValueError(f"failed to read {path}: {e}") from e
+
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".json":
+            data = json.loads(text)
+        else:
+            data = yaml.safe_load(text)
+    except (yaml.YAMLError, json.JSONDecodeError) as e:
+        raise ValueError(f"failed to parse {path}: {e}") from e
+
+    if not isinstance(data, dict):
+        return []
+    artifacts = data.get("audit_artifact") or []
+    if not isinstance(artifacts, list):
+        return []
+    return artifacts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Print the next verified_at value (RFC 3339 UTC ms) strictly "
+            "greater than every prior audit_artifact[] entry's verified_at "
+            "in the given Material Passport (§5.4)."
+        ),
+    )
+    parser.add_argument(
+        "--passport",
+        required=True,
+        type=Path,
+        help="Path to passport YAML or JSON containing audit_artifact[].",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.passport.exists():
+        print(f"ERROR: passport not found: {args.passport}", file=sys.stderr)
+        return 2
+
+    try:
+        artifacts = _load_passport_audit_artifacts(args.passport)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+    print(next_verified_at_ms(artifacts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_next_verified_at_ms.py
+++ b/scripts/_next_verified_at_ms.py
@@ -125,7 +125,13 @@ def _load_passport_audit_artifacts(path: Path) -> list[dict[str, Any]]:
         if suffix == ".json":
             data = json.loads(text)
         else:
-            data = yaml.safe_load(text)
+            # Use BaseLoader so PyYAML returns every scalar as str — without
+            # this, unquoted RFC 3339 timestamps in spec-example passports
+            # (e.g. `verified_at: 2026-04-30T15:23:11.847Z`) get auto-cast
+            # to datetime objects, which would break parse_rfc3339_ms()
+            # downstream. The schema constrains verified_at to a string;
+            # strict string load matches that contract.
+            data = yaml.load(text, Loader=yaml.BaseLoader)  # noqa: S506 - intentional, str-only
     except (yaml.YAMLError, json.JSONDecodeError) as e:
         raise ValueError(f"failed to parse {path}: {e}") from e
 

--- a/scripts/_test_helpers.py
+++ b/scripts/_test_helpers.py
@@ -4,10 +4,12 @@ Avoid duplicating subprocess.run boilerplate across multiple test files.
 """
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
 def run_script(
@@ -39,4 +41,33 @@ def run_skill_linter(script_path: Path, root: Path) -> subprocess.CompletedProce
         "--path",
         str(root),
         extra_env={"PYTHONPATH": str(script_path.parent)},
+    )
+
+
+def load_json_schema(path: Path) -> dict[str, Any]:
+    """Load a JSON Schema file and verify it parses as Draft 2020-12.
+
+    Centralised so test files don't re-implement the same load + check_schema
+    pair. Mirrors the helper at scripts/check_literature_corpus_schema.py
+    (which predates this module) — that script can migrate at next edit.
+    """
+    from jsonschema import Draft202012Validator
+
+    with path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def build_schema_validator(schema: dict[str, Any]):
+    """Construct a Draft 2020-12 validator with format checking enabled.
+
+    Without format_checker, format keywords (date-time on verified_at /
+    acknowledged_at / generated_at) validate silently — a hole codex flagged
+    in T3 review of literature_corpus_entry.schema.json.
+    """
+    from jsonschema import Draft202012Validator
+
+    return Draft202012Validator(
+        schema, format_checker=Draft202012Validator.FORMAT_CHECKER
     )

--- a/scripts/test__next_verified_at_ms.py
+++ b/scripts/test__next_verified_at_ms.py
@@ -1,0 +1,238 @@
+"""Unit tests for scripts/_next_verified_at_ms.py (ARS v3.6.7 Step 6 Phase 6.4).
+
+Per spec §5.4 strict-monotonic helper:
+
+  def _next_verified_at_ms(passport_audit_artifacts: list) -> str:
+      now_ms = utc_now_ms()
+      if not passport_audit_artifacts:
+          return now_ms
+      latest_ms = max(entry["verdict"]["verified_at"] for entry in passport_audit_artifacts)
+      return max(now_ms, increment_ms(latest_ms, 1))
+
+§10 Phase 6.4 verification gate: "_next_verified_at_ms() always returns a
+string strictly greater than every prior verified_at; verified by
+property-based test."
+
+Cases per §10:
+  (a) empty ledger
+  (b) clock fresh (now > latest+1ms)
+  (c) clock stale (now <= latest, helper bumps by 1 ms)
+  (d) multiple prior entries (max selected, not last)
+
+Plus property-based monotonic test and RFC 3339 ms shape test.
+"""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import patch
+
+from scripts._next_verified_at_ms import (
+    bump_ms,
+    next_verified_at_ms,
+    parse_rfc3339_ms,
+    rfc3339_ms,
+    utc_now_ms,
+)
+from scripts._test_helpers import run_script
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts/_next_verified_at_ms.py"
+
+RFC3339_MS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def _persisted_entry(verified_at: str) -> dict[str, Any]:
+    return {
+        "stage": 2,
+        "agent": "synthesis_agent",
+        "deliverable_path": "x.md",
+        "deliverable_sha": "a" * 64,
+        "run_id": "2026-04-30T15-22-04Z-d8f3",
+        "bundle_manifest_sha": "9" * 64,
+        "artifact_paths": {
+            "jsonl": "x.jsonl",
+            "sidecar": "x.meta.json",
+            "verdict": "x.verdict.yaml",
+        },
+        "verdict": {
+            "status": "MINOR",
+            "round": 1,
+            "target_rounds": 3,
+            "finding_counts": {"p1": 0, "p2": 0, "p3": 1},
+            "verified_at": verified_at,
+            "verified_by": "pipeline_orchestrator_agent",
+        },
+    }
+
+
+class TestNextVerifiedAtMs(unittest.TestCase):
+    """Pure-function behaviour per §5.4 / §10 cases (a)-(d)."""
+
+    # Case (a)
+    def test_empty_ledger_returns_now(self) -> None:
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:30:00.000Z"):
+            self.assertEqual(next_verified_at_ms([]), "2026-04-30T15:30:00.000Z")
+
+    # Case (b)
+    def test_clock_fresh_returns_now(self) -> None:
+        prior = [_persisted_entry("2026-04-30T15:22:04.123Z")]
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:30:00.000Z"):
+            self.assertEqual(next_verified_at_ms(prior), "2026-04-30T15:30:00.000Z")
+
+    # Case (c)
+    def test_clock_stale_bumps_latest_by_one_ms(self) -> None:
+        prior = [_persisted_entry("2026-04-30T15:30:00.000Z")]
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:30:00.000Z"):
+            self.assertEqual(next_verified_at_ms(prior), "2026-04-30T15:30:00.001Z")
+
+    def test_clock_behind_bumps_latest_by_one_ms(self) -> None:
+        prior = [_persisted_entry("2026-04-30T15:30:00.000Z")]
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:29:59.500Z"):
+            self.assertEqual(next_verified_at_ms(prior), "2026-04-30T15:30:00.001Z")
+
+    # Case (d)
+    def test_multi_entries_picks_max_not_last(self) -> None:
+        prior = [
+            _persisted_entry("2026-04-30T15:22:04.123Z"),
+            _persisted_entry("2026-04-30T15:50:00.999Z"),
+            _persisted_entry("2026-04-30T15:30:00.000Z"),
+        ]
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:30:00.000Z"):
+            self.assertEqual(next_verified_at_ms(prior), "2026-04-30T15:50:01.000Z")
+
+    def test_ms_overflow_carries_to_seconds(self) -> None:
+        prior = [_persisted_entry("2026-04-30T15:22:04.999Z")]
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:22:04.000Z"):
+            self.assertEqual(next_verified_at_ms(prior), "2026-04-30T15:22:05.000Z")
+
+    def test_returns_rfc3339_ms_shape(self) -> None:
+        with patch("scripts._next_verified_at_ms.utc_now_ms", return_value="2026-04-30T15:30:00.000Z"):
+            result = next_verified_at_ms([])
+        self.assertRegex(result, RFC3339_MS_RE)
+
+
+class TestStrictMonotonicProperty(unittest.TestCase):
+    """§10 verification gate: result strictly greater than every prior entry."""
+
+    def test_property_strictly_greater_than_every_prior(self) -> None:
+        scenarios: list[tuple[list[str], str]] = [
+            ([], "2026-04-30T15:30:00.000Z"),
+            (["2026-04-30T15:30:00.000Z"], "2026-04-30T15:30:00.000Z"),
+            (["2026-04-30T15:30:00.500Z"], "2026-04-30T15:30:00.000Z"),
+            (["2026-04-30T15:30:00.000Z"], "2026-04-30T16:00:00.000Z"),
+            (
+                ["2026-04-30T15:22:04.123Z", "2026-04-30T15:50:00.999Z", "2026-04-30T15:30:00.000Z"],
+                "2026-04-30T15:30:00.000Z",
+            ),
+            (["2026-04-30T15:22:04.999Z"], "2026-04-30T15:22:04.000Z"),
+        ]
+        for prior_strs, now in scenarios:
+            with self.subTest(prior=prior_strs, now=now):
+                prior = [_persisted_entry(s) for s in prior_strs]
+                with patch("scripts._next_verified_at_ms.utc_now_ms", return_value=now):
+                    result = next_verified_at_ms(prior)
+                result_ms = parse_rfc3339_ms(result)
+                for s in prior_strs:
+                    self.assertGreater(
+                        result_ms,
+                        parse_rfc3339_ms(s),
+                        f"result {result} not > prior {s}",
+                    )
+
+
+class TestPrimitives(unittest.TestCase):
+    """parse_rfc3339_ms / rfc3339_ms / bump_ms round-trip and edge cases."""
+
+    def test_parse_round_trip(self) -> None:
+        for s in [
+            "2026-04-30T15:22:04.123Z",
+            "2026-04-30T15:22:04.000Z",
+            "2026-04-30T23:59:59.999Z",
+        ]:
+            with self.subTest(s=s):
+                self.assertEqual(rfc3339_ms(parse_rfc3339_ms(s)), s)
+
+    def test_bump_ms_overflows_second(self) -> None:
+        self.assertEqual(
+            rfc3339_ms(bump_ms(parse_rfc3339_ms("2026-04-30T15:22:04.999Z"), 1)),
+            "2026-04-30T15:22:05.000Z",
+        )
+
+    def test_bump_ms_overflows_minute(self) -> None:
+        self.assertEqual(
+            rfc3339_ms(bump_ms(parse_rfc3339_ms("2026-04-30T15:22:59.999Z"), 1)),
+            "2026-04-30T15:23:00.000Z",
+        )
+
+    def test_utc_now_ms_real_clock_shape(self) -> None:
+        # Sanity: real clock returns the expected shape.
+        self.assertRegex(utc_now_ms(), RFC3339_MS_RE)
+
+    def test_parse_rejects_non_ms_format(self) -> None:
+        for s in [
+            "2026-04-30T15:22:04Z",
+            "2026-04-30T15:22:04.12Z",
+            "2026-04-30T15:22:04.1234Z",
+            "2026-04-30 15:22:04.123Z",
+            "2026-04-30T15:22:04.123+00:00",
+        ]:
+            with self.subTest(s=s):
+                with self.assertRaises(ValueError):
+                    parse_rfc3339_ms(s)
+
+
+class TestCli(unittest.TestCase):
+    """CLI invocation per §10 Phase 6.4 deliverables (--passport <path>)."""
+
+    def test_cli_with_empty_passport_yaml_returns_now_shape(self) -> None:
+        with TemporaryDirectory() as td:
+            passport = Path(td) / "passport.yaml"
+            passport.write_text("audit_artifact: []\n", encoding="utf-8")
+            result = run_script(SCRIPT, "--passport", str(passport))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertRegex(result.stdout.strip(), RFC3339_MS_RE)
+
+    def test_cli_with_prior_entries_returns_strictly_greater(self) -> None:
+        with TemporaryDirectory() as td:
+            passport = Path(td) / "passport.yaml"
+            passport.write_text(
+                "audit_artifact:\n"
+                "  - verdict:\n"
+                "      verified_at: '2099-12-31T23:59:58.000Z'\n"
+                "  - verdict:\n"
+                "      verified_at: '2026-01-01T00:00:00.000Z'\n",
+                encoding="utf-8",
+            )
+            result = run_script(SCRIPT, "--passport", str(passport))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout.strip()
+        self.assertRegex(out, RFC3339_MS_RE)
+        self.assertGreater(parse_rfc3339_ms(out), parse_rfc3339_ms("2099-12-31T23:59:58.000Z"))
+
+    def test_cli_with_no_audit_artifact_key_returns_now(self) -> None:
+        with TemporaryDirectory() as td:
+            passport = Path(td) / "passport.yaml"
+            passport.write_text("schema_version: 9\n", encoding="utf-8")
+            result = run_script(SCRIPT, "--passport", str(passport))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertRegex(result.stdout.strip(), RFC3339_MS_RE)
+
+    def test_cli_missing_passport_exits_nonzero(self) -> None:
+        result = run_script(SCRIPT, "--passport", "/no/such/file.yaml")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_cli_malformed_yaml_exits_two(self) -> None:
+        with TemporaryDirectory() as td:
+            passport = Path(td) / "passport.yaml"
+            passport.write_text("audit_artifact: [\n  unbalanced", encoding="utf-8")
+            result = run_script(SCRIPT, "--passport", str(passport))
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("failed to parse", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test__next_verified_at_ms.py
+++ b/scripts/test__next_verified_at_ms.py
@@ -213,6 +213,24 @@ class TestCli(unittest.TestCase):
         self.assertRegex(out, RFC3339_MS_RE)
         self.assertGreater(parse_rfc3339_ms(out), parse_rfc3339_ms("2099-12-31T23:59:58.000Z"))
 
+    def test_cli_with_unquoted_timestamps_does_not_crash(self) -> None:
+        # Spec §3.1 example uses unquoted timestamps. PyYAML's default loader
+        # would coerce these to datetime objects and break parse_rfc3339_ms.
+        # CLI must keep them as strings (BaseLoader path).
+        with TemporaryDirectory() as td:
+            passport = Path(td) / "passport.yaml"
+            passport.write_text(
+                "audit_artifact:\n"
+                "  - verdict:\n"
+                "      verified_at: 2099-12-31T23:59:58.000Z\n",
+                encoding="utf-8",
+            )
+            result = run_script(SCRIPT, "--passport", str(passport))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout.strip()
+        self.assertRegex(out, RFC3339_MS_RE)
+        self.assertGreater(parse_rfc3339_ms(out), parse_rfc3339_ms("2099-12-31T23:59:58.000Z"))
+
     def test_cli_with_no_audit_artifact_key_returns_now(self) -> None:
         with TemporaryDirectory() as td:
             passport = Path(td) / "passport.yaml"

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -227,6 +227,26 @@ NEG_ENTRY_PERSISTED_BAD_STATUS: dict[str, Any] = {
     },
 }
 
+# §3.7 A2 — AUDIT_FAILED proposal without failure_reason must reject so that
+# Path B5 short-circuit always has a reason string to surface in the BLOCK
+# message (mirrors the verdict-file rule).
+NEG_ENTRY_PROPOSAL_AUDIT_FAILED_NO_REASON = {
+    **{k: v for k, v in ENTRY_PROPOSAL_AUDIT_FAILED.items() if k != "verdict"},
+    "verdict": {
+        k: v
+        for k, v in ENTRY_PROPOSAL_AUDIT_FAILED["verdict"].items()
+        if k != "failure_reason"
+    },
+}
+# §3.7 A2 inverse — non-AUDIT_FAILED proposal carrying failure_reason must reject.
+NEG_ENTRY_PROPOSAL_PASS_WITH_FAILURE_REASON = {
+    **ENTRY_PROPOSAL_PASS,
+    "verdict": {
+        **ENTRY_PROPOSAL_PASS["verdict"],
+        "failure_reason": "should not be here",
+    },
+}
+
 NEG_ENTRY_BAD_AGENT = {**ENTRY_PERSISTED_MINOR, "agent": "rogue_agent"}
 NEG_ENTRY_BAD_RUN_ID = {**ENTRY_PERSISTED_MINOR, "run_id": "not-an-iso-id"}
 NEG_ENTRY_BAD_SHA = {**ENTRY_PERSISTED_MINOR, "deliverable_sha": "tooshort"}
@@ -354,6 +374,12 @@ class TestEntrySchema(_SchemaTestBase):
 
     def test_rejects_persisted_pass_with_acknowledgement(self) -> None:
         self.assertInvalid(NEG_ENTRY_PERSISTED_PASS_WITH_ACK)
+
+    def test_rejects_audit_failed_proposal_without_failure_reason(self) -> None:
+        self.assertInvalid(NEG_ENTRY_PROPOSAL_AUDIT_FAILED_NO_REASON)
+
+    def test_rejects_pass_proposal_with_failure_reason(self) -> None:
+        self.assertInvalid(NEG_ENTRY_PROPOSAL_PASS_WITH_FAILURE_REASON)
 
     def test_rejects_unknown_agent(self) -> None:
         self.assertInvalid(NEG_ENTRY_BAD_AGENT)

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -250,6 +250,26 @@ NEG_ENTRY_PROPOSAL_PASS_WITH_FAILURE_REASON = {
 NEG_ENTRY_BAD_AGENT = {**ENTRY_PERSISTED_MINOR, "agent": "rogue_agent"}
 NEG_ENTRY_BAD_RUN_ID = {**ENTRY_PERSISTED_MINOR, "run_id": "not-an-iso-id"}
 NEG_ENTRY_BAD_SHA = {**ENTRY_PERSISTED_MINOR, "deliverable_sha": "tooshort"}
+# Path safety on artifact_paths: jsonl/sidecar/verdict MUST be repo-relative.
+# Path B reads these to locate evidence; absolute or escaping paths would let a
+# forged proposal point verification outside the repo.
+NEG_ENTRY_ARTIFACT_PATH_ABSOLUTE = {
+    **ENTRY_PERSISTED_MINOR,
+    "artifact_paths": {
+        **ENTRY_PERSISTED_MINOR["artifact_paths"],
+        "jsonl": "/tmp/forged.jsonl",
+    },
+}
+NEG_ENTRY_ARTIFACT_PATH_DOTDOT = {
+    **ENTRY_PERSISTED_MINOR,
+    "artifact_paths": {
+        **ENTRY_PERSISTED_MINOR["artifact_paths"],
+        "verdict": "../../forged.verdict.yaml",
+    },
+}
+# Path safety on deliverable_path:
+NEG_ENTRY_DELIVERABLE_PATH_ABSOLUTE = {**ENTRY_PERSISTED_MINOR, "deliverable_path": "/etc/passwd"}
+NEG_ENTRY_DELIVERABLE_PATH_DOTDOT = {**ENTRY_PERSISTED_MINOR, "deliverable_path": "../../secret.md"}
 
 # §3.7 A4 — acknowledgement requires verdict.status == MATERIAL.
 # Schema-level if/then guard blocks the hand-edit attack where someone
@@ -307,6 +327,34 @@ NEG_SIDECAR_NO_STREAM = {**SIDECAR_CLEAN, "stream": {}}
 NEG_SIDECAR_WRONG_TEMPLATE = {
     **SIDECAR_CLEAN,
     "prompt": {**SIDECAR_CLEAN["prompt"], "audit_template_path": "wrong/path.md"},
+}
+# Path safety: bundle file_ref / process paths MUST be repo-relative POSIX.
+# Layer 3 lint hashes these for SHA-256 / freshness checks; an absolute or
+# escaping path would let a forged sidecar drive the verifier into arbitrary
+# files outside the repo.
+NEG_SIDECAR_BUNDLE_ESCAPING_PATH = {
+    **SIDECAR_CLEAN,
+    "prompt": {
+        **SIDECAR_CLEAN["prompt"],
+        "bundle": {
+            **SIDECAR_CLEAN["prompt"]["bundle"],
+            "primary_deliverables": [{"path": "../../secret.md", "sha": "a" * 64}],
+        },
+    },
+}
+NEG_SIDECAR_BUNDLE_ABSOLUTE_PATH = {
+    **SIDECAR_CLEAN,
+    "prompt": {
+        **SIDECAR_CLEAN["prompt"],
+        "bundle": {
+            **SIDECAR_CLEAN["prompt"]["bundle"],
+            "primary_deliverables": [{"path": "/etc/passwd", "sha": "a" * 64}],
+        },
+    },
+}
+NEG_SIDECAR_PROCESS_ESCAPING_STDOUT = {
+    **SIDECAR_CLEAN,
+    "process": {**SIDECAR_CLEAN["process"], "stdout_path": "../../oops.txt"},
 }
 
 NEG_VERDICT_BAD_STATUS = {**VERDICT_MINOR, "verdict_status": "WHATEVER"}
@@ -381,6 +429,18 @@ class TestEntrySchema(_SchemaTestBase):
     def test_rejects_pass_proposal_with_failure_reason(self) -> None:
         self.assertInvalid(NEG_ENTRY_PROPOSAL_PASS_WITH_FAILURE_REASON)
 
+    def test_rejects_artifact_path_absolute(self) -> None:
+        self.assertInvalid(NEG_ENTRY_ARTIFACT_PATH_ABSOLUTE)
+
+    def test_rejects_artifact_path_dotdot(self) -> None:
+        self.assertInvalid(NEG_ENTRY_ARTIFACT_PATH_DOTDOT)
+
+    def test_rejects_deliverable_path_absolute(self) -> None:
+        self.assertInvalid(NEG_ENTRY_DELIVERABLE_PATH_ABSOLUTE)
+
+    def test_rejects_deliverable_path_dotdot(self) -> None:
+        self.assertInvalid(NEG_ENTRY_DELIVERABLE_PATH_DOTDOT)
+
     def test_rejects_unknown_agent(self) -> None:
         self.assertInvalid(NEG_ENTRY_BAD_AGENT)
 
@@ -439,6 +499,15 @@ class TestSidecarSchema(_SchemaTestBase):
 
     def test_rejects_non_canonical_template_path(self) -> None:
         self.assertInvalid(NEG_SIDECAR_WRONG_TEMPLATE)
+
+    def test_rejects_bundle_path_with_dotdot(self) -> None:
+        self.assertInvalid(NEG_SIDECAR_BUNDLE_ESCAPING_PATH)
+
+    def test_rejects_bundle_absolute_path(self) -> None:
+        self.assertInvalid(NEG_SIDECAR_BUNDLE_ABSOLUTE_PATH)
+
+    def test_rejects_process_stdout_path_escaping(self) -> None:
+        self.assertInvalid(NEG_SIDECAR_PROCESS_ESCAPING_STDOUT)
 
 
 class TestVerdictSchema(_SchemaTestBase):

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -231,9 +231,56 @@ NEG_ENTRY_BAD_AGENT = {**ENTRY_PERSISTED_MINOR, "agent": "rogue_agent"}
 NEG_ENTRY_BAD_RUN_ID = {**ENTRY_PERSISTED_MINOR, "run_id": "not-an-iso-id"}
 NEG_ENTRY_BAD_SHA = {**ENTRY_PERSISTED_MINOR, "deliverable_sha": "tooshort"}
 
+# §3.7 A4 — acknowledgement requires verdict.status == MATERIAL.
+# Schema-level if/then guard blocks the hand-edit attack where someone
+# adds acknowledgement to a PASS / MINOR persisted entry.
+_VALID_ACK = {
+    "finding_ids": ["F-001"],
+    "acknowledged_at": "2026-04-30T15:23:11.847Z",
+    "acknowledged_by": "user",
+}
+NEG_ENTRY_PERSISTED_MINOR_WITH_ACK = {**ENTRY_PERSISTED_MINOR, "acknowledgement": _VALID_ACK}
+_PASS_ENTRY = {
+    **{k: v for k, v in ENTRY_PERSISTED_MINOR.items() if k != "verdict"},
+    "verdict": {
+        "status": "PASS",
+        "round": 1,
+        "target_rounds": 3,
+        "finding_counts": {"p1": 0, "p2": 0, "p3": 0},
+        "verified_at": "2026-04-30T15:23:11.847Z",
+        "verified_by": "pipeline_orchestrator_agent",
+    },
+}
+NEG_ENTRY_PERSISTED_PASS_WITH_ACK = {**_PASS_ENTRY, "acknowledgement": _VALID_ACK}
+
+# Positive: MATERIAL persisted entry with acknowledgement is the canonical
+# §5.4 ship_with_known_residue shape — must validate.
+ENTRY_PERSISTED_MATERIAL_WITH_ACK = {
+    **{k: v for k, v in ENTRY_PERSISTED_MINOR.items() if k != "verdict"},
+    "verdict": {
+        "status": "MATERIAL",
+        "round": 3,
+        "target_rounds": 3,
+        "finding_counts": {"p1": 1, "p2": 0, "p3": 0},
+        "verified_at": "2026-04-30T15:23:11.847Z",
+        "verified_by": "pipeline_orchestrator_agent",
+    },
+    "acknowledgement": _VALID_ACK,
+}
+
 NEG_JSONL_THREAD_STARTED_NO_ID = {"type": "thread.started"}
 NEG_JSONL_UNKNOWN_TYPE = {"type": "totally.fake", "thread_id": "abc"}
 NEG_JSONL_TURN_COMPLETED_NO_USAGE = {"type": "turn.completed"}
+# 36-char garbage (all dashes / all hex without separators) must NOT pass —
+# canonical UUID 8-4-4-4-12 layout closes the Layer 2 forgery seam.
+NEG_JSONL_THREAD_ID_ALL_DASHES = {
+    "type": "thread.started",
+    "thread_id": "------------------------------------",
+}
+NEG_JSONL_THREAD_ID_NO_SEPARATORS = {
+    "type": "thread.started",
+    "thread_id": "0123456789abcdef0123456789abcdef0123",  # 36 hex, no dashes
+}
 
 NEG_SIDECAR_BAD_VERSION = {**SIDECAR_CLEAN, "codex_cli_version": "0.125"}
 NEG_SIDECAR_NO_STREAM = {**SIDECAR_CLEAN, "stream": {}}
@@ -294,8 +341,19 @@ class TestEntrySchema(_SchemaTestBase):
     def test_proposal_audit_failed(self) -> None:
         self.assertValid(ENTRY_PROPOSAL_AUDIT_FAILED)
 
+    def test_persisted_material_with_acknowledgement(self) -> None:
+        self.assertValid(ENTRY_PERSISTED_MATERIAL_WITH_ACK)
+
     def test_rejects_persisted_with_bad_status(self) -> None:
         self.assertInvalid(NEG_ENTRY_PERSISTED_BAD_STATUS)
+
+    def test_rejects_persisted_minor_with_acknowledgement(self) -> None:
+        # A4 hand-edit attack: someone adds acknowledgement to a MINOR entry
+        # to claim residue acknowledgement that the §5.4 prompt never solicited.
+        self.assertInvalid(NEG_ENTRY_PERSISTED_MINOR_WITH_ACK)
+
+    def test_rejects_persisted_pass_with_acknowledgement(self) -> None:
+        self.assertInvalid(NEG_ENTRY_PERSISTED_PASS_WITH_ACK)
 
     def test_rejects_unknown_agent(self) -> None:
         self.assertInvalid(NEG_ENTRY_BAD_AGENT)
@@ -330,6 +388,12 @@ class TestJsonlSchema(_SchemaTestBase):
 
     def test_rejects_turn_completed_without_usage(self) -> None:
         self.assertInvalid(NEG_JSONL_TURN_COMPLETED_NO_USAGE)
+
+    def test_rejects_thread_id_all_dashes(self) -> None:
+        self.assertInvalid(NEG_JSONL_THREAD_ID_ALL_DASHES)
+
+    def test_rejects_thread_id_without_separators(self) -> None:
+        self.assertInvalid(NEG_JSONL_THREAD_ID_NO_SEPARATORS)
 
 
 class TestSidecarSchema(_SchemaTestBase):

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -111,9 +111,20 @@ JSONL_THREAD_STARTED: dict[str, Any] = {
     "thread_id": "019de371-4c13-7521-8af7-fccf6bd23279",
 }
 JSONL_TURN_STARTED: dict[str, Any] = {"type": "turn.started"}
+# Empirically confirmed against codex 0.125 in tool-using runs: item.started
+# precedes the matching item.completed for command_execution etc. Spec §3.3
+# table didn't list it but the wire format requires it; Layer 2 schema accepts.
+JSONL_ITEM_STARTED_TOOL: dict[str, Any] = {
+    "type": "item.started",
+    "item": {"id": "item_1", "type": "command_execution"},
+}
 JSONL_ITEM_COMPLETED: dict[str, Any] = {
     "type": "item.completed",
     "item": {"id": "item_0", "type": "agent_message", "text": "verdict text"},
+}
+JSONL_ITEM_COMPLETED_TOOL: dict[str, Any] = {
+    "type": "item.completed",
+    "item": {"id": "item_1", "type": "command_execution"},
 }
 JSONL_TURN_COMPLETED: dict[str, Any] = {
     "type": "turn.completed",
@@ -462,6 +473,16 @@ class TestJsonlSchema(_SchemaTestBase):
 
     def test_item_completed_agent_message(self) -> None:
         self.assertValid(JSONL_ITEM_COMPLETED)
+
+    def test_item_completed_tool_execution(self) -> None:
+        # tool-using runs emit completed events for non-agent_message item types
+        # (no text field expected).
+        self.assertValid(JSONL_ITEM_COMPLETED_TOOL)
+
+    def test_item_started_tool_execution(self) -> None:
+        # codex 0.125 emits item.started before matching item.completed for
+        # tool calls (command_execution, file_change, etc.).
+        self.assertValid(JSONL_ITEM_STARTED_TOOL)
 
     def test_turn_completed(self) -> None:
         self.assertValid(JSONL_TURN_COMPLETED)

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -1,0 +1,371 @@
+"""Phase 6.2 acceptance tests for the four v3.6.7 Step 6 audit schemas.
+
+Per spec §10 verification gate:
+  1. All four schemas parse as valid JSON Schema 2020-12.
+  2. Example payloads in §3.1 / §3.3 / §3.4 / §3.5 validate against their
+     respective schemas (positive cases).
+  3. Deliberately-malformed counter-examples fail (negative cases).
+
+This is the schema-shape acceptance test. Cross-artifact invariants
+(§3.7 family A-F rows, --mode {proposal,persisted} arms, mirror rules,
+ordering rules) ship in scripts/check_audit_artifact_consistency.py +
+scripts/test_check_audit_artifact_consistency.py at Phase 6.3.
+
+Run:
+    python -m unittest scripts.test_audit_schemas -v
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from scripts._test_helpers import build_schema_validator, load_json_schema
+
+REPO = Path(__file__).resolve().parent.parent
+PASSPORT = REPO / "shared/contracts/passport"
+AUDIT = REPO / "shared/contracts/audit"
+
+SCHEMA_PATHS: dict[str, Path] = {
+    "entry": PASSPORT / "audit_artifact_entry.schema.json",
+    "jsonl": AUDIT / "audit_jsonl.schema.json",
+    "sidecar": AUDIT / "audit_sidecar.schema.json",
+    "verdict": AUDIT / "audit_verdict.schema.json",
+}
+
+
+# ---------------------------------------------------------------------------
+# Positive examples — drawn directly from spec §3.1 / §3.3 / §3.4 / §3.5.
+# ---------------------------------------------------------------------------
+
+# §3.1 / §3.2 — persisted entry (verified_at + verified_by present, MINOR)
+ENTRY_PERSISTED_MINOR: dict[str, Any] = {
+    "stage": 2,
+    "agent": "synthesis_agent",
+    "deliverable_path": "chapter_4/synthesis.md",
+    "deliverable_sha": "a" * 64,
+    "run_id": "2026-04-30T15-22-04Z-d8f3",
+    "bundle_id": "phase2-chapter4-2026-04-30",
+    "bundle_manifest_sha": "9" * 64,
+    "artifact_paths": {
+        "jsonl": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.jsonl",
+        "sidecar": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.meta.json",
+        "verdict": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.verdict.yaml",
+    },
+    "verdict": {
+        "status": "MINOR",
+        "round": 2,
+        "target_rounds": 3,
+        "finding_counts": {"p1": 0, "p2": 0, "p3": 1},
+        "verified_at": "2026-04-30T15:23:11.847Z",
+        "verified_by": "pipeline_orchestrator_agent",
+    },
+}
+
+# §3.2 — proposal entry (verified_at + verified_by absent)
+ENTRY_PROPOSAL_PASS: dict[str, Any] = {
+    "stage": 2,
+    "agent": "synthesis_agent",
+    "deliverable_path": "chapter_4/synthesis.md",
+    "deliverable_sha": "b" * 64,
+    "run_id": "2026-04-30T15-22-04Z-d8f3",
+    "bundle_manifest_sha": "9" * 64,
+    "artifact_paths": {
+        "jsonl": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.jsonl",
+        "sidecar": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.meta.json",
+        "verdict": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.verdict.yaml",
+    },
+    "verdict": {
+        "status": "PASS",
+        "round": 1,
+        "target_rounds": 3,
+        "finding_counts": {"p1": 0, "p2": 0, "p3": 0},
+    },
+}
+
+# §3.2 — proposal AUDIT_FAILED (proposal-arm only, persisted excludes per §3.2)
+ENTRY_PROPOSAL_AUDIT_FAILED: dict[str, Any] = {
+    "stage": 2,
+    "agent": "synthesis_agent",
+    "deliverable_path": "chapter_4/synthesis.md",
+    "deliverable_sha": "c" * 64,
+    "run_id": "2026-04-30T15-22-04Z-d8f3",
+    "bundle_manifest_sha": "9" * 64,
+    "artifact_paths": {
+        "jsonl": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.jsonl",
+        "sidecar": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.meta.json",
+        "verdict": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.verdict.yaml",
+    },
+    "verdict": {
+        "status": "AUDIT_FAILED",
+        "failure_reason": "codex exit 70: network timeout after 600s",
+        "round": 2,
+        "target_rounds": 3,
+        "finding_counts": {"p1": 0, "p2": 0, "p3": 0},
+    },
+}
+
+# §3.3 — canonical four-event JSONL run (one validate per event row)
+JSONL_THREAD_STARTED: dict[str, Any] = {
+    "type": "thread.started",
+    "thread_id": "019de371-4c13-7521-8af7-fccf6bd23279",
+}
+JSONL_TURN_STARTED: dict[str, Any] = {"type": "turn.started"}
+JSONL_ITEM_COMPLETED: dict[str, Any] = {
+    "type": "item.completed",
+    "item": {"id": "item_0", "type": "agent_message", "text": "verdict text"},
+}
+JSONL_TURN_COMPLETED: dict[str, Any] = {
+    "type": "turn.completed",
+    "usage": {
+        "input_tokens": 12345,
+        "cached_input_tokens": 0,
+        "output_tokens": 678,
+        "reasoning_output_tokens": 90,
+    },
+}
+
+# §3.4 — sidecar example (clean run)
+SIDECAR_CLEAN: dict[str, Any] = {
+    "run_id": "2026-04-30T15-22-04Z-d8f3",
+    "codex_cli_version": "0.125.0",
+    "runner": {
+        "hostname": "imbad-mbp.local",
+        "cwd": "/Users/imbad/Projects/academic-research-skills",
+        "git_sha": "b4fbffd",
+        "git_dirty": False,
+    },
+    "timing": {
+        "started_at": "2026-04-30T15:22:04.123Z",
+        "ended_at": "2026-04-30T15:22:58.471Z",
+        "duration_seconds": 54.348,
+    },
+    "process": {
+        "exit_code": 0,
+        "stdout_path": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.stdout",
+        "stderr_path": "audit_artifacts/2026-04-30T15-22-04Z-d8f3.stderr",
+    },
+    "stream": {"jsonl_thread_id": "019de371-4c13-7521-8af7-fccf6bd23279"},
+    "prompt": {
+        "audit_template_path": "shared/templates/codex_audit_multifile_template.md",
+        "audit_template_sha": "f" * 64,
+        "bundle": {
+            "bundle_id": "phase2-chapter4-2026-04-30",
+            "bundle_manifest_sha": "9" * 64,
+            "primary_deliverables": [
+                {"path": "chapter_4/synthesis.md", "sha": "a" * 64},
+            ],
+            "supporting_context": [
+                {"path": "chapter_4/bibliography.json", "sha": "e" * 64},
+                {"path": "chapter_4/verification.md", "sha": "c" * 64},
+            ],
+        },
+    },
+}
+
+# §3.4 — AUDIT_FAILED sidecar (jsonl_thread_id may be empty string)
+SIDECAR_AUDIT_FAILED: dict[str, Any] = {
+    **SIDECAR_CLEAN,
+    "process": {**SIDECAR_CLEAN["process"], "exit_code": 70},
+    "stream": {"jsonl_thread_id": ""},
+}
+
+# §3.5 — verdict file (clean MINOR)
+VERDICT_MINOR: dict[str, Any] = {
+    "run_id": "2026-04-30T15-22-04Z-d8f3",
+    "verdict_status": "MINOR",
+    "round": 2,
+    "target_rounds": 3,
+    "finding_counts": {"p1": 0, "p2": 0, "p3": 1},
+    "findings": [
+        {
+            "id": "F-007",
+            "severity": "P3",
+            "dimension": "3.7",
+            "file": "chapter_4/synthesis.md",
+            "line": 482,
+            "description": "deictic temporal phrase 'currently' on reflexivity disclosure",
+            "suggested_fix": "replace with 'as of 2026-04-30' or 'former director'",
+        }
+    ],
+    "generated_at": "2026-04-30T15:22:58.471Z",
+    "generated_by": "scripts/run_codex_audit.sh",
+    "generator_version": "1.0.0",
+}
+
+# §3.5 — verdict file (AUDIT_FAILED variant)
+VERDICT_AUDIT_FAILED: dict[str, Any] = {
+    "run_id": "2026-04-30T15-22-04Z-d8f3",
+    "verdict_status": "AUDIT_FAILED",
+    "round": 2,
+    "target_rounds": 3,
+    "finding_counts": {"p1": 0, "p2": 0, "p3": 0},
+    "failure_reason": "codex exit 70: network timeout after 600s",
+    "findings": [],
+    "generated_at": "2026-04-30T15:22:58.471Z",
+    "generated_by": "scripts/run_codex_audit.sh",
+    "generator_version": "1.0.0",
+}
+
+
+# ---------------------------------------------------------------------------
+# Negative examples — schema MUST reject each.
+# ---------------------------------------------------------------------------
+
+# Persisted-shape entry whose verdict.status is not in the persisted enum.
+# (Removing verified_at alone falls into the proposal arm — that's a lint-side
+# rule, not schema-side. See Phase 6.3 lint for --mode persisted enforcement.)
+NEG_ENTRY_PERSISTED_BAD_STATUS: dict[str, Any] = {
+    **{k: v for k, v in ENTRY_PERSISTED_MINOR.items() if k != "verdict"},
+    "verdict": {
+        "status": "INVALID",
+        "round": 2,
+        "target_rounds": 3,
+        "finding_counts": {"p1": 0, "p2": 0, "p3": 1},
+        "verified_at": "2026-04-30T15:23:11.847Z",
+        "verified_by": "pipeline_orchestrator_agent",
+    },
+}
+
+NEG_ENTRY_BAD_AGENT = {**ENTRY_PERSISTED_MINOR, "agent": "rogue_agent"}
+NEG_ENTRY_BAD_RUN_ID = {**ENTRY_PERSISTED_MINOR, "run_id": "not-an-iso-id"}
+NEG_ENTRY_BAD_SHA = {**ENTRY_PERSISTED_MINOR, "deliverable_sha": "tooshort"}
+
+NEG_JSONL_THREAD_STARTED_NO_ID = {"type": "thread.started"}
+NEG_JSONL_UNKNOWN_TYPE = {"type": "totally.fake", "thread_id": "abc"}
+NEG_JSONL_TURN_COMPLETED_NO_USAGE = {"type": "turn.completed"}
+
+NEG_SIDECAR_BAD_VERSION = {**SIDECAR_CLEAN, "codex_cli_version": "0.125"}
+NEG_SIDECAR_NO_STREAM = {**SIDECAR_CLEAN, "stream": {}}
+NEG_SIDECAR_WRONG_TEMPLATE = {
+    **SIDECAR_CLEAN,
+    "prompt": {**SIDECAR_CLEAN["prompt"], "audit_template_path": "wrong/path.md"},
+}
+
+NEG_VERDICT_BAD_STATUS = {**VERDICT_MINOR, "verdict_status": "WHATEVER"}
+NEG_VERDICT_AUDIT_FAILED_NO_REASON = {
+    k: v for k, v in VERDICT_AUDIT_FAILED.items() if k != "failure_reason"
+}
+
+
+class TestSchemasParseAsDraft202012(unittest.TestCase):
+    """Verification gate 1: every schema is valid JSON Schema 2020-12."""
+
+    def test_every_schema_file_exists_and_parses(self) -> None:
+        for name, path in SCHEMA_PATHS.items():
+            with self.subTest(schema=name):
+                self.assertTrue(path.exists(), f"missing schema: {path.relative_to(REPO)}")
+                # load_json_schema raises if the schema isn't valid 2020-12
+                load_json_schema(path)
+
+
+class _SchemaTestBase(unittest.TestCase):
+    """Subclasses set `schema_key`; setUp loads the validator once per class."""
+
+    schema_key: str = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        if not cls.schema_key:
+            return
+        cls._validator = build_schema_validator(load_json_schema(SCHEMA_PATHS[cls.schema_key]))
+
+    def assertValid(self, doc: dict[str, Any]) -> None:
+        errors = list(self._validator.iter_errors(doc))
+        if errors:
+            msg = "; ".join(f"{list(e.absolute_path) or '<root>'}: {e.message}" for e in errors)
+            self.fail(f"expected valid, got: {msg}")
+
+    def assertInvalid(self, doc: dict[str, Any]) -> None:
+        errors = list(self._validator.iter_errors(doc))
+        self.assertGreater(len(errors), 0, "expected schema rejection, got pass")
+
+
+class TestEntrySchema(_SchemaTestBase):
+    schema_key = "entry"
+
+    def test_persisted_minor(self) -> None:
+        self.assertValid(ENTRY_PERSISTED_MINOR)
+
+    def test_proposal_pass(self) -> None:
+        self.assertValid(ENTRY_PROPOSAL_PASS)
+
+    def test_proposal_audit_failed(self) -> None:
+        self.assertValid(ENTRY_PROPOSAL_AUDIT_FAILED)
+
+    def test_rejects_persisted_with_bad_status(self) -> None:
+        self.assertInvalid(NEG_ENTRY_PERSISTED_BAD_STATUS)
+
+    def test_rejects_unknown_agent(self) -> None:
+        self.assertInvalid(NEG_ENTRY_BAD_AGENT)
+
+    def test_rejects_malformed_run_id(self) -> None:
+        self.assertInvalid(NEG_ENTRY_BAD_RUN_ID)
+
+    def test_rejects_short_deliverable_sha(self) -> None:
+        self.assertInvalid(NEG_ENTRY_BAD_SHA)
+
+
+class TestJsonlSchema(_SchemaTestBase):
+    schema_key = "jsonl"
+
+    def test_thread_started(self) -> None:
+        self.assertValid(JSONL_THREAD_STARTED)
+
+    def test_turn_started(self) -> None:
+        self.assertValid(JSONL_TURN_STARTED)
+
+    def test_item_completed_agent_message(self) -> None:
+        self.assertValid(JSONL_ITEM_COMPLETED)
+
+    def test_turn_completed(self) -> None:
+        self.assertValid(JSONL_TURN_COMPLETED)
+
+    def test_rejects_thread_started_without_id(self) -> None:
+        self.assertInvalid(NEG_JSONL_THREAD_STARTED_NO_ID)
+
+    def test_rejects_unknown_event_type(self) -> None:
+        self.assertInvalid(NEG_JSONL_UNKNOWN_TYPE)
+
+    def test_rejects_turn_completed_without_usage(self) -> None:
+        self.assertInvalid(NEG_JSONL_TURN_COMPLETED_NO_USAGE)
+
+
+class TestSidecarSchema(_SchemaTestBase):
+    schema_key = "sidecar"
+
+    def test_clean_run(self) -> None:
+        self.assertValid(SIDECAR_CLEAN)
+
+    def test_audit_failed_run_with_empty_thread_id(self) -> None:
+        self.assertValid(SIDECAR_AUDIT_FAILED)
+
+    def test_rejects_non_semver_codex_version(self) -> None:
+        self.assertInvalid(NEG_SIDECAR_BAD_VERSION)
+
+    def test_rejects_missing_jsonl_thread_id(self) -> None:
+        self.assertInvalid(NEG_SIDECAR_NO_STREAM)
+
+    def test_rejects_non_canonical_template_path(self) -> None:
+        self.assertInvalid(NEG_SIDECAR_WRONG_TEMPLATE)
+
+
+class TestVerdictSchema(_SchemaTestBase):
+    schema_key = "verdict"
+
+    def test_clean_minor(self) -> None:
+        self.assertValid(VERDICT_MINOR)
+
+    def test_audit_failed(self) -> None:
+        self.assertValid(VERDICT_AUDIT_FAILED)
+
+    def test_rejects_unknown_status(self) -> None:
+        self.assertInvalid(NEG_VERDICT_BAD_STATUS)
+
+    def test_rejects_audit_failed_without_failure_reason(self) -> None:
+        self.assertInvalid(NEG_VERDICT_AUDIT_FAILED_NO_REASON)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -332,6 +332,12 @@ NEG_JSONL_THREAD_ID_NO_SEPARATORS = {
     "type": "thread.started",
     "thread_id": "0123456789abcdef0123456789abcdef0123",  # 36 hex, no dashes
 }
+# item.started must reject extra top-level fields (consistency with other arms).
+NEG_JSONL_ITEM_STARTED_EXTRA_TOP_FIELD = {
+    "type": "item.started",
+    "item": {"id": "item_1", "type": "command_execution"},
+    "rogue": "should not validate",
+}
 
 NEG_SIDECAR_BAD_VERSION = {**SIDECAR_CLEAN, "codex_cli_version": "0.125"}
 NEG_SIDECAR_NO_STREAM = {**SIDECAR_CLEAN, "stream": {}}
@@ -501,6 +507,9 @@ class TestJsonlSchema(_SchemaTestBase):
 
     def test_rejects_thread_id_without_separators(self) -> None:
         self.assertInvalid(NEG_JSONL_THREAD_ID_NO_SEPARATORS)
+
+    def test_rejects_item_started_with_extra_top_field(self) -> None:
+        self.assertInvalid(NEG_JSONL_ITEM_STARTED_EXTRA_TOP_FIELD)
 
 
 class TestSidecarSchema(_SchemaTestBase):

--- a/shared/contracts/README.md
+++ b/shared/contracts/README.md
@@ -1,27 +1,69 @@
-# ARS Sprint Contracts
+# ARS Shared Contracts
 
-Sprint contract templates for ARS v3.6.2+ reviewer hard-gate orchestration.
+Schema files for cross-skill contracts: reviewer sprint contracts, Material Passport
+ports, and (v3.6.7+) cross-model audit artifact pipelines.
+
+## Sprint contracts (v3.6.2+)
+
+Sprint contract templates for reviewer hard-gate orchestration.
 
 Schema: `shared/sprint_contract.schema.json` (Schema 13).
 Validator: `scripts/check_sprint_contract.py`.
 Spec: `docs/design/2026-04-23-ars-v3.6.2-sprint-contract-design.md`.
 Protocol: `academic-paper-reviewer/references/sprint_contract_protocol.md`.
 
-## Shipped templates (v3.6.2)
+### Shipped templates (v3.6.2)
 
 - `reviewer/full.json` — panel 5, 5 dimensions, 4 failure conditions
 - `reviewer/methodology_focus.json` — panel 2, 2 dimensions, 3 failure conditions
 
-## Reserved reviewer modes without shipped templates
+### Reserved reviewer modes without shipped templates
 
 `reviewer_re_review`, `reviewer_calibration`, `reviewer_guided` are in the schema enum
 but ship without templates in v3.6.2. Those modes continue to operate in their existing
 form (no contract, no hard-gate) until a follow-up patch release adds their templates.
 
-## How to add a new template
+### How to add a new template
 
 1. Add the file under `shared/contracts/<domain>/<mode>.json`.
 2. Run `python scripts/check_sprint_contract.py <path> --ars-version vX.Y.Z`; expect
    zero errors and zero soft warnings.
 3. If `expression` strings use new phrasing, update `sprint_contract_protocol.md`
    and the synthesizer prompt's recognised-pattern list in the same PR.
+
+## Passport contracts (v3.6.4+)
+
+Schemas for Material Passport input ports.
+
+- `passport/literature_corpus_entry.schema.json` (v3.6.4) — Schema 9 `literature_corpus[]`
+  entries produced by user-written adapters.
+- `passport/rejection_log.schema.json` (v3.6.4) — adapter output companion logging
+  entries that could not be included in the corpus.
+- `passport/reset_ledger_entry.schema.json` (v3.6.3) — `reset_boundary[]` ledger entries
+  for the opt-in passport reset boundary protocol.
+- `passport/audit_artifact_entry.schema.json` (v3.6.7 Step 6) — `audit_artifact[]` entries
+  recording one cross-model audit run per downstream-agent deliverable. Two lifecycle
+  states (proposal / persisted) share the schema via `oneOf`. Cross-artifact invariants
+  are enforced by `scripts/check_audit_artifact_consistency.py`. Spec:
+  `docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md` §3.1-§3.2.
+
+## Audit artifact contracts (v3.6.7 Step 6)
+
+The `audit/` directory carries the three wrapper-emitted artifact schemas that pair
+with the passport-side `audit_artifact_entry.schema.json` above. Together they form
+the four-schema contract that `scripts/run_codex_audit.sh` (Phase 6.1) writes and the
+orchestrator agent reads at every per-agent audit gate.
+
+- `audit/audit_jsonl.schema.json` — Layer 2 evidence: per-row schema for the codex CLI
+  0.125 `--json` event stream (`thread.started` / `turn.started` / `item.completed` /
+  `turn.completed` / `error`). One JSONL line per event row.
+- `audit/audit_sidecar.schema.json` — Layer 3 evidence: runner / timing / process /
+  stream / prompt metadata. Cross-file rules linking sidecar fields to JSONL events,
+  on-disk files, and passport entries (B1-B7 in spec §3.7 family B) are enforced by
+  `scripts/check_audit_artifact_consistency.py` (Phase 6.3), not by this schema alone.
+- `audit/audit_verdict.schema.json` — verdict file shape (PASS / MINOR / MATERIAL /
+  AUDIT_FAILED). The artifact orchestrator parses for ship/block decisions; cross-field
+  consistency with `finding_counts` and `failure_reason` is lint-enforced per
+  spec §3.7 A1 / A2 / A5 / A6.
+
+Spec: `docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md` §3.

--- a/shared/contracts/audit/audit_jsonl.schema.json
+++ b/shared/contracts/audit/audit_jsonl.schema.json
@@ -39,8 +39,9 @@
     },
     {
       "title": "item.started",
-      "description": "Emitted in tool-using runs (e.g., command_execution begin) before the matching item.completed event. Carries no text yet — the completed event holds the result. Verdict logic only reads agent_message item.completed events; item.started rows are evidence that codex actually invoked tools.",
+      "description": "Emitted in tool-using runs (e.g., command_execution begin) before the matching item.completed event. Carries no text yet — the completed event holds the result. Verdict logic only reads agent_message item.completed events; item.started rows are evidence that codex actually invoked tools. Closed against unknown top-level fields to match the rest of the event arms; per-tool fields belong inside `item`, not at the row root.",
       "type": "object",
+      "additionalProperties": false,
       "required": ["type", "item"],
       "properties": {
         "type": { "const": "item.started" },

--- a/shared/contracts/audit/audit_jsonl.schema.json
+++ b/shared/contracts/audit/audit_jsonl.schema.json
@@ -2,14 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/audit/audit_jsonl.schema.json",
   "title": "Codex Audit JSONL Event",
-  "description": "Schema for one row of the codex CLI 0.125 --json event stream produced by scripts/run_codex_audit.sh. Each JSONL line in <run_id>.jsonl validates against this schema. This is the Layer 2 anti-fake-audit check (§3.3): orchestrator validates the JSONL row-by-row before reading any verdict. Stream-level rules (first event must be thread.started; clean run ends with turn.completed; exactly one item.completed.agent_message carries the verdict text) live in scripts/check_audit_artifact_consistency.py (Phase 6.3), NOT in this schema. Codex 0.125 retired pre-0.125 fields (model, reasoning_effort, session_id, final_message, per-row usage); see §3.3 'Codex 0.125 --json event-stream shape' for the load-bearing shape contract.",
+  "description": "Schema for one row of the codex CLI 0.125 --json event stream produced by scripts/run_codex_audit.sh. Each JSONL line in <run_id>.jsonl validates against this schema. This is the Layer 2 anti-fake-audit check (§3.3): orchestrator validates the JSONL row-by-row before reading any verdict. Stream-level rules (first event must be thread.started; clean run ends with turn.completed; exactly one item.completed.agent_message carries the verdict text) live in scripts/check_audit_artifact_consistency.py (Phase 6.3), NOT in this schema. Codex 0.125 retired pre-0.125 fields (model, reasoning_effort, session_id, final_message, per-row usage); see §3.3 'Codex 0.125 --json event-stream shape' for the load-bearing shape contract. NOTE: item.started events appear in tool-using runs (command_execution start, etc.) and are accepted here even though spec §3.3's enumerated four-event canonical run did not list them — empirical capture from codex 0.125 confirms they precede every item.completed of types other than agent_message.",
 
   "type": "object",
   "required": ["type"],
   "properties": {
     "type": {
       "type": "string",
-      "enum": ["thread.started", "turn.started", "item.completed", "turn.completed", "error"]
+      "enum": ["thread.started", "turn.started", "item.started", "item.completed", "turn.completed", "error"]
     }
   },
 
@@ -35,6 +35,23 @@
       "required": ["type"],
       "properties": {
         "type": { "const": "turn.started" }
+      }
+    },
+    {
+      "title": "item.started",
+      "description": "Emitted in tool-using runs (e.g., command_execution begin) before the matching item.completed event. Carries no text yet — the completed event holds the result. Verdict logic only reads agent_message item.completed events; item.started rows are evidence that codex actually invoked tools.",
+      "type": "object",
+      "required": ["type", "item"],
+      "properties": {
+        "type": { "const": "item.started" },
+        "item": {
+          "type": "object",
+          "required": ["id", "type"],
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "type": { "type": "string", "minLength": 1 }
+          }
+        }
       }
     },
     {

--- a/shared/contracts/audit/audit_jsonl.schema.json
+++ b/shared/contracts/audit/audit_jsonl.schema.json
@@ -23,8 +23,8 @@
         "type": { "const": "thread.started" },
         "thread_id": {
           "type": "string",
-          "pattern": "^[0-9a-f-]{36}$",
-          "description": "UUID identifying this codex run. Per §3.3, codex emits this once at stream open; downstream events SHOULD NOT redeclare it."
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "description": "Canonical UUID (8-4-4-4-12 hex layout) identifying this codex run. Per §3.3, codex emits this once at stream open; downstream events SHOULD NOT redeclare it. Tight pattern blocks Layer 2 forgery via 36-char garbage like '------------------------------------'."
         }
       }
     },

--- a/shared/contracts/audit/audit_jsonl.schema.json
+++ b/shared/contracts/audit/audit_jsonl.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/audit/audit_jsonl.schema.json",
+  "title": "Codex Audit JSONL Event",
+  "description": "Schema for one row of the codex CLI 0.125 --json event stream produced by scripts/run_codex_audit.sh. Each JSONL line in <run_id>.jsonl validates against this schema. This is the Layer 2 anti-fake-audit check (§3.3): orchestrator validates the JSONL row-by-row before reading any verdict. Stream-level rules (first event must be thread.started; clean run ends with turn.completed; exactly one item.completed.agent_message carries the verdict text) live in scripts/check_audit_artifact_consistency.py (Phase 6.3), NOT in this schema. Codex 0.125 retired pre-0.125 fields (model, reasoning_effort, session_id, final_message, per-row usage); see §3.3 'Codex 0.125 --json event-stream shape' for the load-bearing shape contract.",
+
+  "type": "object",
+  "required": ["type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["thread.started", "turn.started", "item.completed", "turn.completed", "error"]
+    }
+  },
+
+  "oneOf": [
+    {
+      "title": "thread.started",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "thread_id"],
+      "properties": {
+        "type": { "const": "thread.started" },
+        "thread_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f-]{36}$",
+          "description": "UUID identifying this codex run. Per §3.3, codex emits this once at stream open; downstream events SHOULD NOT redeclare it."
+        }
+      }
+    },
+    {
+      "title": "turn.started",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "turn.started" }
+      }
+    },
+    {
+      "title": "item.completed",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "item"],
+      "properties": {
+        "type": { "const": "item.completed" },
+        "item": {
+          "type": "object",
+          "required": ["id", "type"],
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "type": { "type": "string", "minLength": 1 },
+            "text": { "type": "string" }
+          },
+          "allOf": [
+            {
+              "description": "When item.type == 'agent_message', item.text is required and non-empty (§3.3 table row 'item.completed').",
+              "if": {
+                "properties": { "type": { "const": "agent_message" } },
+                "required": ["type"]
+              },
+              "then": {
+                "required": ["text"],
+                "properties": {
+                  "text": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "title": "turn.completed",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "usage"],
+      "properties": {
+        "type": { "const": "turn.completed" },
+        "usage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens"],
+          "properties": {
+            "input_tokens": { "type": "integer", "minimum": 0 },
+            "cached_input_tokens": { "type": "integer", "minimum": 0 },
+            "output_tokens": { "type": "integer", "minimum": 0 },
+            "reasoning_output_tokens": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    {
+      "title": "error",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "error"],
+      "properties": {
+        "type": { "const": "error" },
+        "error": {
+          "type": "object",
+          "required": ["message"],
+          "properties": {
+            "message": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/shared/contracts/audit/audit_sidecar.schema.json
+++ b/shared/contracts/audit/audit_sidecar.schema.json
@@ -116,13 +116,13 @@
 
   "allOf": [
     {
-      "description": "When the companion verdict's status is NOT AUDIT_FAILED, jsonl_thread_id MUST match UUID format. When status == 'AUDIT_FAILED', empty string is also acceptable. Co-validation with the verdict file is performed by Layer 3 lint (Phase 6.3); this schema enforces the format-or-empty discipline so a sidecar file alone (without verdict context) still rejects garbage values.",
+      "description": "When the companion verdict's status is NOT AUDIT_FAILED, jsonl_thread_id MUST match canonical UUID (8-4-4-4-12 hex). When status == 'AUDIT_FAILED', empty string is also acceptable. Pattern mirrors audit/audit_jsonl.schema.json#thread_id — keep in sync. Co-validation with the verdict file is performed by Layer 3 lint (Phase 6.3); this schema enforces the format-or-empty discipline so a sidecar file alone (without verdict context) still rejects garbage values like '------------------------------------'.",
       "properties": {
         "stream": {
           "properties": {
             "jsonl_thread_id": {
               "anyOf": [
-                { "type": "string", "pattern": "^[0-9a-f-]{36}$" },
+                { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
                 { "type": "string", "const": "" }
               ]
             }

--- a/shared/contracts/audit/audit_sidecar.schema.json
+++ b/shared/contracts/audit/audit_sidecar.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/audit/audit_sidecar.schema.json",
+  "title": "Codex Audit Sidecar Metadata",
+  "description": "Schema for <run_id>.meta.json — the Layer 3 anti-fake-audit evidence file produced by scripts/run_codex_audit.sh. Captures runner / timing / process / stream / prompt context for one audit run. Cross-file rules linking sidecar fields to JSONL events / on-disk files / passport entries (B1-B7 in §3.7 family B) are lint-enforced by scripts/check_audit_artifact_consistency.py (Phase 6.3); this schema only enforces the per-file shape. AUDIT_FAILED conditional: when the companion verdict's status == 'AUDIT_FAILED', the JSON Schema 'if/then' below relaxes stream.jsonl_thread_id to allow empty string (no usable JSONL thread exists when codex aborted).",
+
+  "type": "object",
+  "additionalProperties": false,
+
+  "required": [
+    "run_id",
+    "codex_cli_version",
+    "runner",
+    "timing",
+    "process",
+    "stream",
+    "prompt"
+  ],
+
+  "properties": {
+    "run_id": {
+      "$ref": "#/$defs/run_id",
+      "description": "Canonical run identifier; equals file basename (§3.7 F3). Cross-file basename consistency (B7) is lint-enforced."
+    },
+    "codex_cli_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Bare semver. Wrapper strips the 'codex-cli ' prefix from `codex --version` output before writing here (§4.4 _codex_version helper)."
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostname", "cwd", "git_sha", "git_dirty"],
+      "properties": {
+        "hostname": { "type": "string", "minLength": 1 },
+        "cwd": { "type": "string", "minLength": 1 },
+        "git_sha": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{7,40}$",
+          "description": "Repo HEAD at audit start (7-40 hex; not a full SHA-256). Lint (B4) verifies this resolves to a real commit."
+        },
+        "git_dirty": { "type": "boolean" }
+      }
+    },
+    "timing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started_at", "ended_at", "duration_seconds"],
+      "properties": {
+        "started_at": {
+          "$ref": "#/$defs/rfc3339_ms_utc",
+          "description": "RFC 3339 UTC, millisecond precision."
+        },
+        "ended_at": {
+          "$ref": "#/$defs/rfc3339_ms_utc"
+        },
+        "duration_seconds": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Lint (B5) verifies duration_seconds == ended_at - started_at within +/- 1s."
+        }
+      }
+    },
+    "process": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exit_code", "stdout_path", "stderr_path"],
+      "properties": {
+        "exit_code": { "type": "integer" },
+        "stdout_path": { "type": "string", "minLength": 1 },
+        "stderr_path": { "type": "string", "minLength": 1 }
+      }
+    },
+    "stream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["jsonl_thread_id"],
+      "properties": {
+        "jsonl_thread_id": {
+          "type": "string",
+          "description": "UUID matching the JSONL stream's single thread.started event's thread_id (B1, lint-enforced cross-file). When the companion verdict's status == 'AUDIT_FAILED', empty string '' is accepted because no usable JSONL thread exists; UUID format constraint and B1 are both suspended for AUDIT_FAILED entries (§3.4)."
+        }
+      }
+    },
+    "prompt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audit_template_path", "audit_template_sha", "bundle"],
+      "properties": {
+        "audit_template_path": {
+          "const": "shared/templates/codex_audit_multifile_template.md",
+          "description": "v3.6.7 ships a single canonical audit template; the path is constant. Future versions that add additional templates will widen this to enum."
+        },
+        "audit_template_sha": { "$ref": "#/$defs/sha256_hex" },
+        "bundle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bundle_manifest_sha", "primary_deliverables", "supporting_context"],
+          "properties": {
+            "bundle_id": { "type": "string", "minLength": 1 },
+            "bundle_manifest_sha": { "$ref": "#/$defs/sha256_hex" },
+            "primary_deliverables": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/file_ref" }
+            },
+            "supporting_context": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/file_ref" }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "allOf": [
+    {
+      "description": "When the companion verdict's status is NOT AUDIT_FAILED, jsonl_thread_id MUST match UUID format. When status == 'AUDIT_FAILED', empty string is also acceptable. Co-validation with the verdict file is performed by Layer 3 lint (Phase 6.3); this schema enforces the format-or-empty discipline so a sidecar file alone (without verdict context) still rejects garbage values.",
+      "properties": {
+        "stream": {
+          "properties": {
+            "jsonl_thread_id": {
+              "anyOf": [
+                { "type": "string", "pattern": "^[0-9a-f-]{36}$" },
+                { "type": "string", "const": "" }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Lowercase hex SHA-256. Mirrored from passport/audit_artifact_entry.schema.json $defs.sha256_hex; keep regex in sync."
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z-[0-9a-f]{4}$",
+      "description": "Mirrored from passport/audit_artifact_entry.schema.json $defs.run_id; F1 in §3.7. Keep regex in sync."
+    },
+    "rfc3339_ms_utc": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "description": "RFC 3339 UTC with millisecond precision. Mirrored from passport/audit_artifact_entry.schema.json $defs.rfc3339_ms_utc."
+    },
+    "file_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha": { "$ref": "#/$defs/sha256_hex" }
+      }
+    }
+  }
+}

--- a/shared/contracts/audit/audit_sidecar.schema.json
+++ b/shared/contracts/audit/audit_sidecar.schema.json
@@ -67,8 +67,8 @@
       "required": ["exit_code", "stdout_path", "stderr_path"],
       "properties": {
         "exit_code": { "type": "integer" },
-        "stdout_path": { "type": "string", "minLength": 1 },
-        "stderr_path": { "type": "string", "minLength": 1 }
+        "stdout_path": { "$ref": "#/$defs/repo_relative_path" },
+        "stderr_path": { "$ref": "#/$defs/repo_relative_path" }
       }
     },
     "stream": {
@@ -149,12 +149,19 @@
       "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
       "description": "RFC 3339 UTC with millisecond precision. Mirrored from passport/audit_artifact_entry.schema.json $defs.rfc3339_ms_utc."
     },
+    "repo_relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^/][^\\s]*$",
+      "not": { "pattern": "(^|/)\\.\\.(/|$)" },
+      "description": "Repo-relative POSIX path. Mirrored from passport/audit_artifact_entry.schema.json $defs.repo_relative_path; keep regex pair in sync."
+    },
     "file_ref": {
       "type": "object",
       "additionalProperties": false,
       "required": ["path", "sha"],
       "properties": {
-        "path": { "type": "string", "minLength": 1 },
+        "path": { "$ref": "#/$defs/repo_relative_path" },
         "sha": { "$ref": "#/$defs/sha256_hex" }
       }
     }

--- a/shared/contracts/audit/audit_verdict.schema.json
+++ b/shared/contracts/audit/audit_verdict.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/audit/audit_verdict.schema.json",
+  "title": "Codex Audit Verdict File",
+  "description": "Schema for <run_id>.verdict.yaml — the human-readable verdict file produced by the wrapper after parsing the JSONL stream's single item.completed.agent_message event (per §3.3 / §3.5). This is the policy surface the orchestrator reads for ship/block decisions; JSONL is raw evidence (Layer 2) and sidecar is environmental evidence (Layer 3). Cross-field invariants (PASS/MINOR/MATERIAL/AUDIT_FAILED count consistency; finding_counts agrees with findings[]) are lint-enforced in scripts/check_audit_artifact_consistency.py (Phase 6.3 §3.7 family A rows A1/A2/A5/A6) — this schema enforces the per-file shape so wrapper-side lint can reject malformed verdicts before they reach the orchestrator.",
+
+  "type": "object",
+  "additionalProperties": false,
+
+  "required": [
+    "run_id",
+    "verdict_status",
+    "round",
+    "target_rounds",
+    "finding_counts",
+    "findings",
+    "generated_at",
+    "generated_by",
+    "generator_version"
+  ],
+
+  "properties": {
+    "run_id": { "$ref": "#/$defs/run_id" },
+    "verdict_status": {
+      "type": "string",
+      "enum": ["PASS", "MINOR", "MATERIAL", "AUDIT_FAILED"],
+      "description": "Three completion states + AUDIT_FAILED for wrapper-side aborts (§4.6). Cross-field consistency with finding_counts and failure_reason is lint-enforced (§3.7 A1/A2)."
+    },
+    "round": { "type": "integer", "minimum": 1 },
+    "target_rounds": { "type": "integer", "minimum": 1 },
+    "finding_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["p1", "p2", "p3"],
+      "properties": {
+        "p1": { "type": "integer", "minimum": 0 },
+        "p2": { "type": "integer", "minimum": 0 },
+        "p3": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" },
+      "description": "May be []. When verdict_status == 'AUDIT_FAILED', findings MUST be [] (lint-enforced per §3.7 A6). When non-empty, finding_counts must agree with severity tallies (§3.7 A5, lint-enforced)."
+    },
+    "failure_reason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500,
+      "pattern": "^[^\\n\\r]+$",
+      "description": "One-line human-readable reason. Required iff verdict_status == 'AUDIT_FAILED' (§3.7 A2; lint-enforced)."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "generated_by": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the wrapper script that produced this verdict (canonical: 'scripts/run_codex_audit.sh')."
+    },
+    "generator_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Wrapper script semver."
+    }
+  },
+
+  "allOf": [
+    {
+      "title": "[doc-only] round vs target_rounds — enforced by lint, not schema",
+      "description": "JSON Schema 2020-12 has no native cross-field comparison; round <= target_rounds (§3.7 A3) is enforced by scripts/check_audit_artifact_consistency.py (Phase 6.3) and by the wrapper's --round/--target-rounds preflight (§4.2). This clause carries the comment so future readers don't try to add a non-existent schema-level constraint here."
+    },
+    {
+      "description": "AUDIT_FAILED requires failure_reason. Lint additionally enforces findings == [] and finding_counts all zero per §3.7 A2/A6.",
+      "if": {
+        "properties": { "verdict_status": { "const": "AUDIT_FAILED" } },
+        "required": ["verdict_status"]
+      },
+      "then": {
+        "required": ["failure_reason"]
+      }
+    },
+    {
+      "description": "Non-AUDIT_FAILED verdicts MUST NOT carry failure_reason (§3.7 A2 inverse direction).",
+      "if": {
+        "properties": {
+          "verdict_status": {
+            "type": "string",
+            "enum": ["PASS", "MINOR", "MATERIAL"]
+          }
+        },
+        "required": ["verdict_status"]
+      },
+      "then": {
+        "not": { "required": ["failure_reason"] }
+      }
+    }
+  ],
+
+  "$defs": {
+    "run_id": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z-[0-9a-f]{4}$",
+      "description": "Mirrored from passport/audit_artifact_entry.schema.json $defs.run_id; F1 in §3.7. Keep regex in sync."
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "severity", "dimension", "file", "line", "description", "suggested_fix"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^F-[0-9]{3,}$",
+          "description": "Stable per-verdict-file identifier (e.g., 'F-007'). acknowledgement.finding_ids cross-references these (§3.7 B10)."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["P1", "P2", "P3"]
+        },
+        "dimension": {
+          "type": "string",
+          "enum": ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "4(f)"],
+          "description": "Audit template Section 3 dimension or '4(f)' for report_compiler_agent abstract-only checks."
+        },
+        "file": { "type": "string", "minLength": 1 },
+        "line": { "type": "integer", "minimum": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "suggested_fix": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/shared/contracts/passport/audit_artifact_entry.schema.json
+++ b/shared/contracts/passport/audit_artifact_entry.schema.json
@@ -103,7 +103,7 @@
     },
     {
       "title": "persisted",
-      "description": "Orchestrator-merged, post-verification. AUDIT_FAILED excluded — see §3.2 'Why persisted excludes AUDIT_FAILED' rationale.",
+      "description": "Orchestrator-merged, post-verification. AUDIT_FAILED excluded — see §3.2 'Why persisted excludes AUDIT_FAILED' rationale. acknowledgement is allowed only on MATERIAL entries — schema-level if/then below blocks the hand-edit attack where someone adds an acknowledgement block to a non-MATERIAL persisted entry to claim residue acknowledgement that was never solicited (§3.7 A4).",
       "properties": {
         "verdict": {
           "type": "object",
@@ -119,7 +119,24 @@
             }
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "title": "[A4] acknowledgement requires verdict.status == MATERIAL",
+          "if": {
+            "properties": {
+              "verdict": {
+                "properties": { "status": { "enum": ["PASS", "MINOR"] } },
+                "required": ["status"]
+              }
+            },
+            "required": ["verdict"]
+          },
+          "then": {
+            "not": { "required": ["acknowledgement"] }
+          }
+        }
+      ]
     }
   ],
 

--- a/shared/contracts/passport/audit_artifact_entry.schema.json
+++ b/shared/contracts/passport/audit_artifact_entry.schema.json
@@ -84,6 +84,46 @@
     "acknowledgement": { "$ref": "#/$defs/acknowledgement_block" }
   },
 
+  "allOf": [
+    {
+      "title": "[A2] AUDIT_FAILED requires verdict.failure_reason; mirrors audit_verdict.schema.json",
+      "description": "Entry-side mirror of the verdict-file rule (§3.7 A2). Without this, a wrapper-emitted AUDIT_FAILED proposal missing failure_reason passes Path B4 schema validation; Path B5 then short-circuits and tries to surface a non-existent reason in the BLOCK message. Mirror keeps the rule enforceable at the first artifact orchestrator reads (entry), not just at the verdict file.",
+      "if": {
+        "properties": {
+          "verdict": {
+            "properties": { "status": { "const": "AUDIT_FAILED" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["verdict"]
+      },
+      "then": {
+        "properties": {
+          "verdict": { "required": ["failure_reason"] }
+        }
+      }
+    },
+    {
+      "title": "[A2 inverse] non-AUDIT_FAILED proposals MUST NOT carry failure_reason",
+      "if": {
+        "properties": {
+          "verdict": {
+            "properties": {
+              "status": { "type": "string", "enum": ["PASS", "MINOR", "MATERIAL"] }
+            },
+            "required": ["status"]
+          }
+        },
+        "required": ["verdict"]
+      },
+      "then": {
+        "properties": {
+          "verdict": { "not": { "required": ["failure_reason"] } }
+        }
+      }
+    }
+  ],
+
   "oneOf": [
     {
       "title": "proposal",

--- a/shared/contracts/passport/audit_artifact_entry.schema.json
+++ b/shared/contracts/passport/audit_artifact_entry.schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/passport/audit_artifact_entry.schema.json",
+  "title": "Material Passport Audit Artifact Entry",
+  "description": "One entry in Material Passport Schema 9 audit_artifact[]. Records one cross-model audit run for one downstream agent's deliverable. Two lifecycle states share this schema via oneOf: 'proposal' (wrapper-emitted, pre-verification) and 'persisted' (orchestrator-merged, post-verification). See docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md §3.1-§3.2 and §3.7 for cross-artifact invariants. Cross-field rules (PASS/MINOR/MATERIAL/AUDIT_FAILED counts; acknowledgement scoping; etc.) are lint-enforced in scripts/check_audit_artifact_consistency.py (Phase 6.3), NOT in this schema.",
+
+  "type": "object",
+  "additionalProperties": false,
+
+  "required": [
+    "stage",
+    "agent",
+    "deliverable_path",
+    "deliverable_sha",
+    "run_id",
+    "bundle_manifest_sha",
+    "artifact_paths",
+    "verdict"
+  ],
+
+  "properties": {
+    "stage": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 6,
+      "description": "Destination stage the just-completed deliverable is about to enter (per §5.1). v3.6.7 hooks emit stage 2 for synthesis_agent / research_architect_agent exits and stage 5 for report_compiler_agent exit."
+    },
+    "agent": {
+      "type": "string",
+      "enum": [
+        "synthesis_agent",
+        "research_architect_agent",
+        "report_compiler_agent"
+      ],
+      "description": "One of the three v3.6.7 audited agents. Other agent names are reserved for future versions and rejected by Schema 9 lint."
+    },
+    "deliverable_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^/][^\\s]*$",
+      "not": { "pattern": "(^|/)\\.\\.(/|$)" },
+      "description": "Repo-relative POSIX path to the audited deliverable. No leading '/' and no '..' segments."
+    },
+    "deliverable_sha": {
+      "$ref": "#/$defs/sha256_hex",
+      "description": "SHA-256 (lowercase hex) of the deliverable file at the moment audit was dispatched. Used by orchestrator to detect post-audit deliverable mutation."
+    },
+    "run_id": {
+      "$ref": "#/$defs/run_id",
+      "description": "Canonical run identifier emitted by the wrapper. Format <ISO-8601-Z>-<4-hex>. Per §3.7 family F (F1)."
+    },
+    "bundle_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional opaque tag shared by all entries that belong to one logical multi-file audit bundle (§4.5). When present MUST equal the sidecar's prompt.bundle.bundle_id (§3.7 B9, lint-enforced)."
+    },
+    "bundle_manifest_sha": {
+      "$ref": "#/$defs/sha256_hex",
+      "description": "SHA-256 over the canonical bundle manifest of primary + supporting + template files (§3.6)."
+    },
+    "artifact_paths": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["jsonl", "sidecar", "verdict"],
+      "properties": {
+        "jsonl": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\.jsonl$"
+        },
+        "sidecar": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\.meta\\.json$"
+        },
+        "verdict": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\.verdict\\.yaml$"
+        }
+      }
+    },
+    "verdict": { "$ref": "#/$defs/verdict_block" },
+    "acknowledgement": { "$ref": "#/$defs/acknowledgement_block" }
+  },
+
+  "oneOf": [
+    {
+      "title": "proposal",
+      "description": "Wrapper-emitted, pre-verification. verdict.verified_at and verdict.verified_by MUST be absent (Pattern C3 attack surface defense per §3.2 / §3.7 E3+E4). acknowledgement is forbidden — orchestrator-only write per §5.4 / §3.7 A4.",
+      "not": { "required": ["acknowledgement"] },
+      "properties": {
+        "verdict": {
+          "type": "object",
+          "not": {
+            "anyOf": [
+              { "required": ["verified_at"] },
+              { "required": ["verified_by"] }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "persisted",
+      "description": "Orchestrator-merged, post-verification. AUDIT_FAILED excluded — see §3.2 'Why persisted excludes AUDIT_FAILED' rationale.",
+      "properties": {
+        "verdict": {
+          "type": "object",
+          "required": ["verified_at", "verified_by"],
+          "properties": {
+            "status": { "enum": ["PASS", "MINOR", "MATERIAL"] },
+            "verified_at": {
+              "$ref": "#/$defs/rfc3339_ms_utc",
+              "description": "RFC 3339 UTC datetime, millisecond precision (mirrors §3.4 sidecar timing precision so D1 latest-by-verified_at ordering has resolution >= 1 ms; see §5.4 monotonic-bump rule)."
+            },
+            "verified_by": {
+              "const": "pipeline_orchestrator_agent"
+            }
+          }
+        }
+      }
+    }
+  ],
+
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Lowercase hex SHA-256 digest. Sibling audit/* schemas duplicate this pattern (cross-file $ref is operationally awkward without a registry resolver); keep regex in sync via §3.7 family F naming-convention review."
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z-[0-9a-f]{4}$",
+      "description": "<ISO-8601-Z>-<4-hex>. F1 in §3.7 naming family. Sibling audit/* schemas duplicate this pattern."
+    },
+    "rfc3339_ms_utc": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "description": "RFC 3339 UTC datetime with millisecond precision. Format keyword is advisory (validator must enable format_checker); regex is the load-bearing constraint."
+    },
+    "verdict_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "round", "target_rounds", "finding_counts"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["PASS", "MINOR", "MATERIAL", "AUDIT_FAILED"],
+          "description": "Proposal-arm enum; persisted arm narrows to {PASS,MINOR,MATERIAL} via oneOf override (§3.2 Lifecycle-conditional fields)."
+        },
+        "failure_reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "pattern": "^[^\\n\\r]+$",
+          "description": "One-line human-readable reason. Required iff status == AUDIT_FAILED (cross-field rule, lint-enforced per §3.7 A2)."
+        },
+        "round": { "type": "integer", "minimum": 1 },
+        "target_rounds": { "type": "integer", "minimum": 1 },
+        "finding_counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p1", "p2", "p3"],
+          "properties": {
+            "p1": { "type": "integer", "minimum": 0 },
+            "p2": { "type": "integer", "minimum": 0 },
+            "p3": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "verified_by": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "acknowledgement_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["finding_ids", "acknowledged_at", "acknowledged_by"],
+      "properties": {
+        "finding_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Non-empty array; full coverage of every current findings[].id is enforced by lint (§3.7 B10)."
+        },
+        "acknowledged_at": {
+          "$ref": "#/$defs/rfc3339_ms_utc",
+          "description": "RFC 3339 UTC, millisecond precision. Equals verdict.verified_at by construction (§3.7 B8)."
+        },
+        "acknowledged_by": { "const": "user" }
+      }
+    }
+  }
+}

--- a/shared/contracts/passport/audit_artifact_entry.schema.json
+++ b/shared/contracts/passport/audit_artifact_entry.schema.json
@@ -35,10 +35,7 @@
       "description": "One of the three v3.6.7 audited agents. Other agent names are reserved for future versions and rejected by Schema 9 lint."
     },
     "deliverable_path": {
-      "type": "string",
-      "minLength": 1,
-      "pattern": "^[^/][^\\s]*$",
-      "not": { "pattern": "(^|/)\\.\\.(/|$)" },
+      "$ref": "#/$defs/repo_relative_path",
       "description": "Repo-relative POSIX path to the audited deliverable. No leading '/' and no '..' segments."
     },
     "deliverable_sha": {
@@ -64,21 +61,25 @@
       "required": ["jsonl", "sidecar", "verdict"],
       "properties": {
         "jsonl": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "\\.jsonl$"
+          "allOf": [
+            { "$ref": "#/$defs/repo_relative_path" },
+            { "type": "string", "pattern": "\\.jsonl$" }
+          ]
         },
         "sidecar": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "\\.meta\\.json$"
+          "allOf": [
+            { "$ref": "#/$defs/repo_relative_path" },
+            { "type": "string", "pattern": "\\.meta\\.json$" }
+          ]
         },
         "verdict": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "\\.verdict\\.yaml$"
+          "allOf": [
+            { "$ref": "#/$defs/repo_relative_path" },
+            { "type": "string", "pattern": "\\.verdict\\.yaml$" }
+          ]
         }
-      }
+      },
+      "description": "All three paths are repo-relative POSIX (no leading '/', no '..' segments). Path B uses these to locate JSONL/sidecar/verdict evidence; an absolute or escaping path would let a forged proposal point verification outside the repo."
     },
     "verdict": { "$ref": "#/$defs/verdict_block" },
     "acknowledgement": { "$ref": "#/$defs/acknowledgement_block" }
@@ -181,6 +182,13 @@
   ],
 
   "$defs": {
+    "repo_relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^/][^\\s]*$",
+      "not": { "pattern": "(^|/)\\.\\.(/|$)" },
+      "description": "Repo-relative POSIX path (no leading '/', no '..' segments). Sibling audit/* schemas duplicate this pattern; keep the regex pair in sync. Layer 3 lint reads these paths from disk for SHA-256 / git_sha verification — accepting absolute or escaping paths would let a forged proposal hash arbitrary files."
+    },
     "sha256_hex": {
       "type": "string",
       "pattern": "^[a-f0-9]{64}$",


### PR DESCRIPTION
## Summary

Lands Phase 6.2 and Phase 6.4 of the v3.6.7 Step 6 implementation roadmap (spec [`docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md`](docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md) §10). Schema-only + pure helper — no orchestrator behavior changes yet.

**Phase 6.2 — four JSON Schema 2020-12 contracts (spec §3.1–§3.5):**
- `shared/contracts/passport/audit_artifact_entry.schema.json` — passport `audit_artifact[]` entry with proposal/persisted `oneOf` lifecycle (§3.1, §3.2)
- `shared/contracts/audit/audit_jsonl.schema.json` — Layer 2 codex 0.125 `--json` event-stream (6 event types: `thread.started` / `turn.started` / `item.started` / `item.completed` / `turn.completed` / `error`) (§3.3)
- `shared/contracts/audit/audit_sidecar.schema.json` — Layer 3 sidecar metadata with AUDIT_FAILED conditional on `stream.jsonl_thread_id` (§3.4)
- `shared/contracts/audit/audit_verdict.schema.json` — verdict file shape (PASS / MINOR / MATERIAL / AUDIT_FAILED) with `if/then` guards on `failure_reason` (§3.5)
- `shared/contracts/README.md` restructured into three contract families (sprint / passport / audit)

**Phase 6.4 — `scripts/_next_verified_at_ms.py` strict-monotonic helper (spec §5.4):**
- Pure function `next_verified_at_ms(audit_artifacts)` returning RFC 3339 UTC ms strictly greater than every prior `verified_at` (§3.7 family D row D3)
- CLI mode `--passport <path>` for orchestrator + lint integration
- RFC 3339 ms primitives (`utc_now_ms`, `parse_rfc3339_ms`, `rfc3339_ms`, `bump_ms`) — `adapters/_common.now_iso` emits second precision which silently violates §3.2

**Plumbing:**
- `scripts/_test_helpers.py` gains `load_json_schema` + `build_schema_validator` so the future Phase 6.3 lint test can reuse them
- `scripts/test_audit_schemas.py` — 32 unittest cases (positive examples from spec §3.1/§3.3/§3.4/§3.5 + negative counter-examples)
- `scripts/test__next_verified_at_ms.py` — 19 unittest cases including property-based monotonic check, ms→second/minute carry, CLI integration with malformed YAML
- `.github/workflows/spec-consistency.yml` runs both modules on every push/PR

## Codex iterative review (7 rounds → 0 finding)

Per [`feedback_codex_iterative_spec_review_to_zero.md`](https://github.com/Imbad0202/academic-research-skills/) high blast-radius spec discipline:

| Round | Finding | Severity | Fix commit |
|---|---|---|---|
| 1 | YAML datetime crash + loose UUID regex + acknowledgement guard missing | 3× P2 | `dd66b97` |
| 2 | A2 mirror gap on entry vs verdict file | 1× P2 | `52bb61a` |
| 3 | Path-safety guards missing on `artifact_paths` + bundle paths | 2× P2 | `036ea74` |
| 4 | **Spec §3.3 missed `item.started` event** — real codex 0.125 streams emit it during tool use, would block all real audits | **1× P1** | `05260ac` |
| 5 | `item.started` arm needed `additionalProperties: false` for arm-consistency | 1× P3 | `ed0ece8` |
| 6 | Acceptance tests not wired into CI (`spec-consistency.yml`) | 1× P2 | `ddfe162` |
| 7 | Clean | 0 | — |

The P1 in round 4 is real spec drift: §3.3 enumerated four canonical events but real codex 0.125 emits `item.started` for every tool call (`command_execution` etc.). Empirically captured via `codex exec --json`. Spec table needs amending in a follow-up.

## Out of scope (Phase 6.3+)

Per spec §10 sequencing, this PR does NOT include:
- Cross-artifact invariants (§3.7 family A–F rows, `--mode {proposal,persisted}` arms, mirror rules, ordering rules) — Phase 6.3 lint
- Wrapper script `scripts/run_codex_audit.sh` — Phase 6.1
- Schema 9 amendment in `shared/handoff_schemas.md` — Phase 6.5
- Orchestrator agent prompt update — Phase 6.6
- Downstream-agent prompt edits + CI fixtures — Phase 6.7 / 6.8

## Verification

- 60 unittest cases green: `python -m unittest scripts.test_audit_schemas scripts.test__next_verified_at_ms`
- All 4 existing lints unaffected (literature_corpus / passport_reset / v3.6.7 pattern_protection / spec_consistency)
- CI workflow gate added to `spec-consistency.yml`

## Test plan

- [ ] `spec-consistency` workflow green on PR
- [ ] Codex review on PR (cross-model second opinion)
- [ ] Spot-check that schema example payloads in `docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md` §3.1 / §3.3 / §3.4 / §3.5 still validate against the shipped schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)