### PR TITLE
feat(v3.6.6, suite v3.6.8): generator-evaluator contract implementation — code-only tracks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,22 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 | `deep-research` v2.9.3 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
 | `academic-paper` v3.1.1 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.9.0 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.6.7 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.6.8 | Full pipeline orchestrator | (coordinates all above) |
+
+## v3.6.8 Key Additions
+
+> **Naming note**: this release ships the v3.6.6 generator-evaluator contract design (`docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md`) and its implementation. The v3.6.6 spec/implementation work landed after v3.6.7 due to project sequencing (v3.6.7 downstream-agent pattern protection shipped first); the design doc retains the **v3.6.6 internal naming** for the contract gate version (`writer_full` / `evaluator_full` mode, Schema 13.1, `pre_commitment_artifacts` + `disagreement_handling` schema fields), while the suite release is tagged **v3.6.8** to keep the CHANGELOG monotonic.
+
+- **Schema 13.1 generator-evaluator contract gate** for `academic-paper full` mode. `shared/sprint_contract.schema.json` upgrades to Schema 13.1 with two new `mode` enum values (`writer_full` + `evaluator_full`), two new optional top-level fields (`pre_commitment_artifacts` writer-only, `disagreement_handling` evaluator-only), and 12 `allOf` branches enforcing reviewer-conditional / writer-conditional / evaluator-conditional gates. Existing reviewer contracts validate byte-equivalent under Schema 13.1 (§3.6 zero-touch promise).
+- **Two new shipped contract templates**: `shared/contracts/writer/full.json` (D1–D7 dimensions, F1/F4/F2/F3/F0 conditions, no `scoring_plan`) and `shared/contracts/evaluator/full.json` (D1–D5 dimensions, F1/F2/F3/F6/F4/F5/F0 conditions, full `scoring_plan` + `disagreement_handling`).
+- **Two-phase orchestration inside `academic-paper full` mode**: Phase 4 (writer drafting) splits into Phase 4a paper-blind pre-commitment + Phase 4b paper-visible drafting + self-scoring; Phase 6 (in-pair evaluator review) splits into Phase 6a paper-blind pre-commitment + Phase 6b paper-visible scoring + decision. Phase-numbered `<phase4a_output>` / `<phase6a_output>` data delimiters mirror the v3.6.2 reviewer pattern. Lint counts: writer 3+4 / evaluator 5+5 / reviewer 5+6 zero-touch. `[GENERATOR-PHASE-ABORTED]` abort tag with 5%/three-month operational monitor.
+- **`academic-paper/SKILL.md` `## v3.6.6 Generator-Evaluator Contract Protocol` orchestration block** (101 lines): four-call structure, system-vs-user content discipline, schema-vs-runtime emission distinction, per-phase lint, abort handling, two valid Stage 3 entry paths (standard F0/F4 + exceptional F5), cross-session resume scope. Plus `## Known limitations` section carrying graceful-degradation forward note + cross-session resume forward note + in-pair vs external reviewer tech debt.
+- **`draft_writer_agent.md` + `peer_reviewer_agent.md`** each gain a verbatim `## v3.6.6 Generator-Evaluator Contract Protocol` section with system-prompt sub-sections for Phase 4a/4b (writer) and Phase 6a/6b (evaluator).
+- **`scripts/check_sprint_contract.py` SC-* mode-gating audit**: SC-5 (measurement_procedure canonical outputs) and SC-11 (panel_size sanity) now mode-gated to `mode.startswith("reviewer_")`; SC-9 (paraphrase_minimum_dimensions exceeds dim count) extended across all three mode families with each mode reading its own field path. Mode-agnostic warnings (SC-1/2/3/4/7/10) unchanged.
+- **17 new validator tests** (54 → 71): 4 shipped writer/evaluator template positive tests, 5 schema-branch negative tests (branches 11/12/4/5/6 hard-fail; cross-mode field leakage intentionally NOT tested per §7.1 R1 settled), 2 §3.6 reviewer regression tests, 6 SC-5/SC-9/SC-11 mode-gating tests.
+- **`scripts/check_v3_6_6_ab_manifest.py` + workflow extension**: enforces §6.2 manifest schema + §6.5 git-tracked invariants on `tests/fixtures/v3.6.6-ab/manifest.yaml`. `.github/workflows/spec-consistency.yml` extends the sprint contract validation loop to iterate writer + evaluator template directories alongside the existing reviewer loop, plus runs the new manifest CI lint as an additional step.
+- **`tests/fixtures/v3.6.6-ab/` A/B evidence fixture stub** (30 files): manifest + README + 6 paper-A inputs/baseline + 1 paper-C inputs/baseline + Stage 3 reviewer excerpt + 6 codex-judge baseline placeholders. `manifest_lint_mode: spec_branch`, `fixture_version: 0.1.0`. Real fixture data populates in follow-up commits.
+- **`academic-paper-reviewer/references/sprint_contract_protocol.md` cross-reference** noting Schema 13.1 since v3.6.6 + pointing readers at `academic-paper/SKILL.md` + design doc §5 for the parallel generator-evaluator protocol.
 
 ## v3.6.7 Key Additions
 
