### PR TITLE
docs(readme): hero install hook + prerequisites + first-command guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 
 A comprehensive suite of Claude Code skills for academic research, covering the full pipeline from research to publication.
 
+**Install in 30 seconds** (Claude Code CLI / VS Code / JetBrains, v3.7.0+):
+
+```text
+/plugin marketplace add Imbad0202/academic-research-skills
+/plugin install academic-research-skills
+```
+
+Then try `/ars-plan` to walk through your paper structure via Socratic dialogue, or jump to [Quick install](#quick-install) for prerequisites and the traditional symlink flow.
+
 > **AI is your copilot, not the pilot.** This tool won't write your paper for you. It handles the grunt work — hunting down references, formatting citations, verifying data, checking logical consistency — so you can focus on the parts that actually require your brain: defining the question, choosing the method, interpreting what the data means, and writing the sentence after "I argue that."
 >
 > Unlike a humanizer, this tool doesn't help you hide the fact that you used AI. It helps you write better. Style Calibration learns your voice from past work. Writing Quality Check catches the patterns that make prose feel machine-generated. The goal is quality, not cheating.
@@ -28,14 +37,22 @@ v3.3 was inspired by [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Son
 
 The architecture doc supersedes the sprawling pipeline description that used to live here. Everything about *what runs in which stage* now lives in one place.
 
-## Setup & installation
+## Quick install
 
-**Quick install for Claude Code CLI / IDE (v3.7.0+):**
+**Prerequisites**
+
+- [Claude Code](https://claude.ai/install.sh) (latest; plugin packaging requires recent versions)
+- `ANTHROPIC_API_KEY` exported, or set on first `claude` run
+- *Optional:* Pandoc for DOCX, tectonic + Source Han Serif TC for APA 7.0 PDF (Markdown output works without either)
+
+**Plugin install (v3.7.0+, recommended):**
 
 ```text
 /plugin marketplace add Imbad0202/academic-research-skills
 /plugin install academic-research-skills
 ```
+
+**Verify it works:** run `/ars-plan` and describe a paper you're working on — ARS will start a Socratic dialogue to map out chapter structure. For a single-shot test instead, try `/ars-lit-review "your topic"`.
 
 **👉 [docs/SETUP.md](docs/SETUP.md)** — full guide: install Claude Code, set up API keys, optional Pandoc/tectonic for DOCX/PDF, cross-model verification (`ARS_CROSS_MODEL`), and five installation methods (Plugin, project skills, global skills, claude.ai Project, repo-cloned).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,6 +8,15 @@
 
 一套完整的學術研究 Claude Code 技能包，涵蓋從研究到論文出版的全流程。
 
+**30 秒安裝**（Claude Code CLI / VS Code / JetBrains，v3.7.0+）：
+
+```text
+/plugin marketplace add Imbad0202/academic-research-skills
+/plugin install academic-research-skills
+```
+
+裝完跑 `/ars-plan`，ARS 會用蘇格拉底對話幫你規劃章節結構。需要前置條件或傳統 symlink 安裝請看 [快速安裝](#快速安裝)。
+
 > **AI 是你的副駕駛，不是機長。** 這工具不會幫你寫論文。它處理苦工 — 搜文獻、排格式、驗數據、查邏輯一致性 — 讓你專注在真正需要你腦子的事：定義問題、選方法、詮釋數據的意義、寫出「我認為」後面那句話。
 >
 > 跟 humanizer 不同，這工具不是幫你隱藏用 AI 協作的事實，而是幫你把關文章品質。風格校準從你過去的文章學習你的聲音，寫作品質檢查抓出讓文字讀起來像機器產的模式。目標是品質，不是遮掩。
@@ -28,14 +37,22 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 
 這份架構文件取代了原本散在 README 各處的 pipeline 描述。關於「哪個階段跑什麼」的所有資訊都集中在一個地方。
 
-## 安裝與設定
+## 快速安裝
 
-**Claude Code CLI / IDE 用戶一行裝（v3.7.0+）：**
+**前置條件**
+
+- [Claude Code](https://claude.ai/install.sh)（建議最新版；plugin packaging 需要近期版本）
+- 已 export `ANTHROPIC_API_KEY`，或第一次跑 `claude` 時設定
+- *選用：* Pandoc 用於 DOCX 輸出，tectonic + 思源宋體 TC 用於 APA 7.0 PDF（純 Markdown 輸出兩個都不需要）
+
+**Plugin 安裝（v3.7.0+，推薦）：**
 
 ```text
 /plugin marketplace add Imbad0202/academic-research-skills
 /plugin install academic-research-skills
 ```
+
+**驗證可用：** 跑 `/ars-plan` 並描述你正在寫的論文，ARS 會用蘇格拉底對話幫你規劃章節結構。想要單次測試的話改跑 `/ars-lit-review "你的主題"`。
 
 **👉 [docs/SETUP.zh-TW.md](docs/SETUP.zh-TW.md)** — 完整指南：安裝 Claude Code、設定 API key、選用的 Pandoc/tectonic（DOCX/PDF）、跨模型驗證（`ARS_CROSS_MODEL`），以及五種安裝方式（Plugin、專案 skills、全域 skills、claude.ai Project、repo clone）。
 


### PR DESCRIPTION
## Summary

Three first-screen conversion improvements to both `README.md` and `README.zh-TW.md`:

- **Hero install hook** — 30-second install block (slash commands) lifted above the fold, with `/ars-plan` next-step pointer and anchor link to full Quick install section
- **Prerequisites** — Quick install section gains a bullet list (Claude Code latest / `ANTHROPIC_API_KEY` / optional Pandoc + tectonic for DOCX/PDF) so readers know what to verify before pasting commands
- **Verify it works** — first-command guide after install: `/ars-plan` for Socratic dialogue or `/ars-lit-review "topic"` for one-shot test

EN and zh-TW versions kept in lockstep.

## Codex audit

Pre-PR `codex exec` on full diff (~48k tokens): **0 P1 / 0 P2 / 0 P3**. Verified:

- `/ars-plan` and `/ars-lit-review` exist as `commands/ars-plan.md` + `commands/ars-lit-review.md`
- Plugin install name aligns with `.claude-plugin/plugin.json:2` (`academic-research-skills`)
- Prerequisites accurate (Markdown default works without Pandoc/tectonic)
- Anchor integrity: EN `#quick-install` → `## Quick install`, ZH `#快速安裝` → `## 快速安裝`
- EN/ZH parity in claims, ordering, emphasis
- No em-dash overuse or AI-tone in zh-TW additions

## Test plan

- [x] Codex audit clean (0 findings)
- [x] EN/ZH parity confirmed
- [x] Anchor links resolve in both files
- [x] Slash command existence verified against `commands/` directory
- [ ] Visual check: render preview of first 60 lines on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)