### PR TITLE
chore(gitignore): ignore ROADMAP.md (private, lives in claude-memory-sync)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/superpowers/
 
 # Python bytecode / pytest cache.
 __pycache__/
+
+# Private ROADMAP lives in claude-memory-sync (花花/roadmaps/), not this public repo
+ROADMAP.md


### PR DESCRIPTION
## Summary

- Add `ROADMAP.md` to `.gitignore` — it's a private planning doc that lives in `claude-memory-sync`, not this public repo
- Prevents accidental `git add .` from pushing it to a public repo

## Test plan

- [x] Verified `ROADMAP.md` is not currently tracked in main
- [x] One-line `.gitignore` change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)