### PR TITLE
fix(academic-pipeline/SKILL.md): align H1 + Version Info table to v3.6.8 (suite version)

### DIFF
--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -14,7 +14,7 @@ metadata:
     - academic-paper-reviewer
 ---
 
-# Academic Pipeline v3.6.5 — Full Academic Research Workflow Orchestrator
+# Academic Pipeline v3.6.8 — Full Academic Research Workflow Orchestrator
 
 A lightweight orchestrator that manages the complete academic pipeline from research exploration to final manuscript. It does not perform substantive work — it only detects stages, recommends modes, dispatches skills, manages transitions, and tracks state.
 
@@ -579,8 +579,8 @@ Stage 5: academic-paper (format-convert mode)
 
 | Item | Content |
 |------|---------|
-| Skill Version | 3.6.7 |
-| Last Updated | 2026-04-30 |
+| Skill Version | 3.6.8 |
+| Last Updated | 2026-05-03 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | deep-research v2.0+, academic-paper v2.0+, academic-paper-reviewer v1.1+ |
 | Role | Full academic research workflow orchestrator |


### PR DESCRIPTION
## Summary

Three version locations in `academic-pipeline/SKILL.md` drifted out of sync during the v3.6.6 / v3.6.7 / v3.6.8 release sequence. Aligns all three to the suite version `3.6.8`.

| Location | Before | After |
|---|---|---|
| frontmatter `version:` (line 5) | `3.6.8` | `3.6.8` (already correct) |
| H1 (line 17) | `v3.6.5` | `v3.6.8` |
| Version Info table — Skill Version (line 582) | `3.6.7` | `3.6.8` |
| Version Info table — Last Updated | `2026-04-30` | `2026-05-03` |

## Why this slipped past CI

`scripts/check_version_consistency.py` only validates three pairs:
1. `.claude/CLAUDE.md` Skills Overview table ↔ each SKILL.md frontmatter
2. `**Suite version**` ↔ CHANGELOG latest
3. `academic-pipeline` table version ↔ suite version

Body labels (H1 line, Version Info table) are not part of the lint surface, so CI stayed green while drift accumulated. Other SKILL.md files (`academic-paper`, `academic-paper-reviewer`, `deep-research`) keep H1 + frontmatter + Version Info in lockstep — `academic-pipeline` was the outlier.

## Test plan

- [x] `python3 scripts/check_spec_consistency.py` — passes
- [x] `python3 scripts/check_version_consistency.py` — passes
- [ ] CI spec-consistency green on PR

## Out of scope

Tightening `check_version_consistency.py` to also validate H1 + Version Info table against frontmatter is a follow-up — would prevent this drift class globally. Listed in feedback memory `feedback_version_bump_sweep_checklist.md` already; this PR is a one-shot fix, not a lint expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)