### PR TITLE
feat(v3.7.0 Phase 2.2): SessionStart announce hook (2 inline rounds + fresh PR review → 0 findings)

### DIFF
--- a/docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md
+++ b/docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md
@@ -494,19 +494,22 @@ academic-research-skills/
 │   ├── ars-format-convert.md
 │   ├── ars-citation-check.md
 │   └── ars-disclosure.md
-├── agents/                             [Phase 2 新增]
-│   ├── research-agent.md
-│   ├── write-agent.md
-│   ├── review-agent.md
-│   ├── bibliography-agent.md
-│   ├── synthesis-agent.md
-│   ├── survey-designer.md
-│   └── abstract-compiler.md
-├── hooks/                              [Phase 2 新增]
-│   └── hooks.json
+├── agents/                             [Phase 2.1 新增 — 3 個 v3.6.7 hardened agent symlinks]
+│   ├── synthesis_agent.md -> ../deep-research/agents/synthesis_agent.md
+│   ├── research_architect_agent.md -> ../deep-research/agents/research_architect_agent.md
+│   └── report_compiler_agent.md -> ../deep-research/agents/report_compiler_agent.md
+│   # NOTE: original draft listed 7 agents (research-agent / write-agent / review-agent /
+│   # bibliography-agent / synthesis-agent / survey-designer / abstract-compiler).
+│   # Per Update note 2026-05-05 §1, plugin agent council shrank to 3 because v3.6.7 §6
+│   # inversion sweep + INV-1/2/3 lint only hardened those three. bibliography_agent and
+│   # the others remain in-skill prompt templates (v3.6.8+ scope).
+├── hooks/                              [Phase 2.2 新增]
+│   └── hooks.json                          # SessionStart announce only
 ├── scripts/
-│   ├── codex-audit-on-phase-complete.sh    [Phase 2 新增]
-│   └── announce-ars-loaded.sh              [Phase 2 新增]
+│   └── announce-ars-loaded.sh              [Phase 2.2 新增 — Bash 3.2 compatible]
+│   # NOTE: original draft also listed `codex-audit-on-phase-complete.sh` here.
+│   # That script is ABANDONED per the Update note 2026-05-05 (Phase 2.2 scope reduction).
+│   # SubagentStop → run_codex_audit.sh integration deferred to v3.6.8+.
 ├── deep-research/                      [既有，不動]
 ├── academic-paper/                     [既有，不動]
 ├── academic-paper-reviewer/            [既有，不動]

--- a/docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md
+++ b/docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md
@@ -47,6 +47,19 @@ This roadmap was drafted on 2026-04-30, before v3.6.7 Phase 6.1-6.8 shipped to m
 
 ---
 
+## Update note 2026-05-05 (Phase 2.2 scope reduction)
+
+After Phase 2.1 shipped (PR #69, merge commit `e841319`), Phase 2.2 was scoped down from "hooks for SessionStart announce + SubagentStop codex audit" to **SessionStart announce only**. The original Task 2.4 below — `PostToolUse` matcher `Write|Edit` invoking `scripts/codex-audit-on-phase-complete.sh` — was abandoned during Phase 2.2 design review for two compounding reasons:
+
+1. **Wrong invoker class.** `scripts/run_codex_audit.sh` lines 4–7 explicitly forbid same-session in-LLM invocation (Pattern C3 attack surface). `PostToolUse` matcher `Write|Edit` would fire from inside the LLM session that produced the deliverable — exactly the case the wrapper bans. `SubagentStop` is a permitted invoker class, but…
+2. **Contract gap.** `run_codex_audit.sh` requires `--stage <1-6> --agent <name> --deliverable <repo-relative-path>`. The `SubagentStop` hook payload only carries `agent_id`, `agent_type`, `session_id`, `cwd`, `transcript_path`. There is no documented propagation path from ARS pipeline state (current stage + which deliverable just landed) into the hook payload. Building a hook that half-infers stage/deliverable would be design lying — either the wrapper runs against the wrong file, or the hook degrades to "remind the user to invoke the wrapper externally," which is no better than documenting the wrapper's CLI in the README.
+
+Decision: **Phase 2.2 ships only the SessionStart announce hook.** A real SubagentStop → `run_codex_audit.sh` integration is deferred to v3.6.8+ when ARS gains a stage/deliverable propagation contract (likely as a passport ledger entry that the hook can read from `${CLAUDE_PROJECT_DIR}` or a fixed location under `audit_artifacts/`). The sections below describing Step 1–3 of the original Task 2.4 are retained as historical context but treated as obsoleted reference; the actual Phase 2.2 implementation lives at `hooks/hooks.json` and `scripts/announce-ars-loaded.sh`.
+
+The `feedback_no_haiku.md` model-floor concern that motivated PostToolUse-based audit triggering is partially addressed at a different layer: ARS slash commands pin `opus`/`sonnet` in their frontmatter, plugin agents use `model: inherit`, and the user's PreToolUse `warn-agent-no-model.sh` hook enforces no-haiku at Agent dispatch. The remaining gap is "did codex actually audit the deliverable?" — that gate stays human-driven (CI workflow step or external terminal) for v3.7.0.
+
+---
+
 **Goal:** 將 ARS 從「git clone + symlink 到 `~/.claude/skills/`」的分發模式，升級成 Claude Code Plugin（`/plugin install` 一行裝），同時保留 GitHub repo 作為 source of truth 與教學內容主入口。
 
 **Architecture:** 雙軌並行——同一個 repo 同時支援 (a) 傳統 clone+symlink 安裝、(b) Claude Code plugin marketplace 安裝。Plugin 化只新增 `.claude-plugin/`、`commands/`、`agents/`、`hooks/` 四個目錄，不動 `deep-research/`、`academic-paper/`、`academic-paper-reviewer/`、`academic-pipeline/` 四個既有 skill 目錄的 SKILL.md 內容。

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/announce-ars-loaded.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/announce-ars-loaded.sh\""
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/announce-ars-loaded.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/announce-ars-loaded.sh
+++ b/scripts/announce-ars-loaded.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# version: 1.0.0
+#
+# SessionStart hook script for the ARS Claude Code plugin (v3.7.0+).
+#
+# Reads the SessionStart event JSON on stdin and emits a hookSpecificOutput
+# JSON with `additionalContext` describing what ARS provides in this session.
+# The plugin loader injects that context into the LLM's first turn so the
+# user (and Claude) can see, on session start, that ARS is loaded and which
+# slash commands and plugin agents are available.
+#
+# Allowed invokers: Claude Code's plugin loader (SessionStart event).
+# This script is safe to run from any context; it does not invoke codex,
+# does not write outside its own stdout, and produces no side effects on
+# the working tree.
+#
+# Exit codes:
+#   0    Always — even on parse failure, fall back to the long-form announce.
+#   2    Reserved (not used; SessionStart cannot block).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# This script intentionally avoids Bash 4+ features (no associative arrays,
+# no indirect expansion via `${!var}`, no `<<<` here-strings on the hot
+# path). It runs cleanly on macOS stock /bin/bash 3.2 so plugin users
+# don't have to `brew install bash` just to see the SessionStart announce.
+# `run_codex_audit.sh` does need Bash 4+ — that wrapper guards itself.
+# ---------------------------------------------------------------------------
+# Read SessionStart event JSON from stdin and pull `source` (one of
+# startup / resume / clear / compact) without taking a hard dependency on
+# jq — many ARS users won't have it installed and we want this hook to
+# work out of the box.
+# ---------------------------------------------------------------------------
+INPUT=""
+if [[ ! -t 0 ]]; then
+  INPUT=$(cat)
+fi
+
+SOURCE="startup"
+if [[ -n "${INPUT}" ]]; then
+  # Match `"source": "<value>"` with optional whitespace; tolerate single-line
+  # or multi-line JSON. Falls through to default `startup` on any parse miss.
+  if [[ "${INPUT}" =~ \"source\"[[:space:]]*:[[:space:]]*\"([a-z]+)\" ]]; then
+    SOURCE="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# For `compact` and `resume` we keep the announce minimal: the LLM already
+# has prior ARS context from the resumed transcript or carried-over summary,
+# and re-injecting the full slash-command list every resume burns context.
+# `startup` and `clear` get the full version.
+# ---------------------------------------------------------------------------
+case "${SOURCE}" in
+  compact|resume)
+    ANNOUNCE="ARS v3.7.0 plugin still loaded after ${SOURCE}. Slash commands: /ars-full /ars-plan /ars-outline /ars-revision /ars-revision-coach /ars-abstract /ars-lit-review /ars-format-convert /ars-citation-check /ars-disclosure. Plugin agents: synthesis_agent, research_architect_agent, report_compiler_agent."
+    ;;
+  startup|clear|*)
+    ANNOUNCE="ARS v3.7.0 (academic-research-skills) plugin loaded.
+
+Slash commands (10) — model routing pinned in frontmatter:
+  /ars-full              opus    Full pipeline (research → write → review → revise → finalize)
+  /ars-revision-coach    opus    Parse reviewer comments → Revision Roadmap + Response Letter skeleton
+  /ars-plan              sonnet  Socratic chapter-by-chapter planning
+  /ars-outline           sonnet  Detailed outline + evidence map (no full draft)
+  /ars-revision          sonnet  Revised draft + R&R responses
+  /ars-abstract          sonnet  Bilingual abstract + keywords
+  /ars-lit-review        sonnet  Annotated bibliography in paper format
+  /ars-format-convert    sonnet  Convert paper between LaTeX / DOCX / PDF / Markdown
+  /ars-citation-check    sonnet  Citation error report
+  /ars-disclosure        sonnet  Venue-specific AI-usage disclosure statement
+
+Plugin agents (3, v3.6.7-hardened, model: inherit) — dispatched by ARS pipeline:
+  synthesis_agent             Cross-source integration, contradiction resolution, gap analysis
+  research_architect_agent    Methodology blueprint (paradigm, method, data strategy)
+  report_compiler_agent       APA 7.0 report drafting (Phase 4 + Phase 6)
+
+Other ARS agents (bibliography_agent, literature_strategist_agent, field_analyst_agent, etc.) remain in-skill prompt templates loaded via SKILL.md, not plugin agents.
+
+Token budget reference: docs/PERFORMANCE.md (a single full pipeline run ≈ \$4–6 on Opus 4.7)."
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Emit the JSON. We assemble it with a here-doc and a sentinel substitution
+# rather than printf/jq to keep the output stable across Bash patch versions.
+# additionalContext must be a JSON string — escape backslashes, double quotes,
+# newlines.
+# ---------------------------------------------------------------------------
+escape_json() {
+  local raw="$1"
+  raw="${raw//\\/\\\\}"
+  raw="${raw//\"/\\\"}"
+  raw="${raw//$'\n'/\\n}"
+  printf '%s' "${raw}"
+}
+
+ESCAPED=$(escape_json "${ANNOUNCE}")
+
+cat <<JSON
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"${ESCAPED}"}}
+JSON
+
+exit 0


### PR DESCRIPTION
## Summary

Phase 2.2 of the v3.7.0 plugin packaging roadmap — adds the SessionStart announce hook so that when a user opens a session with the ARS plugin enabled, Claude (and the user) get an explicit list of the 10 `/ars-*` slash commands and 3 plugin-shipped agents along with the model routing baked into each.

**Phase 2.2 was scoped down** during design review from "SessionStart announce + SubagentStop codex audit" to **SessionStart announce only**. The `docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md` file gains a second Update note 2026-05-05 block documenting the two reasons for dropping the SubagentStop → `run_codex_audit.sh` integration:

1. **Wrong invoker class.** `run_codex_audit.sh` lines 4–7 explicitly forbid same-session in-LLM invocation (Pattern C3 attack surface). The original `PostToolUse` matcher `Write|Edit` would fire from inside the LLM session producing the deliverable — exactly the case the wrapper bans.
2. **Contract gap.** `run_codex_audit.sh` requires `--stage <1-6> --agent <name> --deliverable <repo-rel-path>`. SubagentStop's hook payload only carries `agent_id`, `agent_type`, `session_id`, `cwd`, `transcript_path` — no propagation path from ARS pipeline state into the hook. Building a wrapper that half-infers stage/deliverable would be design lying.

A real SubagentStop → `run_codex_audit.sh` integration is deferred to v3.6.8+ when ARS gains a stage/deliverable propagation contract (likely a passport ledger entry the hook can read from `${CLAUDE_PROJECT_DIR}` or a fixed location under `audit_artifacts/`).

The model-floor goal that motivated the abandoned audit hook is partially addressed at other layers: slash commands pin `opus`/`sonnet` in their frontmatter (Phase 2.1), plugin agents declare `model: inherit` (Phase 2.1), and the user's PreToolUse `warn-agent-no-model.sh` hook gates haiku at Agent dispatch.

## What changed

- **`hooks/hooks.json` (NEW)** — registers a `SessionStart` command-type hook → `bash "${CLAUDE_PLUGIN_ROOT}/scripts/announce-ars-loaded.sh"`. The path is quoted to handle install paths containing spaces (e.g. `/Users/Jane Doe/...`); pattern matches Claude Code's bundled plugins.
- **`scripts/announce-ars-loaded.sh` (NEW, executable)** — Bash 3.2 compatible (intentionally — no `brew install bash` requirement on macOS). Reads SessionStart event JSON on stdin, extracts `source` (`startup`/`resume`/`clear`/`compact`), emits `hookSpecificOutput` JSON with `additionalContext`. `startup` and `clear` get the full announce (~1500 chars: 10 slash commands + 3 plugin agents + token budget pointer); `resume` and `compact` get a one-line ack to avoid burning context on every resume.
- **`docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md`** — adds the Phase 2.2 scope-reduction Update note and reconciles the §"File Structure 總覽" tree with the actual shipped layout (3 agent symlinks, no `codex-audit-on-phase-complete.sh`).

## Codex review chain

| Round | Mode | Findings | Notes |
|---|---|---|---|
| R1 | inline iterative (`codex exec`) | 0 P0/P1/P2, 1 P3 | P3: stale 7-agent + audit-script references in §"File Structure 總覽". Fixed in commit 2. |
| R2 | inline iterative (convergence) | **0 findings** | No cascade. Ship gate met per `feedback_codex_iterative_spec_review_to_zero`. |
| Fresh PR R1 | `codex exec review --base main` | 1 P2 | Caught what inline rounds missed: `${CLAUDE_PLUGIN_ROOT}` not quoted → install paths with spaces break the hook. Fixed in commit 3 with empirical test (`/tmp/has space in path`). |
| Fresh PR R2 | `codex exec review --base main` | **0 findings** | Convergence confirmed. |

Carrying the lesson from `feedback_codex_review_vs_resume_audit_scope.md`: inline review verifies implementation correctness, fresh PR review verifies contract / install-time properties — different scopes, both needed.

## Validation

```text
claude plugin validate .                          PASS
claude plugin validate .claude-plugin/plugin.json PASS
claude plugin tag --dry-run .                     PASS (would tag academic-research-skills--v3.7.0)
hooks.json schema                                 valid JSON, matches code.claude.com/docs/en/hooks
announce script vs all 4 source values            valid JSON for each
announce script edge cases                        valid JSON for empty stdin + bad JSON
announce script on macOS /bin/bash 3.2            valid JSON
announce script with path containing spaces       valid JSON, 1476 chars
check_v3_6_7_pattern_protection.py                12/12 PASS (A1-A5/B1-B5/C1-C3/INV-1/2/3)
check_corpus_consumer_protocol.py                 PASS
check_spec_consistency.py                         PASS
pytest scripts/                                   742 passed, 3 skipped
```

`check_passport_reset_contract.py` flags `.codex-rounds/round11.txt` (gitignored, pre-existing baseline, not introduced by this PR).

## Test plan

- [x] All 4 SessionStart `source` values produce valid JSON (`startup` / `resume` / `clear` / `compact`)
- [x] Empty stdin and malformed JSON inputs still produce valid JSON output (graceful fallback)
- [x] Script runs cleanly on macOS stock `/bin/bash` 3.2.57 — no Bash 4+ idioms
- [x] Quoted plugin path handles install paths containing spaces
- [x] `claude plugin validate .` and `tag --dry-run .` pass
- [x] All ARS lint scripts green; 742 pytest unchanged
- [x] 2 inline + 2 fresh PR codex rounds → 0 findings
- [ ] After merge: install plugin in a clean session and verify the announce appears (manual check by user)

## Related

- Roadmap: `docs/design/2026-04-30-ars-v3.7.0-plugin-packaging-roadmap.md` (two Update note 2026-05-05 blocks now — original + Phase 2.2 scope reduction; latest wins on conflict)
- Phase 1 (skills + manifest): #68 (`6006c5b`)
- Phase 2.1 (commands + agents): #69 (`e841319`)
- Next: Phase 3 (9-category sweep + git tag v3.7.0 + GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)