### PR TITLE
docs(v3.5.1 spec): mark as retrospective shipped + §5.1 test 8 OBSOLETE

### DIFF
--- a/docs/design/2026-04-22-ars-v3.7.3-reading-check-probe-design.md
+++ b/docs/design/2026-04-22-ars-v3.7.3-reading-check-probe-design.md
@@ -1,5 +1,9 @@
 # ARS v3.5.1 Reading-Check Probe — Design Spec
 
+> **Status (2026-05-04 retrospective):** **SHIPPED in v3.5.1**, 2026-04-22. All §1–§4 components landed; §5 tests landed as `scripts/test_reading_probe_lint.py` covering 7 of 8 specified tests. **§5.1 test 8 (`test_version_bump_sweep`) is OBSOLETE** — superseded by PR #33 which generalised `check_version_consistency.py` to dynamic CHANGELOG-driven version comparison, replacing the per-version pinned-fixture pattern this spec assumed. Pinned fixtures for v3.5.1 strings are no longer the right shape; the dynamic guard already covers the regression class. Filename retains `v3.7.3` because the roadmap slot was originally v3.7.3 before being reshaped into v3.5.1; spec body uses v3.5.1 throughout.
+>
+> Retained as historical design reference. Implementation evidence: `.claude/CLAUDE.md` `## v3.5.1 Key Additions`, `deep-research/agents/socratic_mentor_agent.md` `## Optional Reading Probe Layer (v3.5.1 ...)`, `scripts/test_reading_probe_lint.py`.
+
 **Status:** DRAFT — pending implementation
 **Date:** 2026-04-22
 **Target version:** 3.5.0 → **3.5.1** (patch)
@@ -379,8 +383,8 @@ TDD entry: `scripts/test_reading_probe_lint.py`. Style matches existing `test_ch
 7. **`test_banned_praise_phrases`**
    Assert the probe section's banned-phrases list contains the exact strings: `"correct"`, `"right"`, `"wrong"`, `"good answer"`, `"well said"`, `"make sure"`, `"verify"`, `"prove"`. The word "check" is intentionally excluded from the banned list because it has non-evaluative uses in the surrounding section (e.g., "activation conditions hold").
 
-8. **`test_version_bump_sweep`**
-   Cover the 7 bump sites (already exists as `check_version_consistency.py`) — just extend the regression fixture to include v3.5.1 strings.
+8. **`test_version_bump_sweep`** — **OBSOLETE (2026-05-04)**
+   Spec at draft time assumed extending a pinned-fixture in `check_version_consistency.py`. PR #33 (2026-04-22) generalised that script to dynamic CHANGELOG-driven version comparison, removing the per-version pinned-fixture pattern. Adding v3.5.1 pinned strings would re-introduce the technical debt the dynamic redesign retired. Skip; the dynamic guard already covers this regression class.
 
 ### 5.2 Test execution
 


### PR DESCRIPTION
## Summary

Annotates `docs/design/2026-04-22-ars-v3.7.3-reading-check-probe-design.md` to reflect that the v3.5.1 reading-check probe was fully shipped on 2026-04-22, and marks §5.1 test 8 (`test_version_bump_sweep`) as OBSOLETE.

## Why

A 2026-05-04 reconciliation pass on memory state discovered the spec was being treated as "pending implementation" when in fact:

- `.claude/CLAUDE.md` already has `## v3.5.1 Key Additions`
- `deep-research/agents/socratic_mentor_agent.md` already has `## Optional Reading Probe Layer (v3.5.1 ...)`
- `scripts/test_reading_probe_lint.py` already implements 7 of the 8 specified tests

The spec body kept saying "DRAFT — pending implementation," which misled at least one reading. A retrospective banner at the top fixes this without rewriting history.

## test 8 OBSOLETE rationale

§5.1 test 8 (`test_version_bump_sweep`) was specified as "extend the regression fixture in `check_version_consistency.py` to include v3.5.1 pinned strings."

PR #33 (also 2026-04-22) generalised `check_version_consistency.py` to dynamic CHANGELOG-driven version comparison, removing the per-version pinned-fixture pattern. Adding v3.5.1 pinned strings would re-introduce the technical debt that the dynamic redesign retired.

The dynamic guard already covers this regression class. Test 8 is therefore not the right shape to ship and is annotated OBSOLETE.

## Scope

- Documentation only — no runtime, schema, contract, or test code changes.
- File touched: 1 (`docs/design/2026-04-22-ars-v3.7.3-reading-check-probe-design.md`, +6 / -2).
- `python3 scripts/check_spec_consistency.py` and `python3 scripts/check_version_consistency.py` both pass locally.

## Test plan

- [ ] CI passes (`spec-consistency.yml` workflow)
- [ ] Reviewer confirms the retrospective banner is accurate (cross-check against `.claude/CLAUDE.md` v3.5.1 Key Additions and `socratic_mentor_agent.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)