@@ -132,7 +147,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.6.7 (per CHANGELOG.md)
-- **Last Updated**: 2026-04-30
+- **Suite version**: 3.6.8 (per CHANGELOG.md)
+- **Last Updated**: 2026-05-03
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -81,6 +81,16 @@ jobs:
           for f in shared/contracts/reviewer/*.json; do
             python3 scripts/check_sprint_contract.py "$f" --ars-version "v${ARS_VERSION}"
           done
+          # v3.6.6: writer + evaluator template validation loops mirror reviewer loop above.
+          for f in shared/contracts/writer/*.json; do
+            python3 scripts/check_sprint_contract.py "$f" --ars-version "v${ARS_VERSION}"
+          done
+          for f in shared/contracts/evaluator/*.json; do
+            python3 scripts/check_sprint_contract.py "$f" --ars-version "v${ARS_VERSION}"
+          done
+
+      - name: Validate v3.6.6 A/B fixture manifest
+        run: python3 scripts/check_v3_6_6_ab_manifest.py
 
       - name: Validate literature_corpus schemas and examples
         run: python3 scripts/check_literature_corpus_schema.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,140 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.6.8] - 2026-05-03
+
+> **Naming note**: this release ships the **v3.6.6 generator-evaluator contract**
+> spec (`docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md`)
+> and its implementation. The v3.6.6 work landed after v3.6.7 due to project
+> sequencing; the design doc retains the v3.6.6 internal naming for the
+> contract gate version (`writer_full` / `evaluator_full` mode, Schema 13.1,
+> `pre_commitment_artifacts` + `disagreement_handling` schema fields), while
+> the suite release is tagged v3.6.8 to keep the CHANGELOG monotonic.
+
+### Added
+
+- **Schema 13.1 generator-evaluator contract gate** for `academic-paper full`
+  mode (`shared/sprint_contract.schema.json`, design doc §3): two new `mode`
+  enum values (`writer_full` + `evaluator_full`); two new optional top-level
+  fields (`pre_commitment_artifacts` writer-only with
+  `acceptance_criteria_paraphrase.minimum_dimensions`; `disagreement_handling`
+  evaluator-only with `paraphrase_minimum_dimensions` + `scoring_plan` +
+  `pre_commitment_check_protocol` + `disagreement_resolution`); 12 `allOf`
+  branches enforcing reviewer- / writer- / evaluator-conditional gates
+  (existing 2 + 10 new per design doc §3.5 table).
+- **Two new shipped contract templates**: `shared/contracts/writer/full.json`
+  (writer dimensions D1 section_completeness / D2 citation_density /
+  D3 argument_blueprint_fidelity / D4 total_word_count /
+  D5 per_section_word_count / D6 acknowledged_limitations /
+  D7 register_consistency; F-conditions F1/F4/F2/F3/F0; no `scoring_plan`)
+  and `shared/contracts/evaluator/full.json` (evaluator dimensions
+  D1 originality / D2 methodological_rigor / D3 evidence_sufficiency /
+  D4 argument_coherence / D5 writing_quality; F-conditions F1/F2/F3/F6/F4/F5/F0;
+  full `scoring_plan` + `disagreement_handling`). Templates already shipped on
+  the spec branch as design-time artefacts since 2026-04-28; this release
+  promotes them to live status atomically with the Schema 13.1 upgrade.
+- **Two-phase orchestration inside `academic-paper full` mode** (design doc §5):
+  Phase 4 splits into Phase 4a paper-blind writer pre-commitment + Phase 4b
+  paper-visible drafting + self-scoring. Phase 6 splits into Phase 6a
+  paper-blind evaluator pre-commitment + Phase 6b paper-visible scoring +
+  decision. Phase-numbered `<phase4a_output>` / `<phase6a_output>` data
+  delimiters mirror the v3.6.2 reviewer pattern. Lint counts: writer 3+4 /
+  evaluator 5+5 / reviewer 5+6 (reviewer surfaces remain zero-touch per §3.6).
+  `[GENERATOR-PHASE-ABORTED]` abort tag with 5% / three-month operational
+  monitor.
+- **`academic-paper/SKILL.md` `## v3.6.6 Generator-Evaluator Contract Protocol`
+  orchestration block** (101 lines): four-call structure with system-vs-user
+  content discipline, schema-vs-runtime emission distinction, per-phase lint,
+  abort handling, two valid Stage 3 entry paths (standard F0/F4 + exceptional
+  F5), cross-session resume scope. Plus a new `## Known limitations` section
+  carrying the graceful-degradation forward note (v3.6.7 candidate) + the
+  cross-session resume `pre_commitment_history[]` forward note (v3.6.7+
+  candidate) + in-pair Phase 6 evaluator vs external `academic-paper-reviewer`
+  tech debt.
+- **`academic-paper/agents/draft_writer_agent.md` + `peer_reviewer_agent.md`**
+  each gain a verbatim `## v3.6.6 Generator-Evaluator Contract Protocol`
+  section with the system-prompt sub-sections for Phase 4a/4b (writer) and
+  Phase 6a/6b (evaluator). The orchestrator includes the relevant sub-section
+  verbatim in the system prompt for the corresponding call; user content
+  carries contract JSON, paper metadata, delimiter blocks, and upstream
+  artefacts per the SKILL.md discipline.
+- **`scripts/check_sprint_contract.py` SC-* mode-gating audit** (per §7.1
+  implementation requirement): SC-5 (measurement_procedure canonical outputs)
+  and SC-11 (panel_size sanity) now mode-gated to
+  `mode.startswith("reviewer_")` so they do not noise on clean writer /
+  evaluator templates. SC-9 (paraphrase_minimum_dimensions exceeds dim count)
+  extended across all three mode families: reviewer reads
+  `mp.paraphrase_minimum_dimensions`, writer reads
+  `pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions`,
+  evaluator reads `disagreement_handling.paraphrase_minimum_dimensions`.
+  Mode-agnostic warnings (SC-1 baseline lag, SC-2 single dimension, SC-3 no
+  mandatory, SC-4 orphan dim ref, SC-7 conflicting actions, SC-10 unreferenced
+  mandatory/high) unchanged.
+- **17 new validator tests** (54 → 71 total): 4 writer/evaluator template
+  positive tests; 5 schema-branch negative tests covering branches 11 / 12 /
+  4 / 5 / 6 hard-fail (cross-mode field leakage intentionally NOT a v3.6.6
+  hard-fail per §7.1 R1 settled — v3.7.x `not`-clause hardening is the
+  long-term fix); 2 §3.6 reviewer regression tests
+  (`test_existing_reviewer_contracts_still_valid_under_13_1` +
+  `test_byte_equivalent_validation_for_reviewer_contracts`); 6 SC-5/SC-9/SC-11
+  mode-gating tests.
+- **`scripts/check_v3_6_6_ab_manifest.py`** (new) implements the §7.5 manifest
+  CI lint: schema-shape checks per §6.2 (top-level required fields with
+  declared types; per-paper required fields; paper_id uniqueness; aggregate
+  role counts 6+1; paper-A paper_type families 3 × 2; paper-A required
+  judge_output_baseline; paper-C must-have known_failure_mode +
+  failure_evidence; paper-C must-not-have judge / metrics fields);
+  path-existence checks (mode-conditional + populated-optional);
+  reverse-scan against fixture-orphans; exit-1-on-malformed-YAML mirrors
+  `check_sprint_contract.py` convention.
+- **`.github/workflows/spec-consistency.yml`** extends the "Validate sprint
+  contract templates" step to iterate writer + evaluator template directories
+  alongside the existing reviewer loop, and adds a new "Validate v3.6.6 A/B
+  fixture manifest" step running the new manifest CI lint script as an
+  additional step inside the existing `spec-consistency` job.
+- **`tests/fixtures/v3.6.6-ab/` A/B evidence fixture stub** (30 files):
+  manifest.yaml + README.md + 6 paper-A inputs/baseline + 1 paper-C
+  inputs/baseline + Stage 3 reviewer excerpt + 6 codex-judge baseline
+  placeholders. `manifest_lint_mode: spec_branch`, `fixture_version: 0.1.0`.
+  Each placeholder explains the expected populated content; real fixture data
+  (existing deep-research synthesis reports for paper-A; v3.6.5 session log
+  + Stage 3 reviewer excerpt for paper-C; codex gpt-5.5 + xhigh judge runs
+  against paper-A baseline) populates in follow-up commits before the
+  v3.6.6 implementation work fully completes.
+- **`academic-paper-reviewer/references/sprint_contract_protocol.md`
+  cross-reference** noting Schema 13.1 since v3.6.6 + pointing readers at
+  `academic-paper/SKILL.md` + design doc §5 for the parallel
+  generator-evaluator protocol. The reviewer protocol itself is byte-equivalent
+  across v3.6.2 → v3.6.8 (zero-touch promise per §3.6).
+
+### Changed
+
+- **Suite version**: v3.6.7 → v3.6.8 (per the naming note above; design doc
+  retains v3.6.6 for the contract gate version).
+- **`academic-pipeline` skill version** bumped from v3.6.7 to v3.6.8 in the
+  `.claude/CLAUDE.md` Skills Overview table.
+
+### Deferred
+
+- **Real fixture data populate** for `tests/fixtures/v3.6.6-ab/` (30
+  placeholders → real paper-A inputs + baseline + paper-C session log + codex
+  judge runs) lands in follow-up commits.
+- **Treatment runs** (writer Phase 4a/4b + evaluator Phase 6a/6b on the seven
+  fixtures), **codex judge against treatment**, and **metrics computation
+  + summary.md** require actual `academic-paper full` invocations + Semantic
+  Scholar API + codex CLI runs; deferred to follow-up commits before the
+  fixture-completeness work concludes.
+- **manifest_lint_mode flip** from `spec_branch` to `implementation_pr`
+  co-lands with the treatment population in the same atomic merge state per
+  §6.5 invariant 3.
+- **ROADMAP §3.6.4 description correction** per design doc §9.3 ("Extend
+  v3.6.2 sprint contract pattern to the existing `academic-paper`
+  writer/evaluator pair via contract-gated phase splits and Schema 13.1
+  conditional gates. No new agent files; existing `draft_writer_agent` and
+  `peer_reviewer_agent` gain per-phase sub-section instructions") lands in
+  the private ROADMAP.md (gitignored, lives in claude-memory-sync), not in
+  this repo PR.
+
 ## [3.6.7] - 2026-04-30
 
 ### Added

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.6.7 (2026-04-30)
+Last updated: v3.6.8 (2026-05-03)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.6.7-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.7)
+[![Version](https://img.shields.io/badge/version-v3.6.8-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.8)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -288,6 +288,21 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.6.8 (2026-05-03) — Generator-Evaluator Contract Gate (v3.6.6 spec ship)
+
+> Naming note: this release ships the **v3.6.6 generator-evaluator contract** spec
+> and implementation. The v3.6.6 work landed after v3.6.7 due to project sequencing;
+> the design doc retains the v3.6.6 internal naming for the contract gate version,
+> while the suite release is tagged v3.6.8 to keep the CHANGELOG monotonic.
+
+- **Schema 13.1** (`shared/sprint_contract.schema.json`) extends Schema 13 with two new `mode` enum values (`writer_full` + `evaluator_full`), two new optional top-level fields (`pre_commitment_artifacts` writer-only, `disagreement_handling` evaluator-only), and 12 `allOf` branches enforcing reviewer- / writer- / evaluator-conditional gates. Existing reviewer contracts validate byte-equivalent under Schema 13.1 (§3.6 zero-touch promise).
+- **Two new shipped contract templates** under `shared/contracts/writer/full.json` (D1–D7, F1/F4/F2/F3/F0) and `shared/contracts/evaluator/full.json` (D1–D5, F1/F2/F3/F6/F4/F5/F0). Promoted from design-time artefacts on the spec branch to live shipped status atomically with the Schema 13.1 upgrade.
+- **Two-phase orchestration** inside `academic-paper full`: Phase 4 splits into Phase 4a (writer paper-blind pre-commitment) + Phase 4b (writer paper-visible drafting + self-scoring); Phase 6 splits into Phase 6a (evaluator paper-blind pre-commitment) + Phase 6b (evaluator paper-visible scoring + decision). Phase-numbered `<phase4a_output>` / `<phase6a_output>` data delimiters mirror the v3.6.2 reviewer pattern. Lint count summary: writer 3+4 / evaluator 5+5 / reviewer 5+6 (reviewer remains zero-touch).
+- **`academic-paper` SKILL + agent files** gain a verbatim `## v3.6.6 Generator-Evaluator Contract Protocol` block (101 lines in SKILL.md plus 47 lines in `draft_writer_agent.md` + 57 lines in `peer_reviewer_agent.md`). SKILL.md also adds a new `## Known limitations` section carrying graceful-degradation + cross-session resume forward notes for v3.6.7+.
+- **Validator extensions**: `scripts/check_sprint_contract.py` SC-* mode-gating audit (SC-5 + SC-11 reviewer-only; SC-9 extended across all three mode families). 17 new tests bring the validator unit-test count from 54 to 71 (positive + 5 schema-branch negative + 2 §3.6 reviewer regression + 6 mode-gating tests).
+- **Manifest CI lint**: `scripts/check_v3_6_6_ab_manifest.py` enforces §6.2 manifest schema + §6.5 git-tracked invariants on `tests/fixtures/v3.6.6-ab/manifest.yaml`. `.github/workflows/spec-consistency.yml` extends the sprint contract validation loop to iterate writer + evaluator template directories alongside the existing reviewer loop, plus runs the new manifest CI lint.
+- **A/B evidence fixture stub** at `tests/fixtures/v3.6.6-ab/` (30 files): manifest + README + 6 paper-A inputs/baseline + 1 paper-C inputs/baseline + Stage 3 reviewer excerpt + 6 codex-judge baseline placeholders. Real fixture data populates in follow-up commits before the implementation work fully completes.
 
 ### v3.6.7 (2026-04-30) — Downstream-Agent Pattern Protection (Step 1+2)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.6.7-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.7)
+[![Version](https://img.shields.io/badge/version-v3.6.8-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.6.8)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -269,6 +269,20 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.6.8（2026-05-03）— Generator-Evaluator Contract Gate（v3.6.6 spec ship）
+
+> 命名說明：本次發行交付 **v3.6.6 generator-evaluator contract** spec 與實作。
+> v3.6.6 因專案排序晚於 v3.6.7 才落地；design doc 內仍保留 v3.6.6 內部命名作為
+> contract gate 版本，suite release 標 v3.6.8 維持 CHANGELOG 單調遞增。
+
+- **Schema 13.1**（`shared/sprint_contract.schema.json`）在 Schema 13 之上加兩個 `mode` enum 值（`writer_full` + `evaluator_full`）、兩個新 optional top-level 欄位（`pre_commitment_artifacts` writer-only、`disagreement_handling` evaluator-only）、12 條 `allOf` branch 強制 reviewer- / writer- / evaluator-conditional gate。既有 reviewer contract 在 Schema 13.1 下 byte-equivalent validate（§3.6 zero-touch promise）。
+- **兩個新 shipped contract template**：`shared/contracts/writer/full.json`（D1–D7、F1/F4/F2/F3/F0）+ `shared/contracts/evaluator/full.json`（D1–D5、F1/F2/F3/F6/F4/F5/F0）。Spec branch 上原是 design-time artefact，本次發行 atomically promote 為 live shipped。
+- **`academic-paper full` 模式內加入 two-phase orchestration**：Phase 4 拆成 Phase 4a（writer paper-blind 預先承諾）+ Phase 4b（writer paper-visible 撰稿 + 自評）；Phase 6 拆成 Phase 6a（evaluator paper-blind 預先承諾）+ Phase 6b（evaluator paper-visible 評分 + 決策）。phase-numbered `<phase4a_output>` / `<phase6a_output>` data delimiter 沿用 v3.6.2 reviewer pattern。Lint count summary：writer 3+4 / evaluator 5+5 / reviewer 5+6（reviewer 維持 zero-touch）。
+- **`academic-paper` SKILL + agent file 新增 `## v3.6.6 Generator-Evaluator Contract Protocol` 區塊**（SKILL.md 101 行 + `draft_writer_agent.md` 47 行 + `peer_reviewer_agent.md` 57 行）。SKILL.md 另加 `## Known limitations` 區塊承載 graceful-degradation + cross-session resume v3.6.7+ forward note。
+- **Validator 擴充**：`scripts/check_sprint_contract.py` 做 SC-* mode-gating audit（SC-5 + SC-11 reviewer-only；SC-9 跨三個 mode family 各讀對應欄位）。validator 單元測試從 54 條增加到 71 條（4 positive + 5 schema-branch negative + 2 §3.6 reviewer regression + 6 mode-gating）。
+- **Manifest CI lint**：`scripts/check_v3_6_6_ab_manifest.py` 強制 `tests/fixtures/v3.6.6-ab/manifest.yaml` 的 §6.2 manifest schema + §6.5 git-tracked invariant。`.github/workflows/spec-consistency.yml` 把 sprint contract validation loop 擴成同時跑 reviewer + writer + evaluator 三個 template directory，並加入新的 manifest CI lint 步驟。
+- **A/B evidence fixture stub**（`tests/fixtures/v3.6.6-ab/`，30 個檔案）：manifest + README + 6 paper-A inputs/baseline + 1 paper-C inputs/baseline + Stage 3 reviewer excerpt + 6 codex-judge baseline placeholder。真實 fixture data 在後續 commit populate。
 
 ### v3.6.7（2026-04-30）— 下游 agent pattern protection（Step 1+2）
 

--- a/academic-paper-reviewer/references/sprint_contract_protocol.md
+++ b/academic-paper-reviewer/references/sprint_contract_protocol.md
@@ -1,9 +1,11 @@
 # Sprint Contract Protocol (v3.6.2)
 
 > Authoritative orchestration reference for the ARS v3.6.2 sprint-contract hard gate.
-> Schema: `shared/sprint_contract.schema.json`.
+> Schema: `shared/sprint_contract.schema.json` (Schema 13.1 since v3.6.6).
 > Templates: `shared/contracts/reviewer/*.json`.
 > Design spec: `docs/design/2026-04-23-ars-v3.6.2-sprint-contract-design.md`.
+>
+> **v3.6.6 cross-reference**: this reviewer protocol is byte-equivalent across v3.6.2 → v3.6.6 (zero-touch promise per §3.6 of `docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md`). The v3.6.6 release adds a parallel generator-evaluator protocol inside `academic-paper` for the in-pair writer / evaluator pair (see `academic-paper/SKILL.md` § "v3.6.6 Generator-Evaluator Contract Protocol" and design doc §5).
 
 ## 1. Overview
 

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -140,6 +140,107 @@ Phase 7: FORMAT        -> [formatter]                  -> Final Output Package
 
 > **v3.4.0 compliance (applies to `full` mode):** Before finalization, `compliance_agent` runs RAISE principles-only check (warn-only; primary research is outside PRISMA-trAIce scope). Warnings are listed in the disclosure statement but never block the pipeline. See `shared/raise_framework.md §Scope disclaimer`.
 
+## v3.6.6 Generator-Evaluator Contract Protocol
+
+> Authoritative orchestration block for the v3.6.6 contract-gated phase splits inside `academic-paper full` mode. Schema 13.1 since v3.6.6 (`shared/sprint_contract.schema.json`). Templates: `shared/contracts/writer/full.json` + `shared/contracts/evaluator/full.json`. Design spec: `docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md` §5.
+>
+> **Applies to `academic-paper full` mode only.** Nine non-full modes (`plan`, `outline-only`, `revision`, `revision-coach`, `abstract-only`, `lit-review`, `format-convert`, `citation-check`, `disclosure`) are byte-equivalent across v3.6.5 → v3.6.6 and do not invoke this protocol. Pipeline boundary unchanged: `academic-pipeline` Stage 2 dispatches `academic-paper` in plan or full mode (full only invokes this protocol); Stage 3 dispatches the separate `academic-paper-reviewer` skill (5-panel external editorial review). The in-pair Phase 6 evaluator under this protocol and the Stage 3 reviewer are different review layers — see design doc §5.1 audit conclusion 2.
+
+### Overview
+
+v3.6.6 splits Phase 4 (writer drafting) and Phase 6 (in-pair evaluator review) into paper-blind / paper-visible call pairs gated by the `writer_full` and `evaluator_full` contracts. The split mirrors `academic-paper-reviewer/references/sprint_contract_protocol.md` (the v3.6.2 reviewer pattern) but adapts it for single-agent generator modes that have no panel and (for the writer) no scoring_plan.
+
+The load-bearing mechanism is the **physical separation of calls**: writer Phase 4a never sees the runtime drafting artefacts; evaluator Phase 6a never sees the writer Phase 4b draft. This destroys the "read the paper, then rationalise the standard" drift path on the in-pair self-quality gate.
+
+### Four-call structure
+
+For each `academic-paper full` invocation, Phase 4 + Phase 6 expand from two single calls into four separate model calls. Each call has its own system prompt and user content per the system-vs-user content discipline below.
+
+1. **Phase 4a — writer paper-blind pre-commitment.**
+   - System prompt: `### Phase 4a — Writer paper-blind pre-commitment` sub-section in `academic-paper/agents/draft_writer_agent.md` § "v3.6.6 Generator-Evaluator Contract Protocol".
+   - User content: `writer_full` contract JSON + paper metadata only (`title`, `field`, `word_count`).
+   - Output: `## Acceptance Criteria Paraphrase` section + terminal `[PRE-COMMITMENT-ACKNOWLEDGED]` tag.
+   - Lint: 3 structural checks (see § "Phase 4a / 6a output lint" below).
+2. **Phase 4b — writer paper-visible drafting + self-scoring.**
+   - System prompt: `### Phase 4b — Writer paper-visible drafting + self-scoring` sub-section in the same agent file.
+   - User content: `writer_full` contract JSON (re-injected) + Phase 4a output wrapped in `<phase4a_output>...</phase4a_output>` data delimiter + upstream drafting artefacts (Paper Configuration Record, Paper Outline, Argument Blueprint, Annotated Bibliography, optional Style Profile, optional Knowledge Isolation Directive).
+   - Output: `## Draft Body` → `## Dimension Scores` → `## Failure Condition Checks` → `## Writer Decision`.
+   - Lint: 4 structural checks (see § "Phase 4b / 6b output lint" below).
+3. **Phase 6a — evaluator paper-blind pre-commitment.**
+   - System prompt: `### Phase 6a — Evaluator paper-blind pre-commitment` sub-section in `academic-paper/agents/peer_reviewer_agent.md` § "v3.6.6 Generator-Evaluator Contract Protocol".
+   - User content: `evaluator_full` contract JSON + paper metadata + the writer's most recent `<phase4a_output>` (the writer artefact the evaluator must verify per `disagreement_handling.pre_commitment_check_protocol.check_writer_artifact`).
+   - Output: `## Contract Paraphrase` + `## Scoring Plan` (per-dimension `dimension_id` / `what_to_look_for` / `what_triggers_block` / `what_triggers_warn`) + terminal `[PRE-COMMITMENT-ACKNOWLEDGED]` tag.
+   - Lint: 5 structural checks.
+4. **Phase 6b — evaluator paper-visible scoring + decision.**
+   - System prompt: `### Phase 6b — Evaluator paper-visible scoring + decision` sub-section in the same agent file.
+   - User content: `evaluator_full` contract JSON (re-injected) + Phase 6a output wrapped in `<phase6a_output>...</phase6a_output>` + the writer's `<phase4a_output>` (unconditional per `pre_commitment_check_protocol.check_writer_artifact`) + the writer Phase 4b draft (the artefact under review).
+   - Output: `## Dimension Scores` → `## Failure Condition Checks` → `## Review Body` → `## Evaluator Decision`.
+   - Lint: 5 structural checks.
+
+### System prompt vs user content discipline
+
+Mirrors `sprint_contract_protocol.md` §2 reviewer pattern verbatim:
+
+- **System prompt carries invariant policy text only**: the phase sub-section instructions from the agent file's `## v3.6.6 Generator-Evaluator Contract Protocol` block, the lint description, and the phase-boundary tag conventions.
+- **User content carries the contract JSON (re-injected per call) plus the runtime inputs allowed at that phase**: paper metadata, `<phase4a_output>` / `<phase6a_output>` delimiter blocks, upstream drafting artefacts, the paper draft.
+
+All dynamic LLM output (Phase Na runtime emissions, paper content) lives in user content via data delimiters, never in the system prompt. This prevents accidental elevation of dynamic per-paper content into the invariant policy surface.
+
+### Schema field name vs runtime emission distinction
+
+`pre_commitment_artifacts` (snake_case, backticks) is the schema field name in `shared/sprint_contract.schema.json` — a configuration declaration in the frozen contract baseline. The "writer Phase 4a pre-commitment output" is the runtime emission — the actual Markdown text the writer agent emits in Phase 4a. The runtime emission lives inside `<phase4a_output>` and gets handed off to Phase 4b / Phase 6a / Phase 6b. Same pattern for `disagreement_handling` (schema field) vs "evaluator Phase 6a pre-commitment output" (runtime emission). Mixing the two leads to confusion between contract baseline configuration and LLM-generated content.
+
+### Phase 4a / 6a output lint
+
+Mode-specific structural check counts, per `sprint_contract_protocol.md` §4 enumeration convention:
+
+- **Writer Phase 4a (3 checks)**: required sections in order (`## Acceptance Criteria Paraphrase`, terminal `[PRE-COMMITMENT-ACKNOWLEDGED]`); paraphrase paragraph count ≥ `pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions`; Phase 4a content references contract JSON + paper metadata only. **No `## Scoring Plan` section** — `writer_full` carries no scoring_plan.
+- **Evaluator Phase 6a (5 checks)**: required sections in order (`## Contract Paraphrase`, `## Scoring Plan`, terminal `[PRE-COMMITMENT-ACKNOWLEDGED]`); paraphrase paragraph count ≥ `disagreement_handling.paraphrase_minimum_dimensions`; one `### <Dn>: <name>` subsection per acceptance dimension; each scoring_plan subsection contains `disagreement_handling.scoring_plan.per_dimension_criteria` four-field shape (`dimension_id`, `what_to_look_for`, `what_triggers_block`, `what_triggers_warn`); Phase 6a content references contract JSON + paper metadata + the writer's `<phase4a_output>` only (no full draft / paper content).
+
+Retry semantics: lint failure on the first attempt → retry once with the specific lint gap hinted in the system prompt; second failure → mark this role unusable per § "Single-agent generator unusable handling" below.
+
+### Phase 4b / 6b output lint
+
+- **Writer Phase 4b (4 checks)**: required sections in order — `## Draft Body`, `## Dimension Scores`, `## Failure Condition Checks`, `## Writer Decision`; Dimension Scores one-to-one across the seven writer dimensions D1–D7 (per `shared/contracts/writer/full.json`); Failure Condition Checks one-to-one across F1 / F4 / F2 / F3 / F0; Writer Decision derivable from F-condition severity precedence. **No multi-dissent retry** (writer has no scoring_plan to dissent against). **No consistency check** (writer Phase 4a emits no scoring_plan trigger tokens).
+- **Evaluator Phase 6b (5 checks)**: required sections in order — `## Dimension Scores`, `## Failure Condition Checks`, `## Review Body`, `## Evaluator Decision`; Dimension Scores one-to-one across the five evaluator dimensions D1–D5 (per `shared/contracts/evaluator/full.json`); Failure Condition Checks one-to-one across F1 / F2 / F3 / F6 / F4 / F5 / F0; consistency check (Phase 6b score substring-matches Phase 6a `disagreement_handling.scoring_plan.per_dimension_criteria` trigger tokens); Evaluator Decision derivable from F-condition severity precedence. **No multi-dissent retry** (evaluator's intra-phase disagreement is encoded as F-condition action via `disagreement_handling.disagreement_resolution`, not as a retry trigger).
+
+Multi-dissent retry remains reviewer-only (`academic-paper-reviewer` skill); generator modes have no panel and no scoring_plan dissent anchor.
+
+Lint count summary across the three modes:
+
+| Phase | Reviewer (zero-touch) | Writer | Evaluator |
+|---|---|---|---|
+| Phase 1 / 4a / 6a | 5 | 3 | 5 |
+| Phase 2 / 4b / 6b | 6 | 4 | 5 |
+
+### Single-agent generator unusable handling
+
+When a writer or evaluator phase becomes unusable (Phase Na lint twice fail OR Phase Nb lint fail), `academic-paper` emits a phase-level abort tag and routes to user intervention:
+
+- **Writer Phase 4 unusable** → `[GENERATOR-PHASE-ABORTED: role=writer, contract=<id>, reason=<lint_failure_kind>]` → abort `academic-paper` Phase 4 → user intervention decides retry / fallback / regression to Phase 3 (Argument Blueprint).
+- **Evaluator Phase 6 unusable** → `[GENERATOR-PHASE-ABORTED: role=evaluator, contract=<id>, reason=<lint_failure_kind>]` → abort `academic-paper` Phase 6 → user intervention decides retry / fallback / regression to Phase 5 (Drafting completion).
+
+`[GENERATOR-PHASE-ABORTED]` does **not** constitute a valid Phase 6b emission and cannot enter Stage 3 reviewer dispatch. Two valid Stage 3 entry paths exist (per design doc §5.1):
+
+- **Standard path**: evaluator Phase 6b emits F0 `evaluator_decision=accept` or F4 `evaluator_decision=accept_with_dissent_note`.
+- **Exceptional path**: evaluator Phase 6b emits F5 `evaluator_decision=flag_for_reviewer_stage` after the in-pair revision loop exhausts at round 2 with mandatory-dimension block recurring.
+
+`academic-paper` carries no panel cardinality invariant for writer / evaluator (no `panel_size` field — Schema 13.1 §3.3.5 reviewer-conditional). There is no `[PANEL-SHRUNK]` analogue at the generator side; `[GENERATOR-PHASE-ABORTED]` is phase-level abort.
+
+**Operational monitor**: track `[GENERATOR-PHASE-ABORTED]` rate over the first three months of v3.6.6 deployment. The denominator is **per `academic-paper full` run** — one user-perceived top-level invocation. The 5% threshold is `(runs_with_any_abort) / (total_runs)`. If the rate exceeds 5%, v3.6.7 introduces graceful-degradation fallback (see § "Known limitations" below).
+
+### Cross-session resume scope
+
+The v3.6.6 generator-evaluator round (Phase 4a + Phase 4b + Phase 6a + Phase 6b + in-pair revision loop) is an **in-session atomic unit**. Manual session split mid-round → writer Phase 4a output is lost; new session must restart `academic-paper full` mode from Phase 0.
+
+The v3.6.3 `ARS_PASSPORT_RESET=1` `reset_boundary[]` mechanism (per `academic-pipeline/references/passport_as_reset_boundary.md`) operates at `academic-pipeline` Stage boundaries, not at `academic-paper` internal phase boundaries. `academic-paper` internal phases (4a / 4b / 6a / 6b) are **not** boundary points; no `kind: boundary` ledger entry is emitted between them. v3.6.7+ may introduce `pre_commitment_history[]` to persist writer Phase 4a artefacts across sessions if operational data warrants — see § "Known limitations" below.
+
+## Known limitations
+
+- **No graceful-degradation fallback in v3.6.6**: when the writer or evaluator phase aborts via `[GENERATOR-PHASE-ABORTED]`, `academic-paper full` aborts and routes to user intervention. v3.6.7 may introduce a fallback that degrades the affected phase to v3.6.5 single-call behaviour and logs the degradation. v3.6.6 ships with abort-only behaviour. See § "Single-agent generator unusable handling" above for the operational 5% / three-month monitor.
+- **No cross-session resume mid-round**: the four-phase generator-evaluator round is an in-session atomic unit. Manual session split mid-round loses the writer Phase 4a artefact and forces restart from Phase 0. v3.6.7+ may introduce a `pre_commitment_history[]` ledger entry in Schema 9 to persist the writer Phase 4a artefact across session boundaries; v3.6.6 does not implement.
+- **In-pair Phase 6 evaluator vs `academic-paper-reviewer` external review**: the in-pair `peer_reviewer_agent` (Phase 6 evaluator with the v3.6.6 contract gate) and the standalone `academic-paper-reviewer` skill (Stage 3 5-panel external editorial review) serve different review layers and remain documented as known technical debt per design doc §1 known limitations. Routing / merge decisions are deferred to v3.7.x.
+
 ## Operational Modes (10 Modes)
 
 See `references/mode_selection_guide.md` for details.

--- a/academic-paper/agents/draft_writer_agent.md
+++ b/academic-paper/agents/draft_writer_agent.md
@@ -422,3 +422,50 @@ Quality gate not passed ->
 - Transitions connect every section pair
 - Register is consistent throughout
 - If revision round: all Critical and Major items addressed
+
+## v3.6.6 Generator-Evaluator Contract Protocol
+
+> Authoritative system-prompt sub-sections for the v3.6.6 writer half of the contract-gated phase split. Used by `academic-paper full` mode only. Pinned by the orchestrator block in `academic-paper/SKILL.md` § "v3.6.6 Generator-Evaluator Contract Protocol". Schema 13.1 contract template: `shared/contracts/writer/full.json`. Design spec: `docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md` §5.
+
+This block contains the exact text that becomes the **system prompt** for Phase 4a and Phase 4b model calls. The orchestrator MUST NOT mutate the sub-section text; it must include the relevant sub-section verbatim in the system prompt for the corresponding call. User content is supplied per the SKILL.md block's "System prompt vs user content discipline" — the orchestrator places contract JSON, paper metadata, `<phase4a_output>` data delimiter blocks, and upstream artefacts into user content, never into the system prompt.
+
+### Phase 4a — Writer paper-blind pre-commitment
+
+You are the writer agent in `academic-paper full` mode under the v3.6.6 generator-evaluator contract gate. This is your Phase 4a paper-blind pre-commitment turn. You have NOT yet seen any drafting artefacts (no Paper Outline, no Argument Blueprint, no Annotated Bibliography). You see only:
+
+- The `writer_full` contract JSON (your acceptance criteria as defined in `shared/contracts/writer/full.json`).
+- Paper metadata: `title`, `field`, `word_count`.
+
+Your task is to commit, in writing, what acceptance criteria you intend to honour during the upcoming Phase 4b drafting call. You are NOT drafting the paper in this turn.
+
+**Required output sections in order**:
+
+1. `## Acceptance Criteria Paraphrase` — paraphrase, in your own words, at least N of the contract's acceptance dimensions, where N = `pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions` (which is "all" in the shipped writer template, meaning all seven D1–D7). For each paraphrased dimension, write one paragraph headed `### <Dn>: <name>` (e.g., `### D1: section_completeness`) restating what the dimension requires in language a Phase 4b drafter can act on.
+2. Terminal `[PRE-COMMITMENT-ACKNOWLEDGED]` tag on its own line as the very last line of your output.
+
+**Lint constraints (3 checks)**: required sections in order; paraphrase paragraph count ≥ minimum_dimensions; output content references contract JSON + paper metadata only (no draft content, no upstream artefacts — those arrive only in Phase 4b).
+
+**No `## Scoring Plan` section**: writer_full carries no `scoring_plan` field; the writer's commitment is to acceptance dimensions only, not to a numeric scoring plan.
+
+**Retry**: if your output fails Phase 4a lint, you will be retried once with the specific lint gap hinted in the next system prompt. Second failure marks Phase 4 unusable and emits `[GENERATOR-PHASE-ABORTED: role=writer, contract=<id>, reason=phase4a_lint_failed]`.
+
+### Phase 4b — Writer paper-visible drafting + self-scoring
+
+You are the writer agent in `academic-paper full` mode under the v3.6.6 generator-evaluator contract gate. This is your Phase 4b paper-visible drafting turn. You see:
+
+- The `writer_full` contract JSON (re-injected — same baseline as Phase 4a).
+- Your own Phase 4a output, wrapped in `<phase4a_output>...</phase4a_output>` delimiters.
+- Upstream drafting artefacts: Paper Configuration Record, Paper Outline, Argument Blueprint, Annotated Bibliography, optional Style Profile, optional Knowledge Isolation Directive.
+
+Your task is to write the complete paper draft, then self-score it against your Phase 4a pre-commitments using the contract's `failure_conditions[]`.
+
+**Required output sections in this order** (4 lint checks):
+
+1. `## Draft Body` — the complete paper text, following the Paper Outline section structure and the Argument Blueprint's CER chains. Per-section word counts must respect the Paper Configuration Record (per dimension D5). Total draft word count must stay within ±10% of the overall target (per dimension D4). Every factual claim cites at least one source from the Annotated Bibliography (per dimension D2).
+2. `## Dimension Scores` — one `### <Dn>: <name>` subsection per writer dimension D1–D7 (seven subsections). Each subsection assigns one of `block` / `warn` / `pass` and one paragraph of evidence. The seven dimensions are exactly those declared in `shared/contracts/writer/full.json` (D1 section_completeness, D2 citation_density, D3 argument_blueprint_fidelity, D4 total_word_count, D5 per_section_word_count, D6 acknowledged_limitations, D7 register_consistency).
+3. `## Failure Condition Checks` — one `### <Fn>` subsection per F-condition F1 / F4 / F2 / F3 / F0 (five subsections, severity-ordered). Each subsection states whether the condition fired (`fired` / `did not fire`) and, if fired, the dimensions involved.
+4. `## Writer Decision` — exactly one `writer_decision=accept` / `writer_decision=revise_in_phase_4b` / `writer_decision=escalate_to_evaluator` value, derived from F-condition severity precedence (highest-severity fired condition wins; F0 is the accept-grade baseline).
+
+**No multi-dissent retry, no consistency check** — writer has no scoring_plan to dissent against, and Phase 4a emits no scoring trigger tokens to substring-match.
+
+**Retry**: if your output fails Phase 4b lint, Phase 4 is marked unusable and emits `[GENERATOR-PHASE-ABORTED: role=writer, contract=<id>, reason=phase4b_lint_failed]`. No retry-once for Phase 4b — generator modes have no scoring-plan dissent mechanism to anchor a second attempt.

--- a/academic-paper/agents/peer_reviewer_agent.md
+++ b/academic-paper/agents/peer_reviewer_agent.md
@@ -521,3 +521,60 @@ Quality gate not passed ->
 - Revision instructions are specific enough for the Draft Writer to act on
 - Max 2 revision rounds enforced
 - Re-review focuses only on previously flagged items + new issues from revisions
+
+## v3.6.6 Generator-Evaluator Contract Protocol
+
+> Authoritative system-prompt sub-sections for the v3.6.6 evaluator half of the contract-gated phase split. Used by `academic-paper full` mode only. Pinned by the orchestrator block in `academic-paper/SKILL.md` § "v3.6.6 Generator-Evaluator Contract Protocol". Schema 13.1 contract template: `shared/contracts/evaluator/full.json`. Design spec: `docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md` §5.
+>
+> **`peer_reviewer_agent` is the in-pair `academic-paper` Phase 6 evaluator** (the writer's self-quality floor before handoff out of `academic-paper`). It is **not** the v3.6.2 sprint contract reviewer (the standalone `academic-paper-reviewer` skill that runs Stage 3 5-panel external editorial review). Both layers run in `academic-pipeline full` deployments; the v3.6.6 contract gate operates on this in-pair Phase 6 evaluator only.
+
+This block contains the exact text that becomes the **system prompt** for Phase 6a and Phase 6b model calls. The orchestrator MUST NOT mutate the sub-section text; it must include the relevant sub-section verbatim in the system prompt for the corresponding call. User content placement follows the SKILL.md block's "System prompt vs user content discipline".
+
+### Phase 6a — Evaluator paper-blind pre-commitment
+
+You are the in-pair evaluator agent in `academic-paper full` mode under the v3.6.6 generator-evaluator contract gate. This is your Phase 6a paper-blind pre-commitment turn. You have NOT yet seen the writer's Phase 4b draft. You see only:
+
+- The `evaluator_full` contract JSON (your acceptance criteria as defined in `shared/contracts/evaluator/full.json`).
+- Paper metadata: `title`, `field`, `word_count`.
+- The writer's most recent `<phase4a_output>...</phase4a_output>` (the writer's pre-commitment paraphrase you must verify per `disagreement_handling.pre_commitment_check_protocol.check_writer_artifact`).
+
+Your task is to commit, in writing, the contract paraphrase + scoring plan you intend to apply during the upcoming Phase 6b paper-visible evaluation call. You are NOT scoring the draft in this turn (you have not seen the draft yet).
+
+**Required output sections in order**:
+
+1. `## Contract Paraphrase` — paraphrase, in your own words, at least N of the contract's acceptance dimensions, where N = `disagreement_handling.paraphrase_minimum_dimensions` (which is "all" in the shipped evaluator template, meaning all five D1–D5). For each paraphrased dimension, write one paragraph headed `### <Dn>: <name>` (e.g., `### D2: methodological_rigor`).
+2. `## Scoring Plan` — for each acceptance dimension, write a `### <Dn>: <name>` subsection. Each subsection MUST contain four lines matching `disagreement_handling.scoring_plan.per_dimension_criteria` four-field shape:
+   - `dimension_id: <Dn>`
+   - `what_to_look_for: <one-sentence anchor describing what evidence in the paper indicates this dimension passes>`
+   - `what_triggers_block: <one-sentence anchor describing what evidence triggers a block score on this dimension>`
+   - `what_triggers_warn: <one-sentence anchor describing what evidence triggers a warn score on this dimension>`
+3. Terminal `[PRE-COMMITMENT-ACKNOWLEDGED]` tag on its own line as the very last line of your output.
+
+**Lint constraints (5 checks)**: required sections in order; paraphrase paragraph count ≥ minimum_dimensions; one `### <Dn>: <name>` subsection per acceptance dimension in both Contract Paraphrase + Scoring Plan; each Scoring Plan subsection contains the four-field shape; output content references contract JSON + paper metadata + writer `<phase4a_output>` only (no full draft / paper content — those arrive only in Phase 6b).
+
+**Retry**: if your output fails Phase 6a lint, you will be retried once with the specific lint gap hinted in the next system prompt. Second failure marks Phase 6 unusable and emits `[GENERATOR-PHASE-ABORTED: role=evaluator, contract=<id>, reason=phase6a_lint_failed]`.
+
+### Phase 6b — Evaluator paper-visible scoring + decision
+
+You are the in-pair evaluator agent in `academic-paper full` mode under the v3.6.6 generator-evaluator contract gate. This is your Phase 6b paper-visible evaluation turn. You see:
+
+- The `evaluator_full` contract JSON (re-injected — same baseline as Phase 6a).
+- Your own Phase 6a output, wrapped in `<phase6a_output>...</phase6a_output>` delimiters.
+- The writer's `<phase4a_output>...</phase4a_output>` delimiter block (unconditional per `pre_commitment_check_protocol.check_writer_artifact`).
+- The writer Phase 4b draft (the artefact under review).
+
+Your task is to score the writer's draft against your Phase 6a pre-committed scoring plan, check failure conditions, write the review body, and emit the evaluator decision.
+
+**Required output sections in this order** (5 lint checks):
+
+1. `## Dimension Scores` — one `### <Dn>: <name>` subsection per evaluator dimension D1–D5 (five subsections). Each subsection assigns one of `block` / `warn` / `pass` and one paragraph of evidence drawn from the draft. Score language MUST substring-match the trigger tokens you committed in your Phase 6a `## Scoring Plan` `what_triggers_block` / `what_triggers_warn` anchors (this is the consistency check enforced by Phase 6b lint).
+2. `## Failure Condition Checks` — one `### <Fn>` subsection per F-condition F1 / F2 / F3 / F6 / F4 / F5 / F0 (seven subsections, severity-ordered). Each subsection states whether the condition fired and the dimensions involved.
+3. `## Review Body` — substantive editorial review explaining the scores and the F-conditions that fired. This is a discrete section after Failure Condition Checks (mirrors reviewer Phase 2 ordering).
+4. `## Evaluator Decision` — exactly one `evaluator_decision=accept` / `evaluator_decision=accept_with_dissent_note` / `evaluator_decision=request_revision` / `evaluator_decision=flag_for_reviewer_stage` value, derived from F-condition severity precedence. F5 (`flag_for_reviewer_stage`) fires only if the in-pair revision loop has exhausted at round 2 with mandatory-dimension block recurring.
+5. (Lint check #5 is structural: Evaluator Decision MUST be derivable from the highest-severity F-condition that fired in §2 above; orchestrator audits this derivation.)
+
+**No multi-dissent retry**: evaluator's intra-phase disagreement is encoded as F-condition action via `disagreement_handling.disagreement_resolution.on_dimension_disagreement` (default: `evaluator_decision=request_revision` for mandatory; runtime may downgrade non-mandatory to `accept_with_dissent_note` per F4) and `on_structural_drift` (per `evaluator_full.json` F6). These are F-condition outputs, not retry triggers.
+
+**Retry**: if your output fails Phase 6b lint, Phase 6 is marked unusable and emits `[GENERATOR-PHASE-ABORTED: role=evaluator, contract=<id>, reason=phase6b_lint_failed]`. No retry-once for Phase 6b.
+
+**Stage 3 entry paths**: `evaluator_decision=accept` (F0) and `evaluator_decision=accept_with_dissent_note` (F4) are standard Stage 3 entry paths (the in-pair gate cleared, the draft hands off to the external `academic-paper-reviewer` skill for the 5-panel editorial review). `evaluator_decision=flag_for_reviewer_stage` (F5) is the exceptional Stage 3 entry path used when the in-pair gate could not resolve the issue. `[GENERATOR-PHASE-ABORTED]` is NOT a Stage 3 entry path.

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.6.7"
-  last_updated: "2026-04-30"
+  version: "3.6.8"
+  last_updated: "2026-05-03"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.6.7 (2026-04-30)")
+    expect_contains(rel_path, "Last updated: v3.6.8 (2026-05-03)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.6.7")
+    expect_contains(rel_path, "**Suite version**: 3.6.8")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.6.7-blue")
-    expect_contains(rel_path, "releases/tag/v3.6.7")
+    expect_contains(rel_path, "version-v3.6.8-blue")
+    expect_contains(rel_path, "releases/tag/v3.6.8")
+    expect_contains(rel_path, "### v3.6.8 (2026-05-03)")
     expect_contains(rel_path, "### v3.6.7 (2026-04-30)")
     expect_contains(rel_path, "### v3.6.5 (2026-04-27)")
     expect_contains(rel_path, "### v3.6.4 (2026-04-25)")
@@ -201,8 +202,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.6.7-blue")
-    expect_contains(rel_path, "releases/tag/v3.6.7")
+    expect_contains(rel_path, "version-v3.6.8-blue")
+    expect_contains(rel_path, "releases/tag/v3.6.8")
+    expect_contains(rel_path, "### v3.6.8（2026-05-03）")
     expect_contains(rel_path, "### v3.6.7（2026-04-30）")
     expect_contains(rel_path, "### v3.6.5（2026-04-27）")
     expect_contains(rel_path, "### v3.6.4（2026-04-25）")

--- a/scripts/check_sprint_contract.py
+++ b/scripts/check_sprint_contract.py
@@ -137,16 +137,21 @@ def warn_suspicious(contract: dict, ars_current_version: str | None) -> list[str
 
     # SC-5 measurement_procedure.reviewer_must_output_before_paper missing required outputs.
     # Schema enforces minItems:2 but cannot constrain which specific strings are present;
-    # SC-5 covers that semantic gap. mp hoisted here for SC-9 (Task 11) reuse.
+    # SC-5 covers that semantic gap. Reviewer-only per v3.6.6 §7.1: writer / evaluator
+    # contracts intentionally omit measurement_procedure (§3.3.1 reviewer-conditional),
+    # so firing SC-5 on every clean generator template is noise. Hoist mp here too so SC-9
+    # below can also detect the reviewer-mode field path.
+    mode = contract.get("mode", "")
     mp = contract.get("measurement_procedure", {})
-    outputs = mp.get("reviewer_must_output_before_paper", [])
-    required_outputs = {"contract_paraphrase", "scoring_plan"}
-    missing = required_outputs - set(outputs)
-    if missing:
-        warnings.append(
-            f"SC-5 WARNING: hard-gate protocol requires both 'contract_paraphrase' "
-            f"and 'scoring_plan' in reviewer_must_output_before_paper; missing: {sorted(missing)}"
-        )
+    if mode.startswith("reviewer_"):
+        outputs = mp.get("reviewer_must_output_before_paper", [])
+        required_outputs = {"contract_paraphrase", "scoring_plan"}
+        missing = required_outputs - set(outputs)
+        if missing:
+            warnings.append(
+                f"SC-5 WARNING: hard-gate protocol requires both 'contract_paraphrase' "
+                f"and 'scoring_plan' in reviewer_must_output_before_paper; missing: {sorted(missing)}"
+            )
 
     # SC-7 conflicting failure-condition actions at same severity.
     # Skip entries with missing severity — schema validation catches those upstream.
@@ -164,12 +169,35 @@ def warn_suspicious(contract: dict, ars_current_version: str | None) -> list[str
                 "precedence tie-breaking falls back to ordinal position"
             )
 
-    # SC-9 impossible paraphrase_minimum_dimensions
-    pmd = mp.get("paraphrase_minimum_dimensions")
+    # SC-9 impossible paraphrase_minimum_dimensions.
+    # The paraphrase-count gate is mode-conditional per v3.6.6 §7.1: each mode reads its
+    # own field. Reviewer reads mp.paraphrase_minimum_dimensions; writer reads
+    # pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions;
+    # evaluator reads disagreement_handling.paraphrase_minimum_dimensions. The lint
+    # rule (paraphrase count must not exceed dimension count) is identical across
+    # all three modes — only the source field changes.
+    if mode.startswith("reviewer_"):
+        pmd = mp.get("paraphrase_minimum_dimensions")
+        pmd_source = "measurement_procedure.paraphrase_minimum_dimensions"
+        phase_label = "Phase 1"
+    elif mode == "writer_full":
+        pmd = (contract.get("pre_commitment_artifacts", {})
+               .get("acceptance_criteria_paraphrase", {})
+               .get("minimum_dimensions"))
+        pmd_source = "pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions"
+        phase_label = "Phase 4a"
+    elif mode == "evaluator_full":
+        pmd = contract.get("disagreement_handling", {}).get("paraphrase_minimum_dimensions")
+        pmd_source = "disagreement_handling.paraphrase_minimum_dimensions"
+        phase_label = "Phase 6a"
+    else:
+        pmd = None
+        pmd_source = None
+        phase_label = None
     if isinstance(pmd, int) and pmd > len(dims):
         warnings.append(
-            f"SC-9 WARNING: paraphrase_minimum_dimensions={pmd} exceeds dimension "
-            f"count {len(dims)}; Phase 1 lint will always fail"
+            f"SC-9 WARNING: {pmd_source}={pmd} exceeds dimension "
+            f"count {len(dims)}; {phase_label} lint will always fail"
         )
 
     # SC-10 unreferenced mandatory/high dimension.
@@ -202,20 +230,22 @@ def warn_suspicious(contract: dict, ars_current_version: str | None) -> list[str
             "its score cannot influence the editorial decision"
         )
 
-    # SC-11 panel_size sanity
-    ps = contract.get("panel_size")
-    mode = contract.get("mode")
-    if ps == 1:
-        warnings.append(
-            "SC-11 WARNING: panel_size=1 means no cross-reviewer aggregation; "
-            "cross_reviewer_quantifier values collapse to pass-through"
-        )
-    expected_panel = {"reviewer_full": 5, "reviewer_methodology_focus": 2}
-    if mode in expected_panel and ps != expected_panel[mode]:
-        warnings.append(
-            f"SC-11 WARNING: panel_size={ps} inconsistent with mode={mode}; "
-            f"expected {expected_panel[mode]}"
-        )
+    # SC-11 panel_size sanity. Reviewer-only per v3.6.6 §7.1: writer / evaluator
+    # contracts intentionally omit panel_size (§3.3.5 reviewer-conditional). Each runs a
+    # single agent so panel cardinality has no semantic anchor in those modes.
+    if mode.startswith("reviewer_"):
+        ps = contract.get("panel_size")
+        if ps == 1:
+            warnings.append(
+                "SC-11 WARNING: panel_size=1 means no cross-reviewer aggregation; "
+                "cross_reviewer_quantifier values collapse to pass-through"
+            )
+        expected_panel = {"reviewer_full": 5, "reviewer_methodology_focus": 2}
+        if mode in expected_panel and ps != expected_panel[mode]:
+            warnings.append(
+                f"SC-11 WARNING: panel_size={ps} inconsistent with mode={mode}; "
+                f"expected {expected_panel[mode]}"
+            )
 
     return warnings
 
@@ -257,7 +287,7 @@ def main() -> int:
     for w in warn_suspicious(contract, args.ars_version):
         print(w, file=sys.stderr)
 
-    print(f"OK: {args.contract} is a valid sprint_contract (Schema 13)")
+    print(f"OK: {args.contract} is a valid sprint_contract (Schema 13.1)")
     return 0
 
 

--- a/scripts/check_v3_6_6_ab_manifest.py
+++ b/scripts/check_v3_6_6_ab_manifest.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Enforce the v3.6.6 A/B evidence fixture manifest contract per §6.2 schema +
+§6.5 git-tracked invariants per design doc 2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md.
+
+Three rule families per spec body §7.5:
+
+1. Schema-shape checks: top-level fields exist with declared types;
+   per-paper required fields present; paper-A vs paper-C asymmetric rules.
+
+2. Path-existence checks (mode-conditional + populated-optional):
+   - Required-paths-exist: every required-under-current-mode path declared in
+     the manifest must exist git-tracked.
+   - Declared-paths-exist: any populated optional path must also exist.
+   - Reverse-scan: every git-tracked file under tests/fixtures/v3.6.6-ab/
+     must be referenced from the manifest (no orphans).
+
+3. Behaviour on malformed input: exit 1 with parse-error message
+   identifying the file (mirrors check_sprint_contract.py convention).
+
+Exit code: 0 on pass, 1 on any rule violation. CLI: `--root <path>` (default `.`).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+FIXTURE_DIR = "tests/fixtures/v3.6.6-ab"
+MANIFEST_RELPATH = "manifest.yaml"
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+LINT_MODES = {"spec_branch", "implementation_pr"}
+PAPER_ROLES = {"paper-A", "paper-C"}
+INPUT_ARTEFACT_FIELDS = {
+    "paper_configuration_record",
+    "paper_outline",
+    "argument_blueprint",
+    "annotated_bibliography",
+    "style_profile",
+    "knowledge_isolation_directive",
+}
+TREATMENT_SUBFIELDS = {
+    "phase4a_output",
+    "phase4b_output",
+    "phase6a_output",
+    "phase6b_output",
+}
+
+
+def _load_manifest(manifest_path: Path) -> dict | None:
+    """Load YAML manifest. Return parsed dict, or None on parse failure
+    (caller emits the parse error)."""
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (FileNotFoundError, yaml.YAMLError) as exc:
+        print(
+            f"ERROR: failed to load manifest at {manifest_path}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        print(
+            f"ERROR: manifest at {manifest_path} is not a top-level YAML mapping "
+            f"(got {type(data).__name__})",
+            file=sys.stderr,
+        )
+        return None
+    return data
+
+
+def _check_schema_shape(manifest: dict) -> list[str]:
+    """Schema-shape checks per §6.2 + §7.5. Returns list of error messages."""
+    errors: list[str] = []
+
+    # Top-level required fields
+    fixture_version = manifest.get("fixture_version")
+    if not isinstance(fixture_version, str) or not SEMVER_RE.match(fixture_version):
+        errors.append(
+            f"fixture_version must match semver regex {SEMVER_RE.pattern}; "
+            f"got {fixture_version!r}"
+        )
+    mode = manifest.get("manifest_lint_mode")
+    if mode not in LINT_MODES:
+        errors.append(
+            f"manifest_lint_mode must be one of {sorted(LINT_MODES)}; got {mode!r}"
+        )
+    docs = manifest.get("documentation_paths")
+    if not isinstance(docs, list) or len(docs) == 0:
+        errors.append(
+            "documentation_paths must be a non-empty array (must contain at least the spec-PR-shipped README.md)"
+        )
+    elif not all(isinstance(p, str) for p in docs):
+        errors.append("documentation_paths entries must all be strings (relative paths)")
+    papers = manifest.get("papers")
+    if not isinstance(papers, list):
+        errors.append("papers must be an array")
+        return errors  # cannot continue per-paper checks
+    if len(papers) != 7:
+        errors.append(f"papers must contain exactly 7 entries; got {len(papers)}")
+
+    # summary_output type check (mode-conditional requirement handled in path-existence)
+    summary_output = manifest.get("summary_output")
+    if summary_output is not None and not isinstance(summary_output, str):
+        errors.append(
+            f"summary_output (when present) must be a string relative path; got {type(summary_output).__name__}"
+        )
+    if mode == "implementation_pr" and summary_output is None:
+        errors.append("summary_output is required under manifest_lint_mode=implementation_pr")
+
+    # Per-paper checks
+    paper_a_count = 0
+    paper_c_count = 0
+    paper_a_types: dict[str, int] = {}
+    seen_paper_ids: set[str] = set()
+    for i, p in enumerate(papers):
+        if not isinstance(p, dict):
+            errors.append(f"papers[{i}] must be an object")
+            continue
+        ctx = f"papers[{i}]"
+        # paper_id
+        pid = p.get("paper_id")
+        if not isinstance(pid, str) or not pid:
+            errors.append(f"{ctx}.paper_id must be a non-empty string slug")
+        else:
+            if pid in seen_paper_ids:
+                errors.append(f"{ctx}.paper_id={pid!r} is not unique across papers[]")
+            seen_paper_ids.add(pid)
+            ctx = f"papers[{pid}]"
+        # role
+        role = p.get("role")
+        if role not in PAPER_ROLES:
+            errors.append(f"{ctx}.role must be one of {sorted(PAPER_ROLES)}; got {role!r}")
+        elif role == "paper-A":
+            paper_a_count += 1
+        elif role == "paper-C":
+            paper_c_count += 1
+        # paper_type + topic_label required strings
+        for field in ("paper_type", "topic_label"):
+            val = p.get(field)
+            if not isinstance(val, str) or not val:
+                errors.append(f"{ctx}.{field} must be a non-empty string")
+        if role == "paper-A":
+            pt = p.get("paper_type")
+            if isinstance(pt, str):
+                paper_a_types[pt] = paper_a_types.get(pt, 0) + 1
+        # input_artefacts
+        ia = p.get("input_artefacts")
+        if not isinstance(ia, dict) or not any(
+            ia.get(f) for f in INPUT_ARTEFACT_FIELDS
+        ):
+            errors.append(
+                f"{ctx}.input_artefacts must be an object with at least one populated sub-field "
+                f"from {sorted(INPUT_ARTEFACT_FIELDS)}"
+            )
+        elif not all(
+            isinstance(v, str) and v for k, v in ia.items() if k in INPUT_ARTEFACT_FIELDS
+        ):
+            errors.append(
+                f"{ctx}.input_artefacts populated sub-fields must be non-empty string paths"
+            )
+        # baseline_output (object with two required sub-fields, both string paths)
+        bo = p.get("baseline_output")
+        if not isinstance(bo, dict):
+            errors.append(f"{ctx}.baseline_output must be an object")
+        else:
+            for sub in ("writer_draft", "evaluator_review"):
+                v = bo.get(sub)
+                if not isinstance(v, str) or not v:
+                    errors.append(
+                        f"{ctx}.baseline_output.{sub} must be a non-empty string path"
+                    )
+        # treatment_output (object with four sub-fields when present)
+        to = p.get("treatment_output")
+        if to is not None:
+            if not isinstance(to, dict):
+                errors.append(f"{ctx}.treatment_output (when present) must be an object")
+            else:
+                for sub in TREATMENT_SUBFIELDS:
+                    v = to.get(sub)
+                    if v is not None and (not isinstance(v, str) or not v):
+                        errors.append(
+                            f"{ctx}.treatment_output.{sub} (when present) must be a non-empty string path"
+                        )
+                # implementation_pr mode: all four sub-fields required
+                if mode == "implementation_pr":
+                    for sub in TREATMENT_SUBFIELDS:
+                        if to.get(sub) is None:
+                            errors.append(
+                                f"{ctx}.treatment_output.{sub} is required under manifest_lint_mode=implementation_pr"
+                            )
+        elif mode == "implementation_pr":
+            errors.append(
+                f"{ctx}.treatment_output (object with phase4a/4b/6a/6b sub-fields) is required under manifest_lint_mode=implementation_pr"
+            )
+        # role-conditional fields
+        if role == "paper-A":
+            judge_baseline = p.get("judge_output_baseline")
+            if not isinstance(judge_baseline, str) or not judge_baseline:
+                errors.append(
+                    f"{ctx}.judge_output_baseline is required for paper-A entries (non-empty string path)"
+                )
+            judge_treatment = p.get("judge_output_treatment")
+            if mode == "implementation_pr":
+                if not isinstance(judge_treatment, str) or not judge_treatment:
+                    errors.append(
+                        f"{ctx}.judge_output_treatment is required for paper-A entries under manifest_lint_mode=implementation_pr"
+                    )
+            elif judge_treatment is not None and (
+                not isinstance(judge_treatment, str) or not judge_treatment
+            ):
+                errors.append(
+                    f"{ctx}.judge_output_treatment (when present) must be a non-empty string path"
+                )
+            metrics_output = p.get("metrics_output")
+            if mode == "implementation_pr":
+                if not isinstance(metrics_output, str) or not metrics_output:
+                    errors.append(
+                        f"{ctx}.metrics_output is required for paper-A entries under manifest_lint_mode=implementation_pr"
+                    )
+            elif metrics_output is not None and (
+                not isinstance(metrics_output, str) or not metrics_output
+            ):
+                errors.append(
+                    f"{ctx}.metrics_output (when present) must be a non-empty string path"
+                )
+        elif role == "paper-C":
+            # paper-C must-not-have rules
+            for forbidden in ("judge_output_baseline", "judge_output_treatment", "metrics_output"):
+                if forbidden in p:
+                    errors.append(
+                        f"{ctx}.{forbidden} must NOT be present on paper-C entries (paper-C is categorical and exempt from codex H1/H3 judge + per-paper metrics)"
+                    )
+            # paper-C must-have rules
+            kfm = p.get("known_failure_mode")
+            if not isinstance(kfm, str) or not kfm:
+                errors.append(f"{ctx}.known_failure_mode is required for paper-C entries (non-empty string)")
+            fe = p.get("failure_evidence")
+            if not isinstance(fe, str) or not fe:
+                errors.append(f"{ctx}.failure_evidence is required for paper-C entries (non-empty string path)")
+
+    # Aggregate role + paper-type counts
+    if paper_a_count != 6:
+        errors.append(f"len([p for p in papers if p.role == 'paper-A']) must == 6; got {paper_a_count}")
+    if paper_c_count != 1:
+        errors.append(f"len([p for p in papers if p.role == 'paper-C']) must == 1; got {paper_c_count}")
+    if len(paper_a_types) != 3:
+        errors.append(
+            f"paper-A entries must span exactly 3 paper_type families; got {sorted(paper_a_types)}"
+        )
+    for pt, count in paper_a_types.items():
+        if count != 2:
+            errors.append(
+                f"paper-A paper_type={pt!r} must appear exactly twice; got {count}"
+            )
+
+    return errors
+
+
+def _collect_declared_paths(manifest: dict) -> set[str]:
+    """All paths declared in the manifest. Used for both required + reverse-scan."""
+    declared: set[str] = set()
+    for p in manifest.get("documentation_paths", []) or []:
+        if isinstance(p, str):
+            declared.add(p)
+    summary = manifest.get("summary_output")
+    if isinstance(summary, str):
+        declared.add(summary)
+    for paper in manifest.get("papers", []) or []:
+        if not isinstance(paper, dict):
+            continue
+        ia = paper.get("input_artefacts") or {}
+        if isinstance(ia, dict):
+            for k, v in ia.items():
+                if k in INPUT_ARTEFACT_FIELDS and isinstance(v, str):
+                    declared.add(v)
+        bo = paper.get("baseline_output") or {}
+        if isinstance(bo, dict):
+            for sub in ("writer_draft", "evaluator_review"):
+                v = bo.get(sub)
+                if isinstance(v, str):
+                    declared.add(v)
+        to = paper.get("treatment_output") or {}
+        if isinstance(to, dict):
+            for sub in TREATMENT_SUBFIELDS:
+                v = to.get(sub)
+                if isinstance(v, str):
+                    declared.add(v)
+        for field in ("judge_output_baseline", "judge_output_treatment", "metrics_output", "failure_evidence"):
+            v = paper.get(field)
+            if isinstance(v, str):
+                declared.add(v)
+    return declared
+
+
+def _check_path_existence(manifest: dict, fixture_root: Path) -> list[str]:
+    """Path-existence checks: every declared path must exist git-tracked.
+    Schema-shape already enforced mode-conditional required-vs-optional;
+    here we just check declared-paths-exist (which subsumes required-paths-exist
+    because all required paths are declared)."""
+    errors: list[str] = []
+    declared = _collect_declared_paths(manifest)
+    for rel in sorted(declared):
+        full = fixture_root / rel
+        if not full.exists():
+            errors.append(f"declared path does not exist git-tracked: {rel}")
+    return errors
+
+
+def _check_reverse_scan(manifest: dict, fixture_root: Path) -> list[str]:
+    """Reverse-scan: every file under fixture_root (except manifest.yaml itself)
+    must be referenced from the manifest. Orphans fail lint."""
+    errors: list[str] = []
+    declared = _collect_declared_paths(manifest)
+    for path in sorted(fixture_root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(fixture_root))
+        if rel == MANIFEST_RELPATH:
+            continue
+        if rel not in declared:
+            errors.append(
+                f"fixture-orphan: {rel} is git-tracked under {fixture_root} "
+                f"but not referenced from manifest.yaml"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Repo root (default: cwd)",
+    )
+    args = parser.parse_args()
+
+    fixture_root = args.root / FIXTURE_DIR
+    manifest_path = fixture_root / MANIFEST_RELPATH
+
+    manifest = _load_manifest(manifest_path)
+    if manifest is None:
+        return 1
+
+    errors: list[str] = []
+    errors.extend(_check_schema_shape(manifest))
+    errors.extend(_check_path_existence(manifest, fixture_root))
+    errors.extend(_check_reverse_scan(manifest, fixture_root))
+
+    if errors:
+        print("v3.6.6 A/B fixture manifest lint FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {manifest_path} passes v3.6.6 A/B fixture manifest lint")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_sprint_contract.py
+++ b/scripts/test_check_sprint_contract.py
@@ -1,4 +1,4 @@
-"""Unit tests for check_sprint_contract.py (Schema 13 validator)."""
+"""Unit tests for check_sprint_contract.py (Schema 13.1 validator)."""
 from __future__ import annotations
 
 import json
@@ -9,13 +9,18 @@ from tempfile import TemporaryDirectory
 from scripts._test_helpers import run_script
 
 SCRIPT = Path(__file__).resolve().parent / "check_sprint_contract.py"
-# SCHEMA / TEMPLATE_FULL / TEMPLATE_METHOD reserved for Tasks 15-16 (shipped-template assertions).
 SCHEMA = Path(__file__).resolve().parent.parent / "shared" / "sprint_contract.schema.json"
 TEMPLATE_FULL = (
     Path(__file__).resolve().parent.parent / "shared" / "contracts" / "reviewer" / "full.json"
 )
 TEMPLATE_METHOD = (
     Path(__file__).resolve().parent.parent / "shared" / "contracts" / "reviewer" / "methodology_focus.json"
+)
+TEMPLATE_WRITER_FULL = (
+    Path(__file__).resolve().parent.parent / "shared" / "contracts" / "writer" / "full.json"
+)
+TEMPLATE_EVALUATOR_FULL = (
+    Path(__file__).resolve().parent.parent / "shared" / "contracts" / "evaluator" / "full.json"
 )
 
 
@@ -603,6 +608,180 @@ class TestTemplateSemantics(unittest.TestCase):
         winning = max(fired, key=lambda x: x[0])
         self.assertEqual(winning[1], "F1")
         self.assertEqual(winning[2], "editorial_decision=reject_or_major_revision")
+
+
+def _valid_writer_full_contract() -> dict:
+    """Returns a fresh valid writer_full contract, loaded from the shipped template
+    so structural drift between the test and the live template surfaces as a test
+    failure rather than test-only divergence."""
+    return _load_template(TEMPLATE_WRITER_FULL)
+
+
+def _valid_evaluator_full_contract() -> dict:
+    """Returns a fresh valid evaluator_full contract, loaded from the shipped
+    template (same rationale as _valid_writer_full_contract)."""
+    return _load_template(TEMPLATE_EVALUATOR_FULL)
+
+
+class TestSchema131WriterEvaluatorPositive(unittest.TestCase):
+    """§7.3 schema-level positive fixtures: shipped writer/evaluator templates
+    must validate cleanly under Schema 13.1 + produce zero soft warnings."""
+
+    def test_shipped_writer_full_passes_schema_and_invariants(self):
+        from scripts.check_sprint_contract import validate, check_structural_invariants
+        c = _valid_writer_full_contract()
+        self.assertEqual(validate(c), [])
+        self.assertEqual(check_structural_invariants(c), [])
+
+    def test_shipped_writer_full_produces_zero_soft_warnings(self):
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_writer_full_contract()
+        self.assertEqual(warn_suspicious(c, "v3.6.6"), [])
+
+    def test_shipped_evaluator_full_passes_schema_and_invariants(self):
+        from scripts.check_sprint_contract import validate, check_structural_invariants
+        c = _valid_evaluator_full_contract()
+        self.assertEqual(validate(c), [])
+        self.assertEqual(check_structural_invariants(c), [])
+
+    def test_shipped_evaluator_full_produces_zero_soft_warnings(self):
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_evaluator_full_contract()
+        self.assertEqual(warn_suspicious(c, "v3.6.6"), [])
+
+
+class TestSchema131NegativeBranches(unittest.TestCase):
+    """§7.3 schema-level negative fixtures exercising the five v3.6.6 schema
+    branches the validator hard-fails (branches 4 / 5 / 6 / 11 / 12 per §3.5).
+    Cross-mode field leakage (R1) is intentionally NOT tested as a hard-fail
+    here per §7.1 settled decision; v3.7.x not-clause hardening covers that.
+    """
+
+    def test_branch_11_writer_full_missing_pre_commitment_artifacts_fails(self):
+        from scripts.check_sprint_contract import validate
+        c = _valid_writer_full_contract()
+        del c["pre_commitment_artifacts"]
+        errors = validate(c)
+        self.assertTrue(any("pre_commitment_artifacts" in e for e in errors))
+
+    def test_branch_12_evaluator_full_missing_disagreement_handling_fails(self):
+        from scripts.check_sprint_contract import validate
+        c = _valid_evaluator_full_contract()
+        del c["disagreement_handling"]
+        errors = validate(c)
+        self.assertTrue(any("disagreement_handling" in e for e in errors))
+
+    def test_branch_5_writer_full_action_pinned_to_writer_decision_enum(self):
+        """writer_full pinning failure_conditions[].action to an editorial_decision=*
+        value (the reviewer enum) must fail under allOf branch 5 + branch 8 (F0)."""
+        from scripts.check_sprint_contract import validate
+        c = _valid_writer_full_contract()
+        for fc in c["failure_conditions"]:
+            if fc["condition_id"] == "F1":
+                fc["action"] = "editorial_decision=reject_or_major_revision"
+                break
+        errors = validate(c)
+        self.assertTrue(any("action" in e or "enum" in e.lower() for e in errors))
+
+    def test_branch_6_evaluator_full_action_pinned_to_evaluator_decision_enum(self):
+        """evaluator_full pinning failure_conditions[].action to a writer_decision=*
+        value must fail under allOf branch 6 + branch 9 (F0)."""
+        from scripts.check_sprint_contract import validate
+        c = _valid_evaluator_full_contract()
+        for fc in c["failure_conditions"]:
+            if fc["condition_id"] == "F1":
+                fc["action"] = "writer_decision=revise_in_phase_4b"
+                break
+        errors = validate(c)
+        self.assertTrue(any("action" in e or "enum" in e.lower() for e in errors))
+
+    def test_branch_4_reviewer_action_mis_pinned_to_generator_enum_fails(self):
+        """reviewer_full pinning failure_conditions[].action to a writer_decision=* /
+        evaluator_decision=* value must fail under allOf branch 4. Completes the
+        cross-mode action-enum triplet coverage."""
+        from scripts.check_sprint_contract import validate
+        c = _valid_reviewer_full_contract()
+        for fc in c["failure_conditions"]:
+            if fc["condition_id"] == "F1":
+                fc["action"] = "writer_decision=revise_in_phase_4b"
+                break
+        errors = validate(c)
+        self.assertTrue(any("action" in e or "enum" in e.lower() for e in errors))
+
+
+class TestSchema131ReviewerZeroTouch(unittest.TestCase):
+    """§3.6 backward-compat proof: existing reviewer contracts validate identically
+    under Schema 13.1. These two test names are explicitly committed by §3.6."""
+
+    def test_existing_reviewer_contracts_still_valid_under_13_1(self):
+        """Loads both shipped reviewer templates against Schema 13.1 and asserts
+        validation success without modification. §3.6 zero-touch verification."""
+        from scripts.check_sprint_contract import validate, check_structural_invariants
+        for path in (TEMPLATE_FULL, TEMPLATE_METHOD):
+            with self.subTest(template=path.name):
+                c = _load_template(path)
+                self.assertEqual(validate(c), [])
+                self.assertEqual(check_structural_invariants(c), [])
+
+    def test_byte_equivalent_validation_for_reviewer_contracts(self):
+        """Asserts that running validate() on each shipped reviewer template under
+        Schema 13.1 produces an empty error list — the structural equivalent of
+        diffing against the (now-superseded) Schema 13 result, which was also
+        empty for these templates. §3.6 promised this regression test."""
+        from scripts.check_sprint_contract import validate, warn_suspicious
+        for path in (TEMPLATE_FULL, TEMPLATE_METHOD):
+            with self.subTest(template=path.name):
+                c = _load_template(path)
+                self.assertEqual(validate(c), [])
+                self.assertEqual(warn_suspicious(c, "v3.6.6"), [])
+
+
+class TestSC5SC9SC11ModeGating(unittest.TestCase):
+    """§7.1 implementation requirement: SC-5 (measurement_procedure missing
+    canonical outputs), SC-9 (paraphrase_minimum_dimensions exceeds dim count),
+    and SC-11 (panel_size sanity) are reviewer-mode-specific. They must NOT
+    fire on clean writer/evaluator templates that intentionally omit the
+    reviewer-only fields per §3.3.1 / §3.3.5. Mode-agnostic warnings (SC-1 /
+    SC-2 / SC-3 / SC-4 / SC-7 / SC-10) continue to fire across all modes."""
+
+    def test_sc5_does_not_fire_on_writer_full(self):
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_writer_full_contract()
+        self.assertFalse(any("SC-5" in w for w in warn_suspicious(c, "v3.6.6")))
+
+    def test_sc5_does_not_fire_on_evaluator_full(self):
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_evaluator_full_contract()
+        self.assertFalse(any("SC-5" in w for w in warn_suspicious(c, "v3.6.6")))
+
+    def test_sc11_does_not_fire_on_writer_full(self):
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_writer_full_contract()
+        self.assertFalse(any("SC-11" in w for w in warn_suspicious(c, "v3.6.6")))
+
+    def test_sc11_does_not_fire_on_evaluator_full(self):
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_evaluator_full_contract()
+        self.assertFalse(any("SC-11" in w for w in warn_suspicious(c, "v3.6.6")))
+
+    def test_sc9_writer_full_reads_pre_commitment_artifacts_path(self):
+        """SC-9 for writer_full should read pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions
+        and fire when that integer exceeds dim count; not read measurement_procedure
+        (which writer_full does not carry)."""
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_writer_full_contract()
+        # 7 writer dimensions D1-D7 in shipped template; set minimum_dimensions to 99
+        c["pre_commitment_artifacts"]["acceptance_criteria_paraphrase"]["minimum_dimensions"] = 99
+        warnings = warn_suspicious(c, "v3.6.6")
+        self.assertTrue(any("SC-9" in w and "pre_commitment_artifacts" in w for w in warnings))
+
+    def test_sc9_evaluator_full_reads_disagreement_handling_path(self):
+        """SC-9 for evaluator_full should read disagreement_handling.paraphrase_minimum_dimensions."""
+        from scripts.check_sprint_contract import warn_suspicious
+        c = _valid_evaluator_full_contract()
+        c["disagreement_handling"]["paraphrase_minimum_dimensions"] = 99
+        warnings = warn_suspicious(c, "v3.6.6")
+        self.assertTrue(any("SC-9" in w and "disagreement_handling" in w for w in warnings))
 
 
 if __name__ == "__main__":

--- a/shared/contracts/README.md
+++ b/shared/contracts/README.md
@@ -12,23 +12,19 @@ Validator: `scripts/check_sprint_contract.py`.
 Spec: `docs/design/2026-04-23-ars-v3.6.2-sprint-contract-design.md`.
 Protocol: `academic-paper-reviewer/references/sprint_contract_protocol.md`.
 
-### Spec-branch status (v3.6.6 work in progress)
+### Shipped templates
 
-> **Active spec branch:** `spec/v3.6.6-generator-evaluator-contract` (not yet merged to `main`).
->
-> While that branch is active, the following directories carry **design-time artefacts** rather than live shipped templates:
->
-> - `writer/` — `writer_full` template, design-time only
-> - `evaluator/` — `evaluator_full` template, design-time only
->
-> Schema 13.1 has not yet landed in `shared/sprint_contract.schema.json`, so the current validator rejects these files by design (writer / evaluator modes not in the schema enum, `pre_commitment_artifacts` and `disagreement_handling` not yet declared, mode-specific action enums not yet expressible). Spec § 4.0 of `docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md` covers the full sequencing rationale and lists each expected validator error against its closing §3 schema change.
->
-> Do not load these files as live contracts on the spec branch. Once the v3.6.6 implementation PR merges to `main`, both directories become live atomically with the Schema 13.1 upgrade, this notice is removed, and they are documented under "Shipped templates" alongside `reviewer/`.
-
-### Shipped templates (v3.6.2)
+**v3.6.2 (reviewer family)**:
 
 - `reviewer/full.json` — panel 5, 5 dimensions, 4 failure conditions
 - `reviewer/methodology_focus.json` — panel 2, 2 dimensions, 3 failure conditions
+
+**v3.6.6 / suite v3.6.8 (generator-evaluator family)**:
+
+- `writer/full.json` — single-agent writer, 7 dimensions (D1 section_completeness / D2 citation_density / D3 argument_blueprint_fidelity / D4 total_word_count / D5 per_section_word_count / D6 acknowledged_limitations / D7 register_consistency), 5 failure conditions (F1 / F4 / F2 / F3 / F0). No `scoring_plan` field.
+- `evaluator/full.json` — single-agent evaluator, 5 dimensions (D1 originality / D2 methodological_rigor / D3 evidence_sufficiency / D4 argument_coherence / D5 writing_quality), 7 failure conditions (F1 / F2 / F3 / F6 / F4 / F5 / F0). Carries full `scoring_plan` + `disagreement_handling`.
+
+Both writer + evaluator templates ship under Schema 13.1 (allOf branches 11/12 require `pre_commitment_artifacts` for `writer_full` and `disagreement_handling` for `evaluator_full`; branches 5/6 pin `failure_conditions[].action` to mode-specific enums; branches 8/9 pin F0 contains to the mode's accept variant). Orchestration block lives in `academic-paper/SKILL.md` § "v3.6.6 Generator-Evaluator Contract Protocol" + the writer/evaluator agent files.
 
 ### Reserved reviewer modes without shipped templates
 

--- a/shared/sprint_contract.schema.json
+++ b/shared/sprint_contract.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Imbad0202/academic-research-skills/shared/sprint_contract.schema.json",
-  "title": "ARS Sprint Contract (Schema 13)",
+  "title": "ARS Sprint Contract (Schema 13.1)",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,11 +9,10 @@
     "mode",
     "stage",
     "baseline_version",
-    "panel_size",
     "acceptance_dimensions",
-    "measurement_procedure",
     "failure_conditions"
   ],
+  "$comment": "Schema 13.1 (v3.6.6) lifts measurement_procedure and panel_size out of top-level required into reviewer-conditional gates (allOf branches 3 + 10). The base required list therefore drops those two compared to Schema 13. measurement_procedure is re-required for reviewer modes via allOf branch 3; panel_size is re-required for reviewer modes via allOf branch 10. Writer / evaluator contracts do not carry either field.",
   "properties": {
     "contract_id": {
       "type": "string",
@@ -25,7 +24,9 @@
         "reviewer_methodology_focus",
         "reviewer_re_review",
         "reviewer_calibration",
-        "reviewer_guided"
+        "reviewer_guided",
+        "writer_full",
+        "evaluator_full"
       ]
     },
     "stage": { "type": "string", "minLength": 1 },
@@ -92,18 +93,105 @@
         }
       }
     },
+    "pre_commitment_artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["acceptance_criteria_paraphrase"],
+      "$comment": "Schema 13.1 v3.6.6 §3.4.1 (writer-only). Carries only invariant, paper-agnostic policy: how many acceptance_dimensions the writer must paraphrase in Phase 4a paper-blind output. Everything paper-specific lives in upstream runtime artefacts and is read at Phase 4a / 4b runtime, not committed in the frozen contract baseline. Per-section word counts come from the Paper Configuration Record (intake_agent); section outline comes from the Structure Architect's approved outline (structure_architect_agent); CER chains come from the Argument Blueprint (argument_builder_agent). Writer dimensions D1 (section_completeness), D3 (argument_blueprint_fidelity), D4 (total_word_count), D5 (per_section_word_count) phrase their gates against those upstream artefacts rather than against contract-embedded values. Required for writer_full only (allOf branch 11).",
+      "properties": {
+        "acceptance_criteria_paraphrase": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum_dimensions"],
+          "$comment": "CONFIGURATION declaration, not the paraphrase content itself. Declares how many of the contract's acceptance_dimensions the writer must paraphrase in Phase 4a. The actual paraphrase text is a runtime artifact emitted by draft_writer_agent in its Phase 4a output (analogous to how reviewer paraphrase content lives in <phase1_output>, not in the contract). Mirrors reviewer measurement_procedure.paraphrase_minimum_dimensions semantics.",
+          "properties": {
+            "minimum_dimensions": {
+              "anyOf": [
+                { "const": "all" },
+                { "type": "integer", "minimum": 1 }
+              ],
+              "$comment": "Default in shipped writer template: 'all'."
+            }
+          }
+        }
+      }
+    },
+    "disagreement_handling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paraphrase_minimum_dimensions", "scoring_plan", "pre_commitment_check_protocol", "disagreement_resolution"],
+      "$comment": "Schema 13.1 v3.6.6 §3.4.2 (evaluator-only). Required for evaluator_full only (allOf branch 12).",
+      "properties": {
+        "paraphrase_minimum_dimensions": {
+          "anyOf": [
+            { "const": "all" },
+            { "type": "integer", "minimum": 1 }
+          ],
+          "$comment": "How many of the contract's acceptance_dimensions the evaluator must paraphrase in Phase 6a paper-blind output (the contract_paraphrase artifact named in §1 design goal 2 / §4.3). Mirrors reviewer measurement_procedure.paraphrase_minimum_dimensions and writer pre_commitment_artifacts.acceptance_criteria_paraphrase.minimum_dimensions to keep the Phase-6a anti-drift gate hard-required at the schema layer rather than relying on prose-level commitments. Default in shipped evaluator template: 'all'."
+        },
+        "scoring_plan": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["per_dimension_criteria"],
+          "properties": {
+            "per_dimension_criteria": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["dimension_id", "what_to_look_for", "what_triggers_block", "what_triggers_warn"],
+                "properties": {
+                  "dimension_id": { "type": "string", "pattern": "^D[1-9][0-9]?$" },
+                  "what_to_look_for": { "type": "string", "minLength": 1 },
+                  "what_triggers_block": { "type": "string", "minLength": 1 },
+                  "what_triggers_warn": { "type": "string", "minLength": 1 }
+                },
+                "$comment": "Mirrors reviewer measurement_procedure.scoring_plan_schema four-field structure. Evaluator commits these in Phase 6a paper-blind."
+              }
+            }
+          }
+        },
+        "pre_commitment_check_protocol": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["check_writer_artifact"],
+          "properties": {
+            "check_writer_artifact": {
+              "const": "pre_commitment_artifacts",
+              "$comment": "Pinned to the single writer source for v3.6.6. Field shape exists (rather than inlining the const) for forward compatibility — when v3.6.7+ may add additional writer artifacts, this can relax to an enum without a breaking schema change."
+            }
+          }
+        },
+        "disagreement_resolution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["on_dimension_disagreement", "on_structural_drift"],
+          "$comment": "Both subfield enums use the fully-qualified evaluator_decision=* vocabulary so values can be passed directly into failure_conditions[].action without runtime transformation. Keeping a single canonical action vocabulary across §3.3.3 and §3.4.2 prevents drift between the two surfaces.",
+          "properties": {
+            "on_dimension_disagreement": {
+              "enum": [
+                "evaluator_decision=request_revision",
+                "evaluator_decision=accept_with_dissent_note",
+                "evaluator_decision=flag_for_reviewer_stage"
+              ],
+              "$comment": "What the evaluator does when its own paper-blind scoring plan flags a dimension during paper-visible evaluation (the dimension hits its pre-committed what_triggers_block or what_triggers_warn anchors). Default in shipped templates: 'evaluator_decision=request_revision' for mandatory dimensions; runtime evaluator may downgrade non-mandatory dimensions to 'accept_with_dissent_note' (see F4 in evaluator/full.json)."
+            },
+            "on_structural_drift": {
+              "enum": [
+                "evaluator_decision=request_revision",
+                "evaluator_decision=accept_with_dissent_note",
+                "evaluator_decision=flag_for_reviewer_stage"
+              ],
+              "$comment": "What the evaluator does when the actual draft structure deviates from the Structure Architect's approved outline (the upstream runtime artefact from structure_architect_agent that the writer follows in Phase 4b). Drift threshold lives in the evaluator's runtime judgement, not the schema; the contract carries only the default verdict to apply when drift is observed."
+            }
+          }
+        }
+      }
+    },
     "failure_conditions": {
       "type": "array",
       "minItems": 1,
-      "contains": {
-        "type": "object",
-        "properties": {
-          "condition_id": { "const": "F0" },
-          "action": { "const": "editorial_decision=accept" }
-        },
-        "required": ["condition_id", "action"]
-      },
-      "$comment": "Codex P2-1: every contract must include an F0 accept-grade condition. Without it the synthesizer can reach a 'no condition fired' state with no editorial_decision to emit, aborting the review round at runtime instead of failing CI. Pinning F0's action to editorial_decision=accept also prevents future templates from misusing the reserved id.",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -118,13 +206,8 @@
           "cross_reviewer_quantifier": { "enum": ["any", "majority", "all"] },
           "expression": { "type": "string", "minLength": 1 },
           "action": {
-            "enum": [
-              "editorial_decision=accept",
-              "editorial_decision=minor_revision",
-              "editorial_decision=major_revision",
-              "editorial_decision=reject_or_major_revision",
-              "editorial_decision=reject"
-            ]
+            "type": "string",
+            "$comment": "Schema 13.1 v3.6.6 §3.3.3: base enum lifted; mode-conditional action enums enforced in allOf branches 4 (reviewer) / 5 (writer_full) / 6 (evaluator_full). The base property keeps only type:string as a structural placeholder so JSON Schema's intersection semantics do not block writer / evaluator action values."
           }
         }
       }
@@ -160,6 +243,7 @@
   },
   "allOf": [
     {
+      "$comment": "Branch 1 (existing Schema 13 §3.3): reviewer mode requires cross_reviewer_quantifier on every failure_conditions entry.",
       "if": {
         "properties": { "mode": { "pattern": "^reviewer_" } },
         "required": ["mode"]
@@ -173,6 +257,7 @@
       }
     },
     {
+      "$comment": "Branch 2 (existing Schema 13 §3.3): override_ladder three-round shape if present.",
       "if": { "required": ["override_ladder"] },
       "then": {
         "properties": {
@@ -186,6 +271,184 @@
             ]
           }
         }
+      }
+    },
+    {
+      "$comment": "Branch 3 (new v3.6.6 §3.3.1): reviewer mode requires measurement_procedure (lifted from base required).",
+      "if": {
+        "properties": { "mode": { "pattern": "^reviewer_" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "required": ["measurement_procedure"]
+      }
+    },
+    {
+      "$comment": "Branch 4 (new v3.6.6 §3.3.3): reviewer mode pins failure_conditions[].action to editorial_decision=* enum (re-pins the Schema 13 base enum; structurally identical for reviewer contracts).",
+      "if": {
+        "properties": { "mode": { "pattern": "^reviewer_" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "failure_conditions": {
+            "items": {
+              "properties": {
+                "action": {
+                  "enum": [
+                    "editorial_decision=accept",
+                    "editorial_decision=minor_revision",
+                    "editorial_decision=major_revision",
+                    "editorial_decision=reject_or_major_revision",
+                    "editorial_decision=reject"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Branch 5 (new v3.6.6 §3.3.3): writer_full pins failure_conditions[].action to writer_decision=* enum.",
+      "if": {
+        "properties": { "mode": { "const": "writer_full" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "failure_conditions": {
+            "items": {
+              "properties": {
+                "action": {
+                  "enum": [
+                    "writer_decision=accept",
+                    "writer_decision=revise_in_phase_4b",
+                    "writer_decision=escalate_to_evaluator"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Branch 6 (new v3.6.6 §3.3.3): evaluator_full pins failure_conditions[].action to evaluator_decision=* enum.",
+      "if": {
+        "properties": { "mode": { "const": "evaluator_full" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "failure_conditions": {
+            "items": {
+              "properties": {
+                "action": {
+                  "enum": [
+                    "evaluator_decision=accept",
+                    "evaluator_decision=accept_with_dissent_note",
+                    "evaluator_decision=request_revision",
+                    "evaluator_decision=flag_for_reviewer_stage"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Branch 7 (new v3.6.6 §3.3.4): reviewer mode F0 contains action=editorial_decision=accept (re-pins the Schema 13 inline contains; structurally identical for reviewer contracts).",
+      "if": {
+        "properties": { "mode": { "pattern": "^reviewer_" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "failure_conditions": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "condition_id": { "const": "F0" },
+                "action": { "const": "editorial_decision=accept" }
+              },
+              "required": ["condition_id", "action"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Branch 8 (new v3.6.6 §3.3.4): writer_full F0 contains action=writer_decision=accept.",
+      "if": {
+        "properties": { "mode": { "const": "writer_full" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "failure_conditions": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "condition_id": { "const": "F0" },
+                "action": { "const": "writer_decision=accept" }
+              },
+              "required": ["condition_id", "action"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Branch 9 (new v3.6.6 §3.3.4): evaluator_full F0 contains action=evaluator_decision=accept.",
+      "if": {
+        "properties": { "mode": { "const": "evaluator_full" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "failure_conditions": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "condition_id": { "const": "F0" },
+                "action": { "const": "evaluator_decision=accept" }
+              },
+              "required": ["condition_id", "action"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Branch 10 (new v3.6.6 §3.3.5): reviewer mode requires panel_size (lifted from base required).",
+      "if": {
+        "properties": { "mode": { "pattern": "^reviewer_" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "required": ["panel_size"]
+      }
+    },
+    {
+      "$comment": "Branch 11 (new v3.6.6 §3.5): writer_full requires pre_commitment_artifacts.",
+      "if": {
+        "properties": { "mode": { "const": "writer_full" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "required": ["pre_commitment_artifacts"]
+      }
+    },
+    {
+      "$comment": "Branch 12 (new v3.6.6 §3.5): evaluator_full requires disagreement_handling.",
+      "if": {
+        "properties": { "mode": { "const": "evaluator_full" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "required": ["disagreement_handling"]
       }
     }
   ],


### PR DESCRIPTION
## Summary

Implements the v3.6.6 generator-evaluator contract spec ([PR #58](https://github.com/Imbad0202/academic-research-skills/pull/58) merge commit `61fd9be`). Ships the **code-only tracks** (A+B+C+D+H+I) of the impl PR. The **real-compute tracks E+F+G** (real fixture data populate, treatment runs, codex judge against treatment, metrics computation) are deferred per the **D-strategy decision** below.

**Tagged as suite release v3.6.8** (CHANGELOG monotonic) since v3.6.7 already shipped on main when this work landed; the design doc retains v3.6.6 internal naming for the contract gate version.

## Status & decision (2026-05-03)

**E+F+G defer per D-strategy** (Telegram decision 2026-05-03):

The original §6.2 Round D Q5 decision specified "6 paper-A inputs are existing deep-research synthesis reports already produced by the suite". Filesystem grep at impl-PR-time surfaced a spec/reality gap: only 1 deep-research synthesis report (`heeact-cbqa-chapter`) exists in the suite operator's `~/Projects/`; producing the missing 5 + the 6 v3.6.5 baseline runs + the 7 v3.6.6 treatment runs + the 13 codex judge runs would cost an estimated **12-24 hours of compute time** spread across multiple sessions.

After explicit cost-benefit review, the D-strategy was chosen: **defer real fixture data populate and treatment runs to organic accumulation** as the operator runs `deep-research` and `academic-paper full` mode over time on real research projects. Each completed run can later be archived under `tests/fixtures/v3.6.6-ab/inputs/` / `baseline/` / `codex-judge/` to incrementally populate the fixture, with `manifest_lint_mode` flipping from `spec_branch` to `implementation_pr` only when all 7 papers are populated atomically per §6.5 invariant 3.

**This PR therefore ships the v3.6.6 implementation in two senses**:

1. **Spec-implementation parity is complete** — Schema 13.1 validates writer/evaluator templates; SC-* warnings mode-gated; SKILL.md + agent files carry the verbatim Phase 4a/4b/6a/6b system-prompt blocks; `sprint_contract_protocol.md` cross-referenced; manifest CI lint enforces §6.2 + §6.5 invariants; version sweep brings the suite to v3.6.8. **Users can start invoking `academic-paper full` mode and exercise the v3.6.6 contract gate end-to-end** as soon as this PR merges.

2. **Empirical A/B evidence (the §6 deliverable) is deferred** — the `tests/fixtures/v3.6.6-ab/` directory remains in `manifest_lint_mode: spec_branch` with 30 placeholder files explaining each expected populated content. Real fixture data + treatment runs + metrics summary + paper-C categorical sanity check land in follow-up commits to a future PR (or directly to `main` via small focused PRs as the operator's research output accumulates), with no urgent gate.

This decision favours velocity: shipping the contract-gate code unblocks `ars-codex` re-vendor + cross-runtime benchmark sequencing per ROADMAP commit `0e0d51c`, while the A/B evidence work proceeds at its natural pace without holding the spec implementation hostage to its 12-24 hour real-compute cost.

## What this PR ships (code-only tracks A+B+C+D+H+I)

**Track A — Schema 13.1 file upgrade** (`shared/sprint_contract.schema.json`):
- Title: Schema 13 → Schema 13.1
- mode enum: 5 → 7 values (+writer_full, +evaluator_full)
- Top-level required drops measurement_procedure + panel_size (lifted to reviewer-conditional gates)
- Two new optional top-level fields: pre_commitment_artifacts (writer-only) + disagreement_handling (evaluator-only)
- 12 allOf branches per design doc §3.5 (existing 2 + 10 new)

**Track B — SC-\* mode-gating audit in check_sprint_contract.py** (per §7.1 implementation requirement):
- SC-5 (measurement_procedure canonical outputs) + SC-11 (panel_size sanity) mode-gated to reviewer-only
- SC-9 (paraphrase_minimum_dimensions exceeds dim count) extended across all three mode families with each mode reading its own field path
- Mode-agnostic warnings (SC-1/2/3/4/7/10) unchanged

**Track C — academic-paper SKILL.md + agent files v3.6.6 contract block**:
- `academic-paper/SKILL.md` adds `## v3.6.6 Generator-Evaluator Contract Protocol` orchestration block (101 lines) + `## Known limitations` section
- `academic-paper/agents/draft_writer_agent.md` adds `## v3.6.6 Generator-Evaluator Contract Protocol` section (47 lines) with verbatim Phase 4a + Phase 4b system-prompt sub-sections
- `academic-paper/agents/peer_reviewer_agent.md` adds parallel section (57 lines) with Phase 6a + Phase 6b sub-sections

**Track D — sprint_contract_protocol.md cross-ref**:
- One-line cross-reference paragraph in `academic-paper-reviewer/references/sprint_contract_protocol.md` head matter noting Schema 13.1 since v3.6.6 + pointing readers at academic-paper SKILL.md + design doc §5

**Track H — Manifest CI lint script + workflow extension**:
- New `scripts/check_v3_6_6_ab_manifest.py` (374 lines) implements §7.5: schema-shape + mode-conditional path-existence + reverse-scan + malformed parse error
- `.github/workflows/spec-consistency.yml` extends sprint contract validation loop to include writer + evaluator template directories alongside reviewer; adds new "Validate v3.6.6 A/B fixture manifest" step

**Track I — Version bump sweep to suite v3.6.8** (per `feedback_version_bump_sweep_checklist.md`):
- CHANGELOG.md: new ## [3.6.8] - 2026-05-03 entry above ## [3.6.7]
- .claude/CLAUDE.md: pipeline version 3.6.7 → 3.6.8 in Skills Overview table; new ## v3.6.8 Key Additions section; Suite version 3.6.7 → 3.6.8
- README.md + README.zh-TW.md: badge v3.6.7 → v3.6.8; new v3.6.8 Changelog section
- MODE_REGISTRY.md: Last updated v3.6.7 → v3.6.8
- academic-pipeline/SKILL.md: metadata.version 3.6.7 → 3.6.8
- scripts/check_spec_consistency.py: 8 hardcoded version anchors updated; v3.6.7 anchor re-added since v3.6.7 README entry stays
- shared/contracts/README.md: removed "Spec-branch status (v3.6.6 work in progress)" block (spec branch merged); reorganised "Shipped templates" into v3.6.2 (reviewer family) + v3.6.6 / suite v3.6.8 (generator-evaluator family) sections

## Test plan

- [x] All 4 lint scripts green at every commit:
  - `scripts/check_spec_consistency.py` PASS
  - `scripts/check_version_consistency.py` PASS
  - `scripts/check_v3_6_6_ab_manifest.py` PASS
  - `python3 -m unittest scripts.test_check_sprint_contract` 71 tests PASS (54 + 17 new)
- [x] Spec Consistency CI green on every push commit (latest: `f0964f9` rebased onto main `61fd9be`)
- [x] Workflow extension validated locally: writer + evaluator template validation loops + new manifest CI lint step both invoke correctly

## E+F+G defer scope (CHANGELOG-tracked under "Deferred")

The CHANGELOG `## [3.6.8]` entry's `### Deferred` section already lists what stays out of this PR:

- **Track E** — Real fixture data populate: replace 30 placeholders in `tests/fixtures/v3.6.6-ab/` with real paper-A inputs (existing deep-research synthesis reports × 6) + real paper-A baseline outputs (v3.6.5 academic-paper full-run output) + paper-C session log + Stage 3 reviewer excerpt + 6 codex gpt-5.5 + xhigh judge runs against paper-A baseline.
- **Track F** — Treatment runs: writer Phase 4a/4b + evaluator Phase 6a/6b on the seven fixtures = 28 treatment outputs.
- **Track G** — Codex judge against treatment + Semantic Scholar API for H2 + metrics computation + summary.md (paper-A only metrics, paper-C categorical signal in summary).
- **manifest_lint_mode flip** from `spec_branch` to `implementation_pr` co-lands with E+F+G atomic merge state per §6.5 invariant 3.

These deliver the §6 A/B evidence package and remain on the v3.6.6 backlog. They do not block v3.6.8 ship; they accumulate organically from real operator usage of `deep-research` + `academic-paper full` mode, and the manifest flip happens once all 7 papers are populated.

## Marking ready for review

Per the D-strategy decision above, this PR is intentionally **mark-ready-for-review-able now** even with `manifest_lint_mode: spec_branch` and 30 placeholder files. The spec PR's §6.5 invariant 3 mandates that treatment + judge + metrics land in an "atomic merge state" — that atomicity is preserved by deferring the flip to a separate future PR rather than splitting the spec implementation across multiple PRs. Reviewers can land v3.6.8 once code review approves the code-only tracks; A/B evidence ships when real data exists.

## Sequence

Per ROADMAP commit `0e0d51c`: this v3.6.8 release (which ships v3.6.6 implementation) must merge before re-vendoring `ars-codex` to v3.6.6 and before running cross-runtime benchmark (v4.0 gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)