### PR TITLE
spec(v3.6.8 roadmap slot): trust provenance & drift transparency design

### DIFF
--- a/docs/design/2026-04-30-ars-v3.6.8-trust-provenance-and-drift-transparency-spec.md
+++ b/docs/design/2026-04-30-ars-v3.6.8-trust-provenance-and-drift-transparency-spec.md
@@ -1,0 +1,392 @@
+# ARS v3.6.8 (roadmap slot) — Trust Provenance & Drift Transparency
+
+> **Status (2026-05-05 banner):** **DESIGN-ONLY, NOT YET IMPLEMENTED.** This spec occupies ROADMAP §3.6.8 ("Trust provenance & drift transparency"). Filename and roadmap slot retain **v3.6.8**.
+>
+> **Release semver: TBD.** The release tag `v3.6.8` was already consumed by the generator-evaluator contract (suite v3.6.8 SHIPPED 2026-05-03, main `734dd23`, see CHANGELOG `[3.6.8] - 2026-05-03`). When this spec ships, it will be tagged at the next available semver (v3.6.9 / v3.7.x) per the roadmap-slot-vs-release-semver decoupling pattern (see precedent: `2026-04-22-ars-v3.7.3-reading-check-probe-design.md` filename retains roadmap slot v3.7.3 while actual release tag is v3.5.1).
+>
+> The substance of this spec — five upstream-trust-chain protections (D1–D5) — is unchanged from the 2026-04-30 draft. Sequencing per ROADMAP §3.6.8: HOLD until v3.6.7 follow-up ships (Step 6 done; Step 8 pending).
+
+**Status:** Design — spec input from real-world chapter-writing session
+**Date:** 2026-04-30
+**Target release:** TBD (roadmap slot v3.6.8; release semver to be assigned at ship time)
+**Scope:** Pipeline-wide hallucination defense at the **trust-claim layer** (frontmatter granularity, audit scope disclosure) and **session transparency layer** (drift logging, cite-time verification check, retrieval fallback). Complements v3.6.7 downstream-agent pattern protection by addressing the **upstream trust-chain** between user, source artifacts, and AI-produced descriptions.
+
+---
+
+## 1. Background
+
+A 2026-04-30 production session (HEEACT Springer chapter, Phase 1+2+3 outputs already at V2_CLEAN per v3.6.5/v3.6.6 standard) revealed a class of **silent over-claim** that the downstream-agent pattern protection layer does not catch.
+
+The user, an experienced QA/AI-writing practitioner, repeatedly **left the pipeline phase** to manually verify entries against original PDFs. This was not user-flow noise; it was rational defensive behavior in response to LLM hallucination risk. Each manual return surfaced new findings:
+
+- `bibliography_v2.md` itself contained a **fabricated quote** attributed to D14 (OECD/UNESCO 2005) that does not appear in the retrieved PDF
+- F1 Becker (2013) and F4 UWN (2012) entries cited **wrong case lists** (Malaysia/Dubai/Fiji) when the actual articles concerned a **Singapore IBC cluster**
+- F3 Yale Daily News entry cited **wrong author + wrong date** (2024-09-23 community-reaction piece) when the load-bearing source is a 2021-09-07 announcement-aftermath article by a different reporter
+- D13 INQAAHE ISG was paraphrased as "discipline-specific thematic standards" when the actual ISG architecture is **QA-context modules**
+- G4 SEAMEO RIHED 2012 attribution had the **regional QA picture inverted**
+- The Indonesian decree arc cited **the wrong Permendikbudristek as statutory anchor**, missing PMu 53/2023 entirely until the user retrieved the correct PDF
+
+Three observations follow:
+
+**Observation 1 — Derivative pollution.** The bibliography file (a derivative artifact AI produced earlier) was treated as ground truth in downstream entries. Each entry's frontmatter carried a `verified: <date>` field that conflated three distinct trust strengths: (a) AI viewed the entry .md, (b) AI cross-checked entry .md against the derivative bibliography, (c) AI cross-checked entry .md against the original publication PDF. To the user, `verified: 2026-04-30` reads as "this source is safe to cite." The conflation is a silent over-claim that scales hallucination risk into chapter prose.
+
+**Observation 2 — Audit scope blind spot.** Three rounds of cross-model codex audit reported "ADDRESSED" status on the entry corpus. Coverage analysis after the fact showed the audit could only verify against original PDF for ~22 of ~53 entries (those with retrieved sources). The remaining ~31 entries were "verified" only against the derivative bibliography — i.e., the audit confirmed internal consistency of two same-source artifacts, not correctness against original publications. The audit pipeline did not disclose this scope coverage gap, and the user almost moved into chapter prose under the false confidence that the corpus was uniformly verified.
+
+**Observation 3 — Phase drift as healthy signal.** The user's repeated phase departures (chapter drafting → retrieval → metadata audit → intake) were not pipeline-discipline failures. They were the only mechanism that surfaced the v2 fabrications, the wrong case lists, and the missing statutory anchor. **A pipeline design that nudges the user to "stay on track" would have suppressed the very behavior that caught the hallucinations.** The intervention surface should be transparency (let the user reconstruct their drift trajectory after the session) rather than enforcement (interrupting drift mid-session).
+
+The lesson is that ARS pipeline ship-quality is bounded not only by the weakest downstream agent but also by **the granularity of trust claims** (frontmatter), **the honesty of audit reports** (scope disclosure), and **the user's ability to audit their own session trajectory** (drift transparency). v3.6.7 hardened agents against producing new hallucinations during their own work; v3.6.8 hardens the **trust-chain layer** that decides whether prior content is safe to consume downstream.
+
+---
+
+## 2. Goal & Non-Goals
+
+### 2.1 Goal
+
+Codify five upstream-trust-chain protections into ARS spec, with prompt-level integration into `bibliography_agent` and orchestrator layers, plus tooling for retrieval pipeline robustness. Target outcome: end-of-pipeline deliverables carry an **auditable trust chain** from final claim back to either (a) original-source verification or (b) explicit unverified-flag, with no `verified` claim stronger than the underlying evidence supports.
+
+### 2.2 Non-Goals (out of v3.6.8 scope)
+
+- No keep-on-track enforcement. Drift is healthy; transparency is the intervention surface.
+- No new pipeline phase. Mechanisms attach to existing agents and orchestrator.
+- No mandatory user blocking. Cite-time provenance check is **warn-only** (consistent with the advisory-not-blocking precedent set by v3.5 Collaboration Depth Observer).
+- No automated source acquisition for paywalled material. Retrieval fallback chain is for OA / archived / author-self-hosted sources only.
+
+---
+
+## 3. Pattern Inventory
+
+### 3.1 D1 — Frontmatter trust-strength conflation
+
+A bibliography entry carries `verified: <date>` (or equivalent single field) that does not distinguish between (a) entry-self-consistency, (b) entry-vs-derivative-bibliography consistency, (c) entry-vs-original-source verification. Downstream agents and human readers treat all three as equivalent confidence.
+
+**Mechanism:** `bibliography_agent` and downstream entry writers emit a single `verified` field after performing whichever check is available. When original source is not retrieved, the field is still emitted, indicating only (a) or (b) but reading as (c).
+
+**Protection:** Frontmatter schema must split into orthogonal fields:
+
+```yaml
+source_acquired: true | false           # Original PDF/HTML in repo
+source_acquisition_date: <ISO 8601>     # When acquired
+source_acquisition_path: <relative path># Where it lives
+source_verified_against_original: true | false  # AI cross-checked against original
+source_verification_method: codex_audit | manual_grep | vision_check | none
+human_read_source: true | false         # USER explicitly marked as read
+description_source: original_pdf | bibliography_v<n> | secondary_summary
+description_last_audit: <round_id> | none
+```
+
+Two firm rules:
+- `source_verified_against_original: true` REQUIRES `source_acquired: true` AND a non-empty `source_verification_method`. Lint must enforce.
+- `source_acquired: false` REQUIRES `description_last_audit: none` (no original means audit cannot be substantive). Lint must enforce.
+
+`bibliography_agent` prompt must specify these fields with examples, plus a refusal rule: when source is not retrieved, agent MUST NOT emit `source_verified_against_original: true` regardless of internal-consistency checks performed.
+
+### 3.2 D2 — Audit scope coverage non-disclosure
+
+A cross-model audit (codex round) reports "PASSED" or "ADDRESSED" without disclosing how many corpus entries were independently verifiable (had retrieved source) versus how many were only self-consistency-checked (no retrieved source, audit fell back to derivative comparison).
+
+**Mechanism:** Audit reports are written as global pass/fail summaries. Coverage breakdown is computable from frontmatter (count entries with `source_acquired: true` vs `false`) but is not surfaced in the audit report header.
+
+**Protection:** Audit report template (in `shared/templates/codex_audit_multifile_template.md` and any subsequent codex audit prompt) must require an opening **Scope Report** block:
+
+```markdown
+## Codex Audit Round N — Scope Report
+
+**Total entries audited:** <N_total>
+**Entries with retrieved original source:** <N_with_source> (verified against original publication)
+**Entries description-only (no retrieved source):** <N_without_source> (verified only against derivative bibliography or self-consistency)
+
+**Audit scope warning:** <N_without_source> entries cannot be independently verified by this audit round. Their `verified` status reflects internal consistency between entry .md and the derivative bibliography source, NOT correctness against the original publication. These entries should be treated as **unverifiable until original sources are retrieved**.
+
+**Affected refcodes (description-only):** <comma-separated list>
+```
+
+Two firm rules:
+- The Scope Report block must appear **before** any pass/fail summary
+- Aggregate "PASSED" status MUST be split into:
+  - `verified-against-source: PASS | FAIL` (over the retrieved-source subset)
+  - `description-internally-consistent: PASS | FAIL` (over the non-retrieved subset)
+  - `unaudited-due-to-missing-source: <count>` (always reported, never hidden)
+
+The combined-aggregate "PASSED" verb is forbidden in audit summary.
+
+### 3.3 D3 — Cite-time trust-chain non-check
+
+When narrative-construction agents (`synthesis_agent`, `draft_writer_agent`) emit a citation `[refcode]`, no automated provenance check fires against the refcode's frontmatter. The agent assumes the entry exists and is citable, and produces declarative claims about its content.
+
+**Mechanism:** Agent prompts treat the bibliography as an opaque context. When a citation is emitted, no orchestrator-level hook intercepts to verify trust-chain status of the underlying entry.
+
+**Protection:** Orchestrator must implement a **Cite-Time Provenance Check** hook that fires whenever a downstream agent emits a `[refcode]` citation marker. The hook reads the refcode's frontmatter and applies this matrix:
+
+| `source_acquired` | `source_verified_against_original` | `human_read_source` | Action |
+|-------------------|-----------------------------------|---------------------|--------|
+| false             | —                                  | —                   | **HIGH WARN**: cite has no original source on file. Inject `[UNVERIFIED CITATION — NO ORIGINAL]` marker into draft. |
+| true              | false                             | false               | **MED WARN**: PDF in repo but AI has not cross-checked. Inject `[UNVERIFIED CITATION — AI HAS NOT CROSS-CHECKED]` marker. |
+| true              | true                              | false               | **LOW WARN**: AI cross-checked, user has not. Append to per-section pre-finalization checklist. |
+| true              | true                              | true                | OK, no marker. |
+
+Markers are **draft-only** — they do not block emission. They render in draft prose but must be removed before final-output generation. `format_converter_agent` MUST refuse to convert any draft containing a `[UNVERIFIED CITATION ...]` marker; the user must either (a) acquire/verify the source or (b) rewrite to remove the citation, before format conversion.
+
+Consistent with v3.5 Collaboration Depth Observer precedent: warn, surface, but never silently block user choice. The conversion-time hard gate is the single non-negotiable point.
+
+### 3.4 D4 — Session drift untracked
+
+User leaves expected pipeline phase (e.g., from `academic-paper:plan` mode to manual retrieval to ad-hoc tool building back to `academic-paper:plan`). Session ends. User has no way to reconstruct **what work was done in which phase** vs **what was ad-hoc tooling** vs **what was backflow verification**. Future sessions and audit replay treat all session output as equivalent phase deliverable.
+
+**Mechanism:** ARS session does not emit a structured phase-trajectory log. Phase information lives implicitly in agent invocation order; ad-hoc work (user manually editing files, writing scratch artifacts) is invisible to the pipeline orchestrator.
+
+**Protection:** Add **Session Drift Log** as an end-of-session orchestrator artifact. Orchestrator emits `<session>_drift_log.md` containing:
+
+```markdown
+## Session <session_id> drift log
+
+**Session start phase:** <phase>
+**Session end phase:** <phase>
+**Pipeline mode:** <mode>
+
+### Phase trajectory
+- HH:MM <action> (in-phase | backflow-to-<phase> | crossphase-jump-to-<phase> | ad-hoc)
+- HH:MM ...
+
+### Session deliverables
+
+**Phase-standard artifacts produced:**
+- <filename> (phase: <phase>, agent: <agent>)
+
+**Ad-hoc artifacts produced (NOT phase-standard):**
+- <filename> (rationale recorded by user: <text> | inferred: <text>)
+
+**Sources newly verified-against-original:**
+- <refcode list>
+
+**Sources still unverified-against-original:**
+- <refcode list>
+
+### Phase status diff (from session start to session end)
+- <artifact>: <before> → <after>
+
+### Recommended next-session work (dependency-ordered)
+- <bullet list>
+```
+
+The Drift Log is **not enforcement**. It is a transparency artifact: the user reads it after the session to reconstruct what happened, decide whether ad-hoc artifacts should be promoted to phase-standard, and plan the next session.
+
+Two firm rules:
+- Backflow events are NOT failures. The Drift Log uses neutral language (`backflow-to-<phase>`), never `deviation` / `out-of-spec` / `error`.
+- Ad-hoc artifacts must be enumerated, not hidden. If `bibliography_agent` did not emit a particular file, the file is ad-hoc; this is fine but must be visible to the user.
+
+### 3.5 D5 — Retrieval pipeline single-channel fragility
+
+`retrieval_agent` (or upstream `bibliography_agent` retrieval stage) attempts a single retrieval channel (publisher direct via DOI). On failure (paywall, WAF, 403, redirect to login) the entry is marked `retrieval_failed` and the corpus moves on. Legitimate alternative channels — Wayback Machine CDX API, author personal websites, Google Scholar all-versions, OA aggregators (Unpaywall, OpenAlex, CORE) — are not attempted.
+
+**Mechanism:** Retrieval logic is implemented as a single attempt rather than a fallback chain. False negatives are common: the 2026-04-30 session recovered F3 (Yale Daily News, Vercel-WAF-blocked) via Wayback CDX search and E1 (Harvey & Stensaker 2008, Wiley paywall) via author's institutional repository — both legitimate, both invisible to single-channel retrieval.
+
+A second failure mode in single-channel retrieval: success-criterion is too weak. A 200 OK with `Content-Type: application/pdf` does NOT prove the retrieved file is the requested paper. The 2026-04-30 session retrieved an 8 MB PDF from `peraturan.bpk.go.id` with valid PDF header; first page revealed it was a Banjarmasin city tax regulation, not the requested Permendikbudristek 53/2023. The wrong-record case must be caught by content-grep at retrieval time.
+
+**Protection:** `retrieval_agent` (or equivalent retrieval stage) must implement a **fallback chain** with content verification:
+
+```python
+def retrieve(refcode, citation):
+    fallback_chain = [
+        publisher_direct,        # DOI → publisher PDF
+        wayback_cdx_search,      # CDX API → archived snapshot
+        author_personal_website, # site:<author_lastname>.<inst-tld> grep
+        scholar_all_versions,    # Scholar's "All N versions" → [PDF]-marked
+        oa_aggregators,          # Unpaywall / OpenAlex / CORE
+        researchgate_request,    # Request Full-Text via author RG profile
+    ]
+    for method in fallback_chain:
+        result = method(citation)
+        if not result.acquired:
+            log_failure(refcode, method.name, result.failure_reason)
+            continue
+        if not verify_content_match(result.pdf, citation):
+            log_failure(refcode, method.name, "content_match_failed")
+            continue
+        return result
+    return RetrievalFailed(refcode, attempts=fallback_chain_log)
+```
+
+`verify_content_match()` MUST do at minimum:
+- Read first page of retrieved PDF
+- Grep for citation title (or significant title fragment)
+- Grep for at least one citation author surname
+- Reject if either fails
+
+Two firm rules:
+- Each fallback step's failure reason must be logged (`paywall_403`, `waf_blocked`, `not_indexed`, `content_match_failed`, etc.). No silent skips.
+- `Content-Type: application/pdf` + HTTP 200 is NEVER sufficient for retrieval success. Content match is mandatory.
+
+---
+
+## 4. Implementation Steps
+
+### Step 1 — Frontmatter schema split
+
+**Files to modify:**
+- `shared/contracts/passport/literature_corpus_entry.schema.json` — add the six new fields per §3.1
+- `deep-research/agents/bibliography_agent.md` — add prompt section "Trust-Chain Frontmatter Discipline" specifying field semantics + the two firm rules + refusal-on-uncertain rule
+- `academic-paper/agents/literature_strategist_agent.md` — same prompt addition for downstream consumer
+
+**New CI lint:**
+- `scripts/check_v3_6_8_frontmatter_trust_schema.py` — validates the two firm rules across all entry .md files in a sample corpus
+- Wire into `.github/workflows/spec-consistency.yml`
+
+**Acceptance:**
+- `bibliography_agent` and `literature_strategist_agent` carry the new prompt block
+- Lint enforces both firm rules on test fixtures
+- Mutation tests confirm refusal-on-uncertain behavior
+
+### Step 2 — Audit report Scope Report block
+
+**Files to modify:**
+- `shared/templates/codex_audit_multifile_template.md` — add Scope Report block as opening section, before any pass/fail summary
+- Per-mode codex audit prompts that reference the template
+
+**New CI lint:**
+- `scripts/check_v3_6_8_audit_scope_block.py` — checks audit report templates for required Scope Report header + forbidden combined-aggregate "PASSED" verb
+
+**Acceptance:**
+- All audit templates carry the Scope Report block
+- Lint enforces template compliance
+- Sample audit report run on the 2026-04-30 HEEACT chapter session corpus reproduces the correct coverage breakdown (22 verifiable / 31 description-only of 53)
+
+### Step 3 — Cite-Time Provenance Check orchestrator hook
+
+**Files to modify:**
+- `academic-pipeline/agents/orchestrator.md` (or equivalent) — add hook spec per §3.3 matrix
+- `academic-paper/agents/draft_writer_agent.md` — add prompt block specifying that draft prose with `[UNVERIFIED CITATION ...]` markers must NOT be passed to `format_converter_agent`
+- `academic-paper/agents/format_converter_agent.md` — add hard-gate refusal rule on any draft containing `[UNVERIFIED CITATION ...]`
+
+**New CI lint:**
+- `scripts/check_v3_6_8_cite_provenance_hook.py` — checks that the orchestrator spec includes the four-cell matrix and that `format_converter_agent` carries the hard-gate refusal rule
+
+**Acceptance:**
+- Orchestrator spec includes hook
+- Draft prose containing `[UNVERIFIED CITATION ...]` produces a hard refusal at format conversion time
+- Mutation test: removing the hard-gate rule from `format_converter_agent` causes lint to fail
+
+### Step 4 — Session Drift Log emission
+
+**Files to modify:**
+- `academic-pipeline/agents/orchestrator.md` — add Drift Log artifact spec per §3.4
+- `shared/templates/session_drift_log_template.md` — new file, canonical template
+
+**Acceptance:**
+- Orchestrator emits `<session>_drift_log.md` at session end
+- Template enforces neutral language (no `deviation` / `out-of-spec` / `error` for backflow)
+- Manual run on 2026-04-30 HEEACT chapter session reproduces a plausible Drift Log (validation against this paper's authoring session as case study)
+
+### Step 5 — Retrieval fallback chain
+
+**Files to modify:**
+- `deep-research/agents/bibliography_agent.md` — add retrieval-stage prompt block per §3.5 with the six-method chain and content-match firm rule
+- New shared reference: `shared/references/retrieval_fallback_chain.md` — canonical fallback method spec, failure-reason vocabulary, content-match procedure
+
+**Acceptance:**
+- `bibliography_agent` retrieval prompt enumerates six fallback methods
+- Each method has documented failure-reason vocabulary
+- `verify_content_match()` procedure spec'd in the reference file
+- Sample run: F3 (Wayback recoverable) and E1 (author site recoverable) successfully retrieved by chain
+
+### Step 6 — Integration tests
+
+**New synthetic eval cases:**
+- `tests/eval_cases/v3_6_8_trust_chain_violation.md` — corpus with mixed `source_acquired` states; verifies (a) `bibliography_agent` does not emit unsupported `verified` claims, (b) audit emits correct Scope Report, (c) cite-time hook injects markers correctly, (d) `format_converter_agent` refuses to convert drafts with markers
+- `tests/eval_cases/v3_6_8_retrieval_fallback.md` — corpus with paywall-blocked, Wayback-recoverable, and content-mismatch entries; verifies fallback chain behavior end-to-end
+
+**Acceptance:**
+- Both eval cases pass
+- Wired into the v3.6.8 release CI gate
+
+---
+
+## 5. Acceptance Criteria
+
+ARS v3.6.8 ships when:
+
+1. All five Patterns D1–D5 carry prompt-level protection in the relevant agent(s)
+2. Frontmatter schema split is enforced by CI lint
+3. Audit report Scope Report block is present in all audit templates
+4. Cite-Time Provenance Check hook is integrated and `format_converter_agent` enforces hard gate
+5. Session Drift Log is emitted at session end
+6. Retrieval fallback chain is documented and `bibliography_agent` retrieval prompt references it
+7. Two synthetic eval cases pass end-to-end
+8. Static lint suite (similar to v3.6.7's `check_v3_6_7_pattern_protection.py` model) enforces all the above
+9. Independent xhigh codex audit on the 2026-04-30 HEEACT chapter session corpus, replayed under v3.6.8 protections, would produce a Scope Report disclosing the 22/31 split and inject `[UNVERIFIED CITATION ...]` markers on the 31 description-only entries before the user reaches chapter prose
+
+---
+
+## 6. Out-of-Scope (Future Work)
+
+- **Auto-acquisition for paywalled material via institutional VPN integration** — too environment-specific; user-handled
+- **Per-user trust-policy configuration** (e.g., "always require human-read for journal X") — future extension; v3.6.8 ships uniform schema
+- **Drift Log → automatic phase-promotion suggestion** (e.g., "your ad-hoc Quote Registry should be promoted to Phase 2 deliverable") — too prescriptive; transparency only in v3.6.8
+- **Real-time during-session warnings on phase departure** — explicit non-goal per §2.2; transparency surface is end-of-session only
+
+---
+
+## 7. Cross-References
+
+### Generative session evidence (this paper's ground truth)
+- 2026-04-30 HEEACT Springer chapter authoring session
+- Session deliverables: `chapter/literature_review/_AUDIT_FINDINGS.md`, `chapter/literature_review/PENDING_RETRIEVAL.md`, `chapter/literature_review/B_heeact_documents/B_HEEACT_HANDBOOK_QUOTE_REGISTRY.md`, `chapter/ROADMAP.md`
+- User-side memory entries (Claude Code persistent memory):
+  - `feedback_ars_user_drift_is_verification_behavior.md`
+  - `feedback_ars_verification_provenance_layer.md`
+  - `feedback_ars_audit_scope_disclosure.md`
+  - `feedback_ars_session_drift_log.md`
+  - `feedback_ars_retrieval_fallback_chain.md`
+
+### Prior-version specs this builds on
+- v3.6.7: `docs/design/2026-04-29-ars-v3.6.7-downstream-agent-pattern-protection-spec.md` — downstream agent pattern protection (D1–D5 patterns are the **upstream** complement to v3.6.7's downstream-agent narrative/instrument/publication patterns)
+- v3.6.5: literature_corpus consumer integration — frontmatter schema split (§3.1) extends `literature_corpus_entry.schema.json`
+- v3.5: Collaboration Depth Observer — advisory-not-blocking precedent (Cite-Time Provenance Check follows the same advisory model except at format-conversion hard gate)
+- v3.6.6 generator-evaluator contract: cite-time hook builds on the agent-output-evaluation pattern
+
+### Related downstream-agent feedback (different patterns, same era)
+- `feedback_ars_bibliography_agent_hallucination_patterns.md` (2026-04-29) — five upstream `bibliography_agent` patterns (JSIE prestigious anchoring, online vs print year, author mashup, phantom source, annotation overclaim). v3.6.8 D1 protection mitigates the **downstream consequence** of those upstream patterns by making trust-chain transparent.
+- `feedback_subagent_tool_hallucination.md` (2026-04-29) — sub-agent tool hallucination (claiming to have run codex audit / simulated fixes). v3.6.8 D2 (audit scope disclosure) is the structural protection: audit reports must declare what they actually verified.
+
+---
+
+## 8. Risks & Mitigations
+
+**Risk 1:** Frontmatter schema split breaks existing user adapters that emit only `verified: <date>`.
+**Mitigation:** Adapters can map legacy `verified` to the most conservative of the new fields (`source_verified_against_original: false` unless adapter has affirmative source-acquisition signal). Document migration path in `academic-pipeline/references/literature_corpus_consumers.md`.
+
+**Risk 2:** Cite-Time Provenance Check warnings are noisy in early-corpus drafts.
+**Mitigation:** Markers are draft-only and removed before final output. The hard gate is at format-conversion only. Users self-pace marker resolution.
+
+**Risk 3:** Session Drift Log produces "yet another file to read" with low signal-to-noise.
+**Mitigation:** Drift Log is end-of-session, not real-time. User reads only when reflecting on long sessions. Template structure surfaces top-3 actionable items first; full trajectory in collapsible section.
+
+**Risk 4:** Retrieval fallback chain extends retrieval time meaningfully.
+**Mitigation:** Steps are sequential with early-exit on first content-match success. Wayback CDX is fast (<5s); author-website grep is moderate; ResearchGate is slow but rarely reached. Total wall-clock for typical paper: <30s. Acceptable for batch retrieval.
+
+**Risk 5:** Spec is misread as enforcement of user behavior.
+**Mitigation:** §2.2 explicitly states "no keep-on-track enforcement." All warnings are advisory; only `format_converter_agent` enforces a hard gate, and that gate exists to prevent silent shipment of unverified citations to formal output — a different concern from in-session user behavior.
+
+---
+
+## 9. Open Questions
+
+1. **Schema 9 location of Drift Log artifact** — does the Drift Log live inside `passport.session_history[]` (Schema 9 extension) or as a peer file? Recommend peer file for v3.6.8; Schema 9 integration is v3.6.9+ work.
+2. **Retrieval fallback chain — should ResearchGate Request Full-Text be in the auto-chain or human-mediated step?** RG requires asynchronous response from the original author. Recommend marking as "human-handoff" final step that enqueues the request rather than blocking the pipeline.
+3. **Cite-Time hook — does it fire on every emission or only at deliverable-finalization?** Recommend at every emission (low overhead with cached frontmatter reads, catches issues early).
+4. **`human_read_source: true` marker — does the user signal this via UI/command, or does ARS infer from session activity?** Recommend explicit user signal (an explicit affordance is more honest than inference); the per-section pre-finalization checklist in §3.3 LOW WARN row is the natural surface.
+
+---
+
+## 10. Spec Traceability
+
+Each pattern in §3 is traceable to a specific event in the 2026-04-30 session:
+
+| Pattern | Generative event | Memory entry |
+|---------|------------------|--------------|
+| D1 | `verified: 2026-04-30` written on entries that were never cross-checked against original | `feedback_ars_verification_provenance_layer.md` |
+| D2 | Round 3 codex audit reported "ADDRESSED" without disclosing 22/31 split | `feedback_ars_audit_scope_disclosure.md` |
+| D3 | Risk articulated: user could have written chapter prose citing description-only entries before realizing scope gap | `feedback_ars_verification_provenance_layer.md` (cite-time provision) |
+| D4 | User repeatedly left phase to verify; session-end visibility of trajectory absent | `feedback_ars_user_drift_is_verification_behavior.md`, `feedback_ars_session_drift_log.md` |
+| D5 | F3 Wayback recovery + E1 Harvey personal-site recovery + PMu wrong-record content match failure | `feedback_ars_retrieval_fallback_chain.md` |
+
+Patterns are not speculative; each is a real-world hallucination-defense gap that materialized in production use.


### PR DESCRIPTION
## Summary

Commits the 386-line trust-provenance design doc that was sitting untracked in working tree since 2026-04-30 (HEEACT Springer chapter Phase 1 retrieval session). Codifies ROADMAP §3.6.8 — five upstream-trust-chain protections (D1–D5).

- **D1** Frontmatter trust-strength conflation → split `verified` into 7 orthogonal fields
- **D2** Audit scope coverage non-disclosure → Scope Report block
- **D3** Cite-time trust-chain non-check → orchestrator hook + format-converter hard gate
- **D4** Session drift untracked → end-of-session drift_log emission
- **D5** Retrieval pipeline single-channel fragility → publisher → Wayback CDX → author site → Scholar versions → OA aggregators → ResearchGate fallback chain

## Roadmap-slot-vs-release-semver decoupling

The 2026-05-05 banner clarifies why filename keeps `v3.6.8`:

- **Roadmap slot v3.6.8** = ROADMAP §3.6.8 (private, in claude-memory-sync)
- **Release tag v3.6.8** already consumed by the generator-evaluator contract (suite v3.6.8 SHIPPED 2026-05-03, main `734dd23`, see CHANGELOG `[3.6.8] - 2026-05-03`)
- When this spec ships, it tags at the next available semver (v3.6.9 / v3.7.x)
- Precedent: `2026-04-22-ars-v3.7.3-reading-check-probe-design.md` filename slot v3.7.3, released as v3.5.1

## What this PR is NOT

- ❌ Not implementation. No runtime, schema, or prompt changes.
- ❌ Not consumed by any CI lint outside spec-consistency / version-consistency (both green locally).
- ❌ Not a release. Sequencing per ROADMAP §3.6.8: HOLD until v3.6.7 follow-up ships (Step 6 Phase 6.1–6.5 done; Phase 6.6/6.7/6.8 + Step 8 pending).

## Test plan

- [x] `python3 scripts/check_spec_consistency.py` — passes
- [x] `python3 scripts/check_version_consistency.py` — passes
- [ ] CI spec-consistency green on PR

## Substance traceability

Five feedback memories (2026-04-29 ~ 2026-04-30) underpin the patterns; spec §10 maps each pattern to its generative event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)