### PR TITLE
feat(v3.7.0 Phase 2.1): plugin commands + hardened agent symlinks (3 codex rounds → 0 findings)

### DIFF
--- a/agents/report_compiler_agent.md
+++ b/agents/report_compiler_agent.md
@@ -1,0 +1,1 @@
+../deep-research/agents/report_compiler_agent.md

--- a/agents/research_architect_agent.md
+++ b/agents/research_architect_agent.md
@@ -1,0 +1,1 @@
+../deep-research/agents/research_architect_agent.md

--- a/agents/synthesis_agent.md
+++ b/agents/synthesis_agent.md
@@ -1,0 +1,1 @@
+../deep-research/agents/synthesis_agent.md

--- a/commands/ars-abstract.md
+++ b/commands/ars-abstract.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `abstract-only` mode — bilingual abstract + keywords
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `abstract-only` mode. Produces a bilingual (zh-TW + EN) abstract plus keywords. Fidelity spectrum, medium oversight. Carries the v3.6.7 `report_compiler_agent` PATTERN PROTECTION layer when invoked through the pipeline.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-citation-check.md
+++ b/commands/ars-citation-check.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `citation-check` mode — citation error report
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `citation-check` mode. Produces a citation error report (missing references, mismatched in-text citations, format errors). Fidelity spectrum, low oversight.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-disclosure.md
+++ b/commands/ars-disclosure.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `disclosure` mode — venue-specific AI-usage statement
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `disclosure` mode. Produces a venue-specific AI-usage disclosure statement (ICLR / NeurIPS / Nature / Science / ACL / EMNLP supported). Fidelity spectrum, low oversight.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-format-convert.md
+++ b/commands/ars-format-convert.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `format-convert` mode — convert to LaTeX / DOCX / PDF / Markdown
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `format-convert` mode. Converts a paper between LaTeX, DOCX (via Pandoc), PDF, or Markdown, and converts citation styles between major formats. Fidelity spectrum, low oversight.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-full.md
+++ b/commands/ars-full.md
@@ -1,0 +1,9 @@
+---
+description: ARS full pipeline — research → write → review → revise → finalize
+model: opus
+---
+
+Trigger the ARS `full` pipeline mode. Load the `academic-pipeline` skill and execute the complete academic research workflow (10-stage orchestration: deep-research → academic-paper → integrity → academic-paper-reviewer → revision → re-review → final integrity → finalize).
+
+Mode reference: `MODE_REGISTRY.md` § academic-pipeline.
+Skill entry: `academic-pipeline/SKILL.md`.

--- a/commands/ars-full.md
+++ b/commands/ars-full.md
@@ -3,7 +3,7 @@ description: ARS full pipeline — research → write → review → revise → 
 model: opus
 ---
 
-Trigger the ARS `full` pipeline mode. Load the `academic-pipeline` skill and execute the complete academic research workflow (10-stage orchestration: deep-research → academic-paper → integrity → academic-paper-reviewer → revision → re-review → final integrity → finalize).
+Trigger the `academic-pipeline` orchestrator (`(pipeline)` in MODE_REGISTRY.md — the orchestrator has no named mode of its own). Loads the skill and executes the complete academic research workflow (10-stage orchestration: deep-research → academic-paper → integrity → academic-paper-reviewer → revision → re-review → final integrity → finalize).
 
 Mode reference: `MODE_REGISTRY.md` § academic-pipeline.
 Skill entry: `academic-pipeline/SKILL.md`.

--- a/commands/ars-lit-review.md
+++ b/commands/ars-lit-review.md
@@ -1,0 +1,11 @@
+---
+description: ARS academic-paper `lit-review` mode — annotated bibliography in paper format
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `lit-review` mode. Produces an annotated bibliography rendered as a literature review section. Fidelity spectrum, medium oversight.
+
+For the upstream research-side literature review (annotated bibliography + synthesis report) prefer the `deep-research` skill `lit-review` mode instead.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-outline.md
+++ b/commands/ars-outline.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `outline-only` mode — detailed outline + evidence map
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `outline-only` mode. Produces a detailed paper outline with evidence map, no full draft. Balanced spectrum, high oversight.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-plan.md
+++ b/commands/ars-plan.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `plan` mode — Socratic chapter-by-chapter planning
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `plan` mode. Produces a Chapter Plan + INSIGHT collection through Socratic dialogue with the user. Originality-spectrum, very-high oversight.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-revision-coach.md
+++ b/commands/ars-revision-coach.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `revision-coach` mode — Revision Roadmap + Response Letter Skeleton
+model: opus
+---
+
+Trigger the `academic-paper` skill in `revision-coach` mode. Parses reviewer comments and produces a Revision Roadmap plus a Response Letter skeleton, without writing the revision itself. Balanced spectrum, medium oversight. Uses opus per project policy for review-interpretation depth.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/commands/ars-revision.md
+++ b/commands/ars-revision.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper `revision` mode — revised draft + R&R responses
+model: sonnet
+---
+
+Trigger the `academic-paper` skill in `revision` mode. Produces a revised draft plus point-by-point response-to-reviewers. Fidelity spectrum, high oversight.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper.
+Skill entry: `academic-paper/SKILL.md`.

--- a/deep-research/agents/report_compiler_agent.md
+++ b/deep-research/agents/report_compiler_agent.md
@@ -1,6 +1,7 @@
 ---
 name: report_compiler_agent
 description: "Transforms research findings into polished APA 7.0 academic reports; activated in Phase 4 and Phase 6"
+model: inherit
 ---
 
 # Report Compiler Agent — APA 7.0 Academic Report Writer

--- a/deep-research/agents/research_architect_agent.md
+++ b/deep-research/agents/research_architect_agent.md
@@ -1,6 +1,7 @@
 ---
 name: research_architect_agent
 description: "Designs the methodological blueprint; selects research paradigm, method, data strategy, and analytical framework"
+model: inherit
 ---
 
 # Research Architect Agent — Methodology Blueprint Designer

--- a/deep-research/agents/synthesis_agent.md
+++ b/deep-research/agents/synthesis_agent.md
@@ -1,6 +1,7 @@
 ---
 name: synthesis_agent
 description: "Integrates findings across sources, resolves evidence conflicts, and maps knowledge gaps"
+model: inherit
 ---
 
 # Synthesis Agent — Cross-Source Integration & Gap Analysis

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -31,6 +31,18 @@
 
 > **⚠️ Skip Permissions**: This flag disables all tool-use confirmation dialogs. Use at your own discretion — it is convenient for trusted, long-running pipelines but removes the safety net of manual approval. Only enable this in environments where you are comfortable with Claude executing file reads, writes, and shell commands without asking first.
 
+### v3.7.0 Plugin agents and model routing
+
+When ARS is installed as a Claude Code plugin (`/plugin install academic-research-skills`), three downstream worker agents are exposed as plugin-shipped subagents: `synthesis_agent`, `research_architect_agent`, and `report_compiler_agent`. Each declares `model: inherit` in its frontmatter, which means they run under the **dispatching session's model** rather than a pinned floor:
+
+- An Opus session running the full pipeline gets Opus agents, preserving the integrative depth those agents were designed for.
+- A Sonnet session gets Sonnet agents, matching the cost/latency profile of the parent run.
+- The agents never silently fall back to Haiku — `inherit` resolves through the parent session's model, which is itself gated by the project policy of "no Haiku for ARS runs."
+
+This means **plugin-agent token costs track the per-mode estimates above unchanged**; there is no separate plugin agent surcharge or discount, because dispatched agents inherit the same model the parent run already pays for. If you change the main session model mid-pipeline (e.g., downshift to Sonnet for a long revision pass), the next agent dispatch picks up the new floor automatically.
+
+Other ARS agents (`bibliography_agent`, `literature_strategist_agent`, etc.) are not plugin-exposed in v3.7.0; they remain in-skill prompt templates that the main session executes inline, with no separate model routing layer. Wider plugin-agent coverage is v3.6.8+ scope.
+
 ## Long-running session management
 
 The full academic pipeline is designed for human-in-the-loop execution, with mandatory user confirmation at every stage. In practice, a full run often spans hours to days — longer than Anthropic's prompt cache TTL (5 minutes). Two consequences:

--- a/docs/PERFORMANCE.zh-TW.md
+++ b/docs/PERFORMANCE.zh-TW.md
@@ -31,6 +31,18 @@
 
 > **⚠️ Skip Permissions 注意事項**：此旗標會停用所有工具使用的確認對話框。請自行斟酌使用 — 在可信任的長時間 pipeline 中非常方便，但會移除手動審核的安全機制。僅在你確定接受 Claude 自動執行檔案讀寫、shell 指令等操作時才啟用。
 
+### v3.7.0 Plugin agent 與模型路由
+
+當 ARS 以 Claude Code plugin 方式安裝（`/plugin install academic-research-skills`）時，會把三個下游 worker agent 暴露為 plugin-shipped subagent：`synthesis_agent`、`research_architect_agent`、`report_compiler_agent`。三個 agent frontmatter 都標 `model: inherit`，意思是它們**繼承派工 session 的模型**而非寫死特定 floor：
+
+- Opus session 跑完整 pipeline 時 agent 是 Opus，保留這三個 agent 設計的整合深度。
+- Sonnet session 取得 Sonnet agent，跟主 session cost / latency 對齊。
+- Agent 永遠不會默默掉到 Haiku — `inherit` 走的是主 session 模型，主 session 本身又被「ARS 全程不用 Haiku」政策守住。
+
+意涵：**plugin agent 的 token 成本完全跟著上表各模式估算走，沒有額外加減**。dispatched agent 跟主 session 同一個模型，主 session 已經付的成本沒有再多一層 plugin agent 收費。如果 pipeline 中途換模型（例如 revision pass 改用 Sonnet 省成本），下一輪 agent 派工自動跟上。
+
+其他 ARS agent（`bibliography_agent`、`literature_strategist_agent` 等）在 v3.7.0 不暴露為 plugin agent；它們仍是 in-skill prompt template，由主 session 內聯執行，沒有獨立的模型路由層。更廣的 plugin agent 覆蓋是 v3.6.8+ 的工作。
+
 ## 長時間 session 管理
 
 完整 pipeline 設計為 human-in-the-loop，每個階段都需使用者確認。實務上一次完整執行會跨越數小時到數天，遠長於 Anthropic 的 prompt cache TTL（5 分鐘）。兩項結果：


### PR DESCRIPTION
## Summary

Phase 2.1 of the v3.7.0 plugin packaging roadmap — exposes ARS modes and downstream worker agents through Claude Code's plugin command/agent layers, without touching the existing 4 skill directories.

- **10 slash commands** under `commands/ars-*.md` mapping `MODE_REGISTRY.md` entries to `/ars-<mode>` triggers. Explicit model routing per project policy: `opus` for `full` and `revision-coach` (architectural / review-interpretation depth); `sonnet` for the other 8. No haiku.
- **3 plugin-shipped agents** under `agents/*_agent.md` as relative symlinks to the v3.6.7-hardened downstream agents in `deep-research/agents/`: `synthesis_agent`, `research_architect_agent`, `report_compiler_agent`. Underscore filenames preserved to match `scripts/check_v3_6_7_pattern_protection.py` hard-pinned paths and the INV-3 manifest-confined Clause 1 invariant. Symlinks (not copies) preserve a single source of truth and prevent the Pattern C3 attack surface that v3.6.7 §6 inversion sweep + INV-1/2/3 lint closes.
- **`model: inherit`** added to those three source agent frontmatters (R1 codex finding). Inherit was chosen over pinning `sonnet` because (a) the agents are designed as downstream pipeline workers that follow the dispatching session's model floor, (b) the existing PreToolUse hook (`~/.claude/hooks/warn-agent-no-model.sh`, 2026-04-18) already gates Haiku at the Agent dispatch boundary, (c) an Opus session running ARS full pipeline keeps Opus agents instead of being capped at sonnet.
- **`docs/PERFORMANCE.md` + `docs/PERFORMANCE.zh-TW.md`** gain a "v3.7.0 Plugin agents and model routing" subsection (R2-P3 finding) explaining the inherit semantics and the current 3-agent scope boundary (other ARS agents are v3.6.8+ scope).

Phase 2.1 deliberately scopes out hooks — those land in Phase 2.2 with `scripts/run_codex_audit.sh` wrapper integration.

## Codex iterative review

- **R1**: 1 P1 (missing `model:` on 3 source agents → default haiku risk via plugin loader) + 1 P2 (`ars-full.md` body called orchestrator a "full mode" but `MODE_REGISTRY.md` shows it has no named mode). Both addressed in commit 2.
- **R2**: 1 P1 (transient — uncommitted R1 fixes blocked tag dry-run; resolved by committing) + 1 P3 (`docs/PERFORMANCE.md` doc gap for the new model routing decision). P3 addressed in commit 3.
- **R3**: **0 findings (P0/P1/P2)**. Ship gate met per `feedback_codex_iterative_spec_review_to_zero`. No cascade.

## Validation

```text
claude plugin validate .                          PASS
claude plugin validate .claude-plugin/plugin.json PASS
claude plugin tag --dry-run .                     PASS
check_v3_6_7_pattern_protection.py                12/12 PASS (A1-A5/B1-B5/C1-C3/INV-1/2/3)
check_corpus_consumer_protocol.py                 PASS
check_spec_consistency.py                         PASS
pytest scripts/                                   742 passed, 3 skipped
```

`check_passport_reset_contract.py` flags `.codex-rounds/round11.txt` (gitignored) — pre-existing baseline, not introduced by this PR.

## Test plan

- [x] `claude plugin validate .` and `.claude-plugin/plugin.json` pass
- [x] `claude plugin tag --dry-run .` passes (clean working tree, version intact)
- [x] All ARS lint scripts green (`check_v3_6_7_pattern_protection`, `check_corpus_consumer_protocol`, `check_spec_consistency`)
- [x] 742 pytest + 3 skipped (unchanged from main `6006c5b`)
- [x] 3 codex review rounds → 0 findings
- [x] Public-repo PII scan: clean
- [ ] After merge: verify `/plugin install` exposes the 10 slash commands and 3 agents in a fresh session (manual check by user)

## Related

- Roadmap: `docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md` (Update note 2026-05-05 supersedes original Phase 2 prose)
- Phase 1 (skills/ symlinks + manifest): #68 (merged 2026-05-05, `6006c5b`)
- Next: Phase 2.2 (hooks/hooks.json + run_codex_audit.sh wrapper) and Phase 3 (sweep + tag + GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)