### PR TITLE
v3.7.1 Step 2: D2 audit Scope Report block + lint enforcement

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -166,6 +166,18 @@ jobs:
           pip install pytest
           pytest scripts/test_check_v3_6_8_audit_scope_block.py -v
 
+      - name: Run v3.7.1 audit_snapshot render-side Section 0 regression tests
+        # PR #78 codex round-5 P2-7: lint enforces the static template
+        # contract, but render_prompt is the runtime path that actually
+        # builds the codex prompt. Without this CI step, render_prompt
+        # could drop Section 0 again silently while the template lint
+        # stays green — exactly the failure mode round-1 P1 closed.
+        env:
+          PYTHONPATH: .
+        run: |
+          pip install pytest
+          pytest scripts/test_audit_snapshot_render_section_0.py -v
+
       - name: Run v3.6.7 Step 6 audit schema + helper tests (Phase 6.2 + 6.4)
         env:
           PYTHONPATH: .

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -152,6 +152,20 @@ jobs:
           pip install pytest pyyaml jsonschema
           pytest scripts/test_check_v3_6_8_frontmatter_trust_schema.py -v
 
+      - name: Validate v3.7.1 audit Scope Report block (Step 2 / D2)
+        # Step 2 of v3.7.1: enforces spec §3.2 Scope Report contract on the
+        # codex audit prompt template — Section 0 header + four required
+        # content fields + three aggregate-status splits + forbidden
+        # combined-aggregate "PASSED" verb (spec line 152).
+        run: python3 scripts/check_v3_6_8_audit_scope_block.py
+
+      - name: Run v3.7.1 audit Scope Report block mutation tests
+        env:
+          PYTHONPATH: .
+        run: |
+          pip install pytest
+          pytest scripts/test_check_v3_6_8_audit_scope_block.py -v
+
       - name: Run v3.6.7 Step 6 audit schema + helper tests (Phase 6.2 + 6.4)
         env:
           PYTHONPATH: .

--- a/scripts/audit_snapshot.py
+++ b/scripts/audit_snapshot.py
@@ -111,15 +111,36 @@ def _extract_template_sections(template_str: str, section_numbers: list[int]) ->
     into prompts dispatched for non-synthesis agents, contradicting the real
     Section 4(f) we substituted above.
 
+    PR #78 codex round-1 P1: heading detection must skip headings inside
+    fenced code blocks (```/~~~). The v3.7.1 Section 0 Scope Report contains
+    a fenced sub-block whose first line starts with `## Codex Audit Round N
+    — Scope Report`; without fence-awareness, that line was treated as the
+    next H2 boundary and Section 0 was truncated mid-fence.
+
     Returns concatenated section text (with the leading `## Section N` header
     intact and the appendix excluded).
     """
     import re as _re
+
+    # Mask fenced code blocks (```...``` and ~~~...~~~) with whitespace so
+    # ## headings inside them don't count as section boundaries. Length is
+    # preserved so match offsets stay aligned with the original string.
+    def _mask_fences(s: str) -> str:
+        fence_re = _re.compile(
+            r"^([ \t]*)(```|~~~)[^\n]*\n.*?^\1\2[ \t]*$",
+            _re.DOTALL | _re.MULTILINE,
+        )
+        def _repl(m: _re.Match[str]) -> str:
+            return "".join(" " if ch != "\n" else "\n" for ch in m.group(0))
+        return fence_re.sub(_repl, s)
+
+    masked = _mask_fences(template_str)
+
     # Match either Section heading or any other top-level `## ` heading
     # (e.g. "## Worked example", "## Cross-references"); the latter terminate
     # the last extracted section.
     boundary_re = _re.compile(r"^## (?:Section (\d+)( —|$)|.+)", _re.MULTILINE)
-    matches = list(boundary_re.finditer(template_str))
+    matches = list(boundary_re.finditer(masked))
     if not matches:
         return template_str  # no headings found — fall back to verbatim
 
@@ -232,19 +253,25 @@ def render_prompt(
         "\n".join(f"- {p}" for p in supporting_paths) if supporting_paths else "- (none)"
     )
 
-    # Extract audit template Sections 3, 6, 7 (verbatim — describe codex's
-    # expected output / dimensions / anti-fake guard). Sections 1, 2, 4, 5 are
-    # rendered above with real values, so we skip the template's placeholder
-    # versions to avoid showing codex two copies of the same section (one with
-    # placeholders, one substituted) — F-023 closure also requires the
-    # placeholder text not appear.
+    # Extract audit template Sections 0, 3, 6, 7 (verbatim — Section 0 is the
+    # v3.7.1 D2 Scope Report block riding verbatim every round per spec §3.2;
+    # Sections 3 / 6 / 7 describe codex's expected output / dimensions /
+    # anti-fake guard). Sections 1, 2, 4, 5 are rendered below with real
+    # values, so we skip the template's placeholder versions to avoid showing
+    # codex two copies of the same section (one with placeholders, one
+    # substituted) — F-023 closure also requires the placeholder text not
+    # appear. Section 0 contains a `<N_total>` etc. placeholder set that codex
+    # is expected to fill from bundle inventory at audit time, so it rides
+    # verbatim alongside Sections 3 / 6 / 7 (codex round-1 PR #78 P1 closure).
     template_str = audit_template.decode("utf-8", errors="replace")
+    section_0 = _extract_template_sections(template_str, [0])
     section_3_to_7 = _extract_template_sections(template_str, [3, 6, 7])
 
     rendered_intro = (
         f"# ARS v3.6.7 cross-model audit — round {round_n} of {target_rounds}\n"
         f"# Stage: {stage} | Agent: {agent}\n"
         f"# Git SHA at audit start: {git_sha}\n\n"
+        f"{section_0}"
         f"## Section 1 — Round metadata\n\n"
         f"Audit round: {round_n} of {target_rounds}\n"
         f"Previous rounds: {prior_summary}\n"

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -369,21 +369,72 @@ def check(target: Path) -> tuple[int, list[str]]:
                 f"{split!r} (spec lines 147-150)."
             )
 
-    # ---- R4: forbidden combined-aggregate 'PASSED' verb ----
-    # Codex round-4 P2: fenced code blocks ARE the prompt content sent to
-    # codex (the canonical Scope Report header lives inside a fence). A
-    # forbidden 'verdict: PASSED' line in a fenced sub-block defeats the
-    # spec line 152 contract just as much as one outside a fence. Run the
-    # patterns against text_full so fence content is included.
-    for pattern in FORBIDDEN_AGGREGATE_PATTERNS:
-        match = pattern.search(text_full)
-        if match is not None:
-            failed = True
-            report.append(
-                f"  FAIL [R4]: forbidden combined-aggregate 'PASSED' verb in "
-                f"audit summary context: {match.group(0)!r} "
-                "(spec line 152: combined-aggregate 'PASSED' is forbidden)."
-            )
+    # ---- R4: forbidden combined-aggregate 'PASSED' verb (cap rule) ----
+    # Codex rounds 4-7 + 13 enumerated the forbidden surface lexically
+    # (verdict-key + same-line, multi-word keys, multi-line summary headings,
+    # bare verdict lines). Each round surfaced another shape codex could
+    # construct, signalling that pattern enumeration is unbounded.
+    #
+    # Round-13 architectural inflection (per
+    # `feedback_architectural_inflection_after_repeated_p1.md`): replace
+    # the enumeration with a cap rule. ANY unquoted `PASSED` token on the
+    # post-Section-0 surface violates the spec line 152 contract. Quoted
+    # forms (`"PASSED"`, `'PASSED'`, backtick `` `PASSED` ``) remain
+    # permitted because the canonical spec template uses them in self-
+    # explanation prose ("the combined-aggregate 'PASSED' verb is forbidden").
+    #
+    # Surface = template text after the Section 0 H2 anchor (or whole
+    # text if Section 0 anchor missing — already failed by R1). The
+    # legacy FORBIDDEN_AGGREGATE_PATTERNS still run as supplementary
+    # diagnostics on the pre-Section-0 surface (the upstream parts where
+    # an audit summary heading would be a structural violation).
+    cap_rule_surface_start = (
+        section_0_anchors[0] if section_0_anchors else 0
+    )
+    cap_rule_surface = text_full[cap_rule_surface_start:]
+    bare_passed_re = re.compile(r"\bPASSED\b")
+    for match in bare_passed_re.finditer(cap_rule_surface):
+        # Determine if this PASSED is quoted (allowed) or bare (forbidden).
+        start, end = match.start(), match.end()
+        # Look at the immediate surrounding character on each side. Quoted
+        # if both neighbours are matching quote characters or if either
+        # side is a backtick (Markdown inline code).
+        left = cap_rule_surface[start - 1] if start > 0 else ""
+        right = cap_rule_surface[end] if end < len(cap_rule_surface) else ""
+        is_quoted = (
+            (left == '"' and right == '"')
+            or (left == "'" and right == "'")
+            or (left == "`" and right == "`")
+            or (left == "“" and right == "”")
+        )
+        if is_quoted:
+            continue
+        failed = True
+        # Build a small context excerpt for the diagnostic.
+        ctx_start = max(0, start - 30)
+        ctx_end = min(len(cap_rule_surface), end + 30)
+        excerpt = cap_rule_surface[ctx_start:ctx_end].replace("\n", " ")
+        report.append(
+            f"  FAIL [R4]: unquoted PASSED token on post-Section-0 surface "
+            f"(spec line 152 cap rule). Context: …{excerpt}… "
+            "Use quoted form (\"PASSED\", `PASSED`) for self-explanation only."
+        )
+        break  # one diagnostic is enough; user fixes then re-runs
+
+    # Supplementary diagnostics: run the legacy patterns on the FULL text
+    # so any structural violations they specifically detect (audit-summary
+    # heading + verdict combinations) still surface even when the cap
+    # rule already fired. Skip if already failed to avoid noise.
+    if not failed:
+        for pattern in FORBIDDEN_AGGREGATE_PATTERNS:
+            match = pattern.search(text_full)
+            if match is not None:
+                failed = True
+                report.append(
+                    f"  FAIL [R4]: forbidden combined-aggregate 'PASSED' verb in "
+                    f"audit summary context: {match.group(0)!r} "
+                    "(spec line 152: combined-aggregate 'PASSED' is forbidden)."
+                )
 
     if failed:
         report.append("[v3.7.1 audit-scope-block] FAILED")

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -67,12 +67,16 @@ SCOPE_REPORT_HEADER = "## Codex Audit Round N — Scope Report"
 # The byte-equivalent Section 1 heading per Q5 invariant.
 SECTION_1_HEADING_EXACT = "## Section 1 — Round metadata"
 
-# Required Scope Report content fields (spec lines 136-140).
+# Required Scope Report content fields (spec lines 136-142).
+# Codex round-9 P2a: spec line 142 requires the Affected-refcodes
+# disclosure too — without it, an audit can hide which entries were
+# unaudited even if the count is published.
 REQUIRED_FIELDS: list[str] = [
     "**Total entries audited:**",
     "**Entries with retrieved original source:**",
     "**Entries description-only (no retrieved source):**",
     "**Audit scope warning:**",
+    "**Affected refcodes (description-only):**",
 ]
 
 # Required aggregate-status splits (spec lines 147-150).
@@ -296,23 +300,40 @@ def check(target: Path) -> tuple[int, list[str]]:
             "heading line, not a prose mention)."
         )
 
-    # ---- R6 firm-rule check: no pass/fail summary ahead of Section 0 ----
-    # Codex round-5 P2-6 broadened this to detect bare-verdict lines (e.g.
-    # `verdict: PASS`, `result: FAIL`) regardless of `## ... Summary`
-    # heading framing. Any pre-Section-0 verdict signal violates spec
-    # line 146 firm rule. Scan runs on text_no_fences so a verdict-shaped
+    # ---- R6 firm-rule check: no pass/fail summary ahead of Scope Report ----
+    # Spec line 146 ordering rule: the Scope Report content must appear
+    # before any pass/fail summary surface.
+    # Codex round-5 P2-6 broadened detection to bare-verdict lines.
+    # Codex round-9 P2b: "Section 0 H2 alone is not the Scope Report" —
+    # a verdict line inserted between the Section 0 heading and the
+    # canonical fenced Scope Report header still violates the ordering
+    # rule because it precedes the Scope Report CONTENT. Anchor the
+    # ordering scan on the canonical Scope Report header (or, if absent,
+    # the Section 1 heading as a coarse upper bound) and scan everything
+    # before that point. Scan runs on text_no_fences so a verdict-shaped
     # line that lives inside a fenced reference / quoted documentation
     # block does NOT trip the rule.
-    if section_0_anchors:
-        section_0_pos = section_0_anchors[0]
-        prefix = text_no_fences[:section_0_pos]
+    scope_header_match = re.search(
+        r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
+        text_no_fences,
+        re.MULTILINE,
+    )
+    ordering_boundary: int | None = None
+    if scope_header_match is not None:
+        ordering_boundary = scope_header_match.start()
+    elif section_1_pos != -1:
+        ordering_boundary = section_1_pos
+    elif section_0_anchors:
+        ordering_boundary = section_0_anchors[0]
+    if ordering_boundary is not None:
+        prefix = text_no_fences[:ordering_boundary]
         for pattern in BARE_VERDICT_BEFORE_SECTION_0_PATTERNS:
             match = pattern.search(prefix)
             if match is not None:
                 failed = True
                 anchor = match.group(0).strip()
                 report.append(
-                    f"  FAIL [R1]: pass/fail summary detected ahead of Section 0 "
+                    f"  FAIL [R1]: pass/fail summary detected ahead of Scope Report content "
                     f"(anchor: {anchor!r}); spec line 146 requires Scope Report "
                     f"to appear BEFORE any pass/fail summary."
                 )

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""ARS v3.7.1 Step 2 — D2 audit Scope Report block lint.
+
+Spec: docs/design/2026-04-30-ars-v3.6.8-trust-provenance-and-drift-transparency-spec.md
+      §3.2 (D2 — Audit scope coverage non-disclosure)
+      §4 Step 2 — Audit report Scope Report block (lines 412-425)
+
+Enforces, on the codex audit prompt template:
+
+  R1. A Section 0 Scope Report header appears strictly BEFORE the first
+      Section 1 heading (spec line 146: "must appear before any pass/fail
+      summary"). The header is the literal "## Codex Audit Round N — Scope
+      Report" (spec line 134).
+  R2. The Scope Report block carries the four mandatory content fields
+      (spec lines 136-140):
+        - Total entries audited
+        - Entries with retrieved original source
+        - Entries description-only (no retrieved source)
+        - Audit scope warning
+  R3. The aggregate-status section carries the three required splits
+      (spec lines 147-150):
+        - verified-against-source: PASS | FAIL
+        - description-internally-consistent: PASS | FAIL
+        - unaudited-due-to-missing-source: <count>
+  R4. The combined-aggregate "PASSED" verb is forbidden in audit summary
+      contexts (spec line 152). We forbid the literal pattern
+      "Audit summary ... PASSED" (case-insensitive on the surrounding
+      tokens) anywhere in the template.
+  R5. Additive-prepend invariant per Q5 amend (spec §3.2 line 131,
+      §3.7 line 346): the Section 1 heading must appear with exact bytes
+      "## Section 1 — Round metadata" so prepending Section 0 has not
+      altered the existing v3.6.7 audit template's byte-equivalent
+      Sections 1-7 zone.
+
+Attack-surface design notes (informed by issue #77 lessons):
+  - Heading-anchored matching uses begin-of-line regex `^## ` to skip
+    headings that appear inside fenced code blocks. The Scope Report
+    block in the canonical template DOES contain a fenced sub-block with
+    its own "## Codex Audit Round N — Scope Report" heading; our header
+    detector must recognize that as the canonical Scope Report marker
+    even though it lives inside a fence. We resolve this by allowing the
+    Scope Report header to be inside the first fenced block of Section 0
+    OR at top-level — but require that AT LEAST ONE such header anchor
+    exists strictly before the Section 1 boundary, and that exactly one
+    Section-0 anchor exists at top level (the H2 outside any fence).
+  - Multiple Section-0 H2 anchors at top level → reject (mirror of #77
+    P1-1 duplicate-marker bypass).
+
+Exit codes: 0 on PASS, 1 on FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TARGET = REPO_ROOT / "shared" / "templates" / "codex_audit_multifile_template.md"
+
+# The canonical Section-0 H2 anchor at the top level of the template.
+SECTION_0_H2 = "## Section 0"
+# The Scope Report header literal, placed inside the fenced markdown block
+# of Section 0 per spec line 134.
+SCOPE_REPORT_HEADER = "## Codex Audit Round N — Scope Report"
+# The byte-equivalent Section 1 heading per Q5 invariant.
+SECTION_1_HEADING_EXACT = "## Section 1 — Round metadata"
+
+# Required Scope Report content fields (spec lines 136-140).
+REQUIRED_FIELDS: list[str] = [
+    "**Total entries audited:**",
+    "**Entries with retrieved original source:**",
+    "**Entries description-only (no retrieved source):**",
+    "**Audit scope warning:**",
+]
+
+# Required aggregate-status splits (spec lines 147-150).
+REQUIRED_SPLITS: list[str] = [
+    "verified-against-source",
+    "description-internally-consistent",
+    "unaudited-due-to-missing-source",
+]
+
+# Forbidden combined-aggregate "PASSED" verb in audit summary contexts.
+# Spec line 152: "The combined-aggregate 'PASSED' verb is forbidden in
+# audit summary." We match a summary-like context line carrying PASSED
+# (case-insensitive on the framing words; PASSED stays caps-only because
+# the verb itself is the violation).
+FORBIDDEN_AGGREGATE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"audit\s+summary[^\n]{0,80}\bPASSED\b", re.IGNORECASE),
+    re.compile(r"^\s*\w*\s*verdict\s*:\s*PASSED\b", re.IGNORECASE | re.MULTILINE),
+]
+
+
+def _strip_fenced_blocks(text: str) -> str:
+    """Replace fenced code blocks with same-length whitespace so headings
+    inside fences don't count as top-level H2 anchors.
+
+    Length preservation keeps any line/column reporting consistent with
+    the original file. We support the standard ``` and ~~~ fences.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        content = match.group(0)
+        # Replace non-newline characters with spaces so newlines and
+        # column positions are preserved, but content is neutralized.
+        return "".join(" " if ch != "\n" else "\n" for ch in content)
+
+    pattern = re.compile(
+        r"^([ \t]*)(```|~~~)[^\n]*\n.*?^\1\2[ \t]*$",
+        re.DOTALL | re.MULTILINE,
+    )
+    return pattern.sub(_replace, text)
+
+
+def _find_section_1_position(text: str) -> int:
+    """Return the byte offset of the exact Section 1 heading, or -1 if absent."""
+    pos = text.find(SECTION_1_HEADING_EXACT)
+    if pos == -1:
+        return -1
+    # Must start at line beginning.
+    if pos > 0 and text[pos - 1] != "\n":
+        return -1
+    return pos
+
+
+def check(target: Path) -> tuple[int, list[str]]:
+    """Run all rules. Return (exit_code, report_lines)."""
+    if not target.exists():
+        return 1, [f"FAIL: target file does not exist: {target}"]
+
+    text = text_full = target.read_text(encoding="utf-8")
+    text_no_fences = _strip_fenced_blocks(text)
+
+    report: list[str] = [f"[v3.7.1 audit-scope-block] target: {target.relative_to(REPO_ROOT)}"]
+    failed: bool = False
+
+    # ---- R5: Section 1 byte-equivalence sentinel ----
+    section_1_pos = _find_section_1_position(text_full)
+    if section_1_pos == -1:
+        failed = True
+        report.append(
+            "  FAIL [R5]: Section 1 heading exact bytes "
+            f"{SECTION_1_HEADING_EXACT!r} missing or shifted; "
+            "Q5 additive-prepend invariant broken (spec §3.2 line 131)."
+        )
+
+    # ---- R1: Section 0 H2 anchor present, before Section 1 ----
+    section_0_anchors = [
+        m.start()
+        for m in re.finditer(r"^## Section 0\b", text_no_fences, re.MULTILINE)
+    ]
+    if not section_0_anchors:
+        failed = True
+        report.append(
+            "  FAIL [R1]: Section 0 Scope Report header missing "
+            f"(expected H2 anchor starting with {SECTION_0_H2!r} at top level)."
+        )
+    elif len(section_0_anchors) > 1:
+        failed = True
+        report.append(
+            f"  FAIL [R1]: multiple Section 0 H2 anchors found at top level "
+            f"(positions={section_0_anchors}); duplicate-marker hardening rejects "
+            f"more than one (compare issue #77 P1-1)."
+        )
+    elif section_1_pos != -1 and section_0_anchors[0] >= section_1_pos:
+        failed = True
+        report.append(
+            f"  FAIL [R1]: Section 0 anchor (offset {section_0_anchors[0]}) "
+            f"appears at or after Section 1 heading (offset {section_1_pos}); "
+            f"spec line 146 firm rule: Scope Report must appear BEFORE any "
+            f"pass/fail summary."
+        )
+
+    # ---- R1 continued: Scope Report header literal must appear before Section 1 ----
+    scope_header_pos = text_full.find(SCOPE_REPORT_HEADER)
+    if scope_header_pos == -1:
+        failed = True
+        report.append(
+            f"  FAIL [R1]: Scope Report header literal {SCOPE_REPORT_HEADER!r} "
+            "missing (spec line 134)."
+        )
+    elif section_1_pos != -1 and scope_header_pos >= section_1_pos:
+        failed = True
+        report.append(
+            f"  FAIL [R1]: Scope Report header (offset {scope_header_pos}) is "
+            f"not strictly before Section 1 heading (offset {section_1_pos})."
+        )
+
+    # ---- R6 firm-rule check: no synthetic 'audit summary' verdict before Section 0 ----
+    if section_0_anchors:
+        section_0_pos = section_0_anchors[0]
+        prefix = text_no_fences[:section_0_pos]
+        # Detect a pass/fail summary block ahead of Section 0. Markers are
+        # "## ... Summary" headings or "verdict:" lines outside fences.
+        summary_heading = re.search(
+            r"^##\s+[A-Za-z][^\n]{0,80}\b(Summary|Verdict)\b",
+            prefix,
+            re.MULTILINE,
+        )
+        verdict_line = re.search(
+            r"^\s*verified-against-source\s*:\s*(PASS|FAIL)\b",
+            prefix,
+            re.MULTILINE,
+        )
+        if summary_heading or verdict_line:
+            failed = True
+            anchor = (summary_heading or verdict_line).group(0).strip()
+            report.append(
+                f"  FAIL [R1]: pass/fail summary detected ahead of Section 0 "
+                f"(anchor: {anchor!r}); spec line 146 requires Scope Report "
+                f"to appear BEFORE any pass/fail summary."
+            )
+
+    # ---- R2: required content fields ----
+    for field in REQUIRED_FIELDS:
+        if field not in text_full:
+            failed = True
+            report.append(
+                f"  FAIL [R2]: required Scope Report field missing: {field!r} "
+                "(spec lines 136-140)."
+            )
+
+    # ---- R3: aggregate-status three-way split ----
+    for split in REQUIRED_SPLITS:
+        if split not in text_full:
+            failed = True
+            report.append(
+                f"  FAIL [R3]: required aggregate-status split missing: "
+                f"{split!r} (spec lines 147-150)."
+            )
+
+    # ---- R4: forbidden combined-aggregate 'PASSED' verb ----
+    for pattern in FORBIDDEN_AGGREGATE_PATTERNS:
+        match = pattern.search(text_no_fences)
+        if match is not None:
+            failed = True
+            report.append(
+                f"  FAIL [R4]: forbidden combined-aggregate 'PASSED' verb in "
+                f"audit summary context: {match.group(0)!r} "
+                "(spec line 152: combined-aggregate 'PASSED' is forbidden)."
+            )
+
+    if failed:
+        report.append("[v3.7.1 audit-scope-block] FAILED")
+        return 1, report
+    report.append("[v3.7.1 audit-scope-block] PASS")
+    return 0, report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="ARS v3.7.1 Step 2 — D2 audit Scope Report block lint."
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=DEFAULT_TARGET,
+        help="Audit prompt template path (default: shared/templates/codex_audit_multifile_template.md).",
+    )
+    args = parser.parse_args()
+
+    exit_code, report = check(args.target)
+    print("\n".join(report))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -286,8 +286,13 @@ def check(target: Path) -> tuple[int, list[str]]:
             )
 
     # ---- R4: forbidden combined-aggregate 'PASSED' verb ----
+    # Codex round-4 P2: fenced code blocks ARE the prompt content sent to
+    # codex (the canonical Scope Report header lives inside a fence). A
+    # forbidden 'verdict: PASSED' line in a fenced sub-block defeats the
+    # spec line 152 contract just as much as one outside a fence. Run the
+    # patterns against text_full so fence content is included.
     for pattern in FORBIDDEN_AGGREGATE_PATTERNS:
-        match = pattern.search(text_no_fences)
+        match = pattern.search(text_full)
         if match is not None:
             failed = True
             report.append(

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -86,6 +86,18 @@ REQUIRED_SPLITS: list[str] = [
     "unaudited-due-to-missing-source",
 ]
 
+# Line-equality regex for the canonical Scope Report header. End-of-line
+# anchored so a suffixed form like "## Codex Audit Round N — Scope Report
+# (draft)" cannot satisfy R1 by prefix match (codex round-12 P2,
+# symmetric to round-8 P2 on Section 1). Optional trailing whitespace
+# before the line break is tolerated (invisible in rendered Markdown);
+# anything else after the canonical bytes — including a space + suffix —
+# fails. \Z covers EOF cases.
+_SCOPE_REPORT_HEADER_LINE_RE = re.compile(
+    rf"^{re.escape(SCOPE_REPORT_HEADER)}[ \t]*(?:\n|\Z)",
+    re.MULTILINE,
+)
+
 # Forbidden combined-aggregate "PASSED" verb in audit summary contexts.
 # Spec line 152: "The combined-aggregate 'PASSED' verb is forbidden in
 # audit summary." Codex round-4 forced fence-content scan; round-5 P2-5
@@ -286,13 +298,12 @@ def check(target: Path) -> tuple[int, list[str]]:
     # is missing the canonical header.
     # Codex round-6 P2-8: anchor to a real heading line. A prose mention
     # of the header literal (`The required header is "## Codex Audit Round
-    # N — Scope Report"`) inside Section 0 must NOT satisfy the contract
-    # because the rendered audit prompt needs the actual heading line.
-    scope_header_line_re = re.compile(
-        r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
-        re.MULTILINE,
-    )
-    if scope_header_line_re.search(section_0_only) is None:
+    # N — Scope Report"`) inside Section 0 must NOT satisfy the contract.
+    # Codex round-12 P2: require line equality (not prefix) so a suffixed
+    # form like `... — Scope Report (draft)` cannot satisfy R1. Uses the
+    # module-level _SCOPE_REPORT_HEADER_LINE_RE shared with the ordering
+    # boundary derivation below.
+    if _SCOPE_REPORT_HEADER_LINE_RE.search(section_0_only) is None:
         failed = True
         report.append(
             f"  FAIL [R1]: Scope Report header line {SCOPE_REPORT_HEADER!r} "
@@ -315,11 +326,7 @@ def check(target: Path) -> tuple[int, list[str]]:
     ordering_boundary: int | None = None
     section_0_start = section_0_anchors[0] if section_0_anchors else None
     if section_0_start is not None:
-        scope_header_in_section_0 = re.search(
-            r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
-            section_0_only,
-            re.MULTILINE,
-        )
+        scope_header_in_section_0 = _SCOPE_REPORT_HEADER_LINE_RE.search(section_0_only)
         if scope_header_in_section_0 is not None:
             ordering_boundary = section_0_start + scope_header_in_section_0.start()
     if ordering_boundary is None and section_1_pos != -1:

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -84,12 +84,31 @@ REQUIRED_SPLITS: list[str] = [
 
 # Forbidden combined-aggregate "PASSED" verb in audit summary contexts.
 # Spec line 152: "The combined-aggregate 'PASSED' verb is forbidden in
-# audit summary." We match a summary-like context line carrying PASSED
-# (case-insensitive on the framing words; PASSED stays caps-only because
-# the verb itself is the violation).
+# audit summary." Codex round-4 forced fence-content scan; round-5 P2-5
+# broadened the verdict-key set (verdict / status / result / final /
+# overall) so the lint catches `Overall status: PASSED` etc., not only
+# `verdict: PASSED`. PASSED is matched case-insensitive on the surrounding
+# tokens but the verb itself stays caps-only — that IS the forbidden
+# verb form. The 80-char window after `audit summary` keeps the spec
+# self-explanation prose (`...forbidden in the audit summary.`) clear
+# of any PASSED token within reach.
+_VERDICT_KEY = r"(?:verdict|status|result|final|final[\s_-]?status|overall(?:[\s_-]?status)?)"
 FORBIDDEN_AGGREGATE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"audit\s+summary[^\n]{0,80}\bPASSED\b", re.IGNORECASE),
-    re.compile(r"^\s*\w*\s*verdict\s*:\s*PASSED\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(rf"^\s*{_VERDICT_KEY}\s*:\s*PASSED\b", re.IGNORECASE | re.MULTILINE),
+]
+
+# Bare-verdict line patterns used to detect a pass/fail summary preceding
+# Section 0 (spec line 146 firm rule). Wider than R4 because here we want
+# to catch BOTH PASS and FAIL — anything resembling a verdict line counts
+# as a pass/fail summary, regardless of the verb.
+BARE_VERDICT_BEFORE_SECTION_0_PATTERNS: list[re.Pattern[str]] = [
+    # Heading-style pass/fail summary
+    re.compile(r"^##\s+[A-Za-z][^\n]{0,80}\b(Summary|Verdict)\b", re.MULTILINE),
+    # Existing first-aggregate-split line (kept from earlier rounds)
+    re.compile(r"^\s*verified-against-source\s*:\s*(PASS|FAIL)\b", re.MULTILINE),
+    # Bare `<key>: PASS|FAIL` line, no heading framing
+    re.compile(rf"^\s*{_VERDICT_KEY}\s*:\s*(PASS|FAIL|PASSED|FAILED)\b", re.IGNORECASE | re.MULTILINE),
 ]
 
 
@@ -238,30 +257,27 @@ def check(target: Path) -> tuple[int, list[str]]:
             "missing from Section 0 (spec line 134)."
         )
 
-    # ---- R6 firm-rule check: no synthetic 'audit summary' verdict before Section 0 ----
+    # ---- R6 firm-rule check: no pass/fail summary ahead of Section 0 ----
+    # Codex round-5 P2-6 broadened this to detect bare-verdict lines (e.g.
+    # `verdict: PASS`, `result: FAIL`) regardless of `## ... Summary`
+    # heading framing. Any pre-Section-0 verdict signal violates spec
+    # line 146 firm rule. Scan runs on text_no_fences so a verdict-shaped
+    # line that lives inside a fenced reference / quoted documentation
+    # block does NOT trip the rule.
     if section_0_anchors:
         section_0_pos = section_0_anchors[0]
         prefix = text_no_fences[:section_0_pos]
-        # Detect a pass/fail summary block ahead of Section 0. Markers are
-        # "## ... Summary" headings or "verdict:" lines outside fences.
-        summary_heading = re.search(
-            r"^##\s+[A-Za-z][^\n]{0,80}\b(Summary|Verdict)\b",
-            prefix,
-            re.MULTILINE,
-        )
-        verdict_line = re.search(
-            r"^\s*verified-against-source\s*:\s*(PASS|FAIL)\b",
-            prefix,
-            re.MULTILINE,
-        )
-        if summary_heading or verdict_line:
-            failed = True
-            anchor = (summary_heading or verdict_line).group(0).strip()
-            report.append(
-                f"  FAIL [R1]: pass/fail summary detected ahead of Section 0 "
-                f"(anchor: {anchor!r}); spec line 146 requires Scope Report "
-                f"to appear BEFORE any pass/fail summary."
-            )
+        for pattern in BARE_VERDICT_BEFORE_SECTION_0_PATTERNS:
+            match = pattern.search(prefix)
+            if match is not None:
+                failed = True
+                anchor = match.group(0).strip()
+                report.append(
+                    f"  FAIL [R1]: pass/fail summary detected ahead of Section 0 "
+                    f"(anchor: {anchor!r}); spec line 146 requires Scope Report "
+                    f"to appear BEFORE any pass/fail summary."
+                )
+                break  # one fail diagnostic per check is enough
 
     # ---- R2: required content fields ----
     # Codex round-2 P2-1: scope to Section 0 only. A marker in an appendix

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -165,14 +165,19 @@ def _find_section_1_position(text_no_fences: str) -> int:
     a worked example) was previously accepted as the anchor. The check now
     runs against the fence-stripped text and requires line-start anchoring
     so a fenced occurrence of the exact heading bytes cannot satisfy R5.
+
+    Codex round-8 P2: byte-equivalence must hold for the WHOLE heading line.
+    A `find()` match treats the canonical bytes as a prefix and accepts
+    `## Section 1 — Round metadata (renamed)` as if it were the canonical
+    heading. Match a full line whose only content is the canonical heading,
+    optionally followed by trailing whitespace before the line break.
     """
-    pos = text_no_fences.find(SECTION_1_HEADING_EXACT)
-    if pos == -1:
-        return -1
-    # Must start at line beginning.
-    if pos > 0 and text_no_fences[pos - 1] != "\n":
-        return -1
-    return pos
+    line_re = re.compile(
+        rf"^{re.escape(SECTION_1_HEADING_EXACT)}[ \t]*(?:\n|\Z)",
+        re.MULTILINE,
+    )
+    match = line_re.search(text_no_fences)
+    return match.start() if match else -1
 
 
 def _format_target_for_report(target: Path) -> str:

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -114,13 +114,19 @@ def _strip_fenced_blocks(text: str) -> str:
     return pattern.sub(_replace, text)
 
 
-def _find_section_1_position(text: str) -> int:
-    """Return the byte offset of the exact Section 1 heading, or -1 if absent."""
-    pos = text.find(SECTION_1_HEADING_EXACT)
+def _find_section_1_position(text_no_fences: str) -> int:
+    """Return the byte offset of the exact top-level Section 1 heading, or -1 if absent.
+
+    Codex round-3 P2-3: a decoy heading inside a fenced code block (e.g. in
+    a worked example) was previously accepted as the anchor. The check now
+    runs against the fence-stripped text and requires line-start anchoring
+    so a fenced occurrence of the exact heading bytes cannot satisfy R5.
+    """
+    pos = text_no_fences.find(SECTION_1_HEADING_EXACT)
     if pos == -1:
         return -1
     # Must start at line beginning.
-    if pos > 0 and text[pos - 1] != "\n":
+    if pos > 0 and text_no_fences[pos - 1] != "\n":
         return -1
     return pos
 
@@ -182,7 +188,9 @@ def check(target: Path) -> tuple[int, list[str]]:
     failed: bool = False
 
     # ---- R5: Section 1 byte-equivalence sentinel ----
-    section_1_pos = _find_section_1_position(text_full)
+    # Codex round-3 P2-3: search the fence-stripped string so a decoy heading
+    # inside a fenced code block (e.g. worked example) cannot satisfy R5.
+    section_1_pos = _find_section_1_position(text_no_fences)
     if section_1_pos == -1:
         failed = True
         report.append(
@@ -218,19 +226,16 @@ def check(target: Path) -> tuple[int, list[str]]:
             f"pass/fail summary."
         )
 
-    # ---- R1 continued: Scope Report header literal must appear before Section 1 ----
-    scope_header_pos = text_full.find(SCOPE_REPORT_HEADER)
-    if scope_header_pos == -1:
+    # ---- R1 continued: Scope Report header literal must appear inside Section 0 ----
+    # Codex round-3 P2-4: scope to section_0_only so a preamble decoy
+    # (e.g. an "Appendix" or "historical reference" carrying the exact
+    # header) cannot falsely satisfy R1 when the real Section 0 block
+    # is missing the canonical header.
+    if SCOPE_REPORT_HEADER not in section_0_only:
         failed = True
         report.append(
             f"  FAIL [R1]: Scope Report header literal {SCOPE_REPORT_HEADER!r} "
-            "missing (spec line 134)."
-        )
-    elif section_1_pos != -1 and scope_header_pos >= section_1_pos:
-        failed = True
-        report.append(
-            f"  FAIL [R1]: Scope Report header (offset {scope_header_pos}) is "
-            f"not strictly before Section 1 heading (offset {section_1_pos})."
+            "missing from Section 0 (spec line 134)."
         )
 
     # ---- R6 firm-rule check: no synthetic 'audit summary' verdict before Section 0 ----

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -304,18 +304,23 @@ def check(target: Path) -> tuple[int, list[str]]:
     # Spec line 146 ordering rule: the Scope Report content must appear
     # before any pass/fail summary surface.
     # Codex round-5 P2-6 broadened detection to bare-verdict lines.
-    # Codex round-9 P2b: "Section 0 H2 alone is not the Scope Report" —
-    # a verdict line inserted between the Section 0 heading and the
-    # canonical fenced Scope Report header still violates the ordering
-    # rule because it precedes the Scope Report CONTENT. Anchor the
-    # ordering scan on the canonical Scope Report header (or, if absent,
-    # the Section 1 heading as a coarse upper bound) and scan everything
-    # before that point. Scan runs on text_no_fences so a verdict-shaped
-    # line that lives inside a fenced reference / quoted documentation
-    # block does NOT trip the rule.
+    # Codex round-9 P2b: anchor on the canonical Scope Report header so
+    # a verdict line between Section 0 H2 and the canonical header is
+    # caught.
+    # Codex round-10 P2: search the FULL template text (including fenced
+    # content) for both the canonical header and the verdict prefix scan.
+    # Earlier rounds masked fences to keep documentation references in
+    # late-template appendices from tripping the rule. That is no longer
+    # needed: the prefix is bounded by the canonical header, which sits
+    # near the top of Section 0; documentation references live after
+    # Section 7 (well past the boundary) and do not appear in the scan
+    # range. Meanwhile the canonical header IS in a fence, so a
+    # text_no_fences search could never anchor on it — that hid every
+    # verdict injection that lived inside the same live Scope Report
+    # fence. Use text_full for both anchor discovery and prefix scan.
     scope_header_match = re.search(
         r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
-        text_no_fences,
+        text_full,
         re.MULTILINE,
     )
     ordering_boundary: int | None = None
@@ -326,7 +331,7 @@ def check(target: Path) -> tuple[int, list[str]]:
     elif section_0_anchors:
         ordering_boundary = section_0_anchors[0]
     if ordering_boundary is not None:
-        prefix = text_no_fences[:ordering_boundary]
+        prefix = text_full[:ordering_boundary]
         for pattern in BARE_VERDICT_BEFORE_SECTION_0_PATTERNS:
             match = pattern.search(prefix)
             if match is not None:

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -98,11 +98,29 @@ REQUIRED_SPLITS: list[str] = [
 # this so multi-word keys like `Final verdict: PASSED` are also caught.
 # Each qualifier is restricted to alphabetic characters of length 1-15
 # so the regex does not gobble unrelated text on the same line.
-_VERDICT_TOKEN = r"(?:verdict|status|result|final|outcome|overall)"
+_VERDICT_TOKEN = r"(?:verdict|status|result|final|outcome|overall|summary)"
 _VERDICT_KEY = rf"(?:[A-Za-z]{{1,15}}\s+){{0,2}}{_VERDICT_TOKEN}"
+# Heading-style summary token used for multi-line lookahead detection
+# (codex round-7 P2). Catches `## Audit Summary`, `## Final Verdict`,
+# `## Overall Outcome`, etc. — H2 headings whose title carries any
+# verdict-key token (bare PASSED on the next lines is the violation).
+_SUMMARY_HEADING = rf"^##\s+(?:[A-Za-z][\w-]*\s+){{0,3}}{_VERDICT_TOKEN}\b[^\n]*"
+
 FORBIDDEN_AGGREGATE_PATTERNS: list[re.Pattern[str]] = [
+    # Same-line: "audit summary ... PASSED" within 80 chars (legacy R4).
     re.compile(r"audit\s+summary[^\n]{0,80}\bPASSED\b", re.IGNORECASE),
+    # Same-line: `<key>: PASSED` (legacy + multi-word key).
     re.compile(rf"^\s*{_VERDICT_KEY}\s*:\s*PASSED\b", re.IGNORECASE | re.MULTILINE),
+    # Multi-line (codex round-7 P2): `## Summary heading` followed within
+    # ~5 lines (≤400 chars across newlines) by a `PASSED` token. Catches
+    # `## Audit Summary\n\nThis audit PASSED.` and `## Audit Summary\n\nPASSED`.
+    # DOTALL lets `.` cross newlines; the 400-char window stays tight enough
+    # that a much later unrelated PASSED in a separate section does not pair
+    # with the heading.
+    re.compile(
+        rf"{_SUMMARY_HEADING}.{{0,400}}?\bPASSED\b",
+        re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    ),
 ]
 
 # Bare-verdict line patterns used to detect a pass/fail summary preceding

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -304,32 +304,28 @@ def check(target: Path) -> tuple[int, list[str]]:
     # Spec line 146 ordering rule: the Scope Report content must appear
     # before any pass/fail summary surface.
     # Codex round-5 P2-6 broadened detection to bare-verdict lines.
-    # Codex round-9 P2b: anchor on the canonical Scope Report header so
-    # a verdict line between Section 0 H2 and the canonical header is
-    # caught.
-    # Codex round-10 P2: search the FULL template text (including fenced
-    # content) for both the canonical header and the verdict prefix scan.
-    # Earlier rounds masked fences to keep documentation references in
-    # late-template appendices from tripping the rule. That is no longer
-    # needed: the prefix is bounded by the canonical header, which sits
-    # near the top of Section 0; documentation references live after
-    # Section 7 (well past the boundary) and do not appear in the scan
-    # range. Meanwhile the canonical header IS in a fence, so a
-    # text_no_fences search could never anchor on it — that hid every
-    # verdict injection that lived inside the same live Scope Report
-    # fence. Use text_full for both anchor discovery and prefix scan.
-    scope_header_match = re.search(
-        r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
-        text_full,
-        re.MULTILINE,
-    )
+    # Codex round-9 P2b: anchor on the canonical Scope Report header.
+    # Codex round-10 P2: search includes fenced content (canonical header
+    # lives in fence by spec design).
+    # Codex round-11 P2: derive boundary from the Section-0-validated
+    # header, not first whole-file occurrence. A preamble decoy line
+    # carrying the canonical header text would otherwise short-circuit
+    # the boundary too early, letting verdict lines between the decoy
+    # and the real Scope Report content escape the prefix scan.
     ordering_boundary: int | None = None
-    if scope_header_match is not None:
-        ordering_boundary = scope_header_match.start()
-    elif section_1_pos != -1:
+    section_0_start = section_0_anchors[0] if section_0_anchors else None
+    if section_0_start is not None:
+        scope_header_in_section_0 = re.search(
+            r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
+            section_0_only,
+            re.MULTILINE,
+        )
+        if scope_header_in_section_0 is not None:
+            ordering_boundary = section_0_start + scope_header_in_section_0.start()
+    if ordering_boundary is None and section_1_pos != -1:
         ordering_boundary = section_1_pos
-    elif section_0_anchors:
-        ordering_boundary = section_0_anchors[0]
+    if ordering_boundary is None and section_0_start is not None:
+        ordering_boundary = section_0_start
     if ordering_boundary is not None:
         prefix = text_full[:ordering_boundary]
         for pattern in BARE_VERDICT_BEFORE_SECTION_0_PATTERNS:

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -125,6 +125,50 @@ def _find_section_1_position(text: str) -> int:
     return pos
 
 
+def _format_target_for_report(target: Path) -> str:
+    """Format target path for lint report.
+
+    Codex round-2 P2-2: when --target is a relative repo path or points
+    outside REPO_ROOT, `target.relative_to(REPO_ROOT)` raises ValueError.
+    Resolve to absolute first, then attempt relativization, falling back
+    to the raw path if the resolved path is not under REPO_ROOT.
+    """
+    try:
+        resolved = target.resolve()
+    except (OSError, RuntimeError):
+        return str(target)
+    try:
+        return str(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(resolved)
+
+
+def _section_0_block(text_full: str, text_no_fences: str) -> str:
+    """Slice the Section 0 block from the H2 anchor up to (but not including)
+    the next H2 boundary at top level. Returns "" if the anchor is missing.
+
+    Codex round-2 P2-1: required-field and aggregate-status-split checks
+    must scope to Section 0 only, not whole-file. Otherwise a marker that
+    appears in a later appendix or documentation block can falsely satisfy
+    the check while Section 0 itself is incomplete.
+
+    Boundary detection runs on the fence-stripped string so a fenced sub-
+    block inside Section 0 (e.g. the canonical Scope Report header) does
+    not terminate the slice. The returned slice is taken from the original
+    text so contents are byte-equivalent to the source.
+    """
+    import re as _re
+    section_0_match = _re.search(
+        r"^## Section 0\b", text_no_fences, _re.MULTILINE
+    )
+    if section_0_match is None:
+        return ""
+    start = section_0_match.start()
+    next_h2 = _re.search(r"^## ", text_no_fences[start + 1 :], _re.MULTILINE)
+    end = (start + 1 + next_h2.start()) if next_h2 else len(text_full)
+    return text_full[start:end]
+
+
 def check(target: Path) -> tuple[int, list[str]]:
     """Run all rules. Return (exit_code, report_lines)."""
     if not target.exists():
@@ -132,8 +176,9 @@ def check(target: Path) -> tuple[int, list[str]]:
 
     text = text_full = target.read_text(encoding="utf-8")
     text_no_fences = _strip_fenced_blocks(text)
+    section_0_only = _section_0_block(text_full, text_no_fences)
 
-    report: list[str] = [f"[v3.7.1 audit-scope-block] target: {target.relative_to(REPO_ROOT)}"]
+    report: list[str] = [f"[v3.7.1 audit-scope-block] target: {_format_target_for_report(target)}"]
     failed: bool = False
 
     # ---- R5: Section 1 byte-equivalence sentinel ----
@@ -214,20 +259,24 @@ def check(target: Path) -> tuple[int, list[str]]:
             )
 
     # ---- R2: required content fields ----
+    # Codex round-2 P2-1: scope to Section 0 only. A marker in an appendix
+    # or documentation block must NOT satisfy the contract — the audit
+    # prompt that gets sent to codex contains Section 0, not the appendix.
     for field in REQUIRED_FIELDS:
-        if field not in text_full:
+        if field not in section_0_only:
             failed = True
             report.append(
-                f"  FAIL [R2]: required Scope Report field missing: {field!r} "
-                "(spec lines 136-140)."
+                f"  FAIL [R2]: required Scope Report field missing from Section 0: "
+                f"{field!r} (spec lines 136-140)."
             )
 
     # ---- R3: aggregate-status three-way split ----
+    # Codex round-2 P2-1: same scoping fix as R2.
     for split in REQUIRED_SPLITS:
-        if split not in text_full:
+        if split not in section_0_only:
             failed = True
             report.append(
-                f"  FAIL [R3]: required aggregate-status split missing: "
+                f"  FAIL [R3]: required aggregate-status split missing from Section 0: "
                 f"{split!r} (spec lines 147-150)."
             )
 

--- a/scripts/check_v3_6_8_audit_scope_block.py
+++ b/scripts/check_v3_6_8_audit_scope_block.py
@@ -92,7 +92,14 @@ REQUIRED_SPLITS: list[str] = [
 # verb form. The 80-char window after `audit summary` keeps the spec
 # self-explanation prose (`...forbidden in the audit summary.`) clear
 # of any PASSED token within reach.
-_VERDICT_KEY = r"(?:verdict|status|result|final|final[\s_-]?status|overall(?:[\s_-]?status)?)"
+# A verdict-shaped key word: any of the canonical verdict tokens, optionally
+# preceded by one or two short qualifier words (e.g. "Final verdict",
+# "Audit status", "Overall final result"). Codex round-6 P2-9 broadened
+# this so multi-word keys like `Final verdict: PASSED` are also caught.
+# Each qualifier is restricted to alphabetic characters of length 1-15
+# so the regex does not gobble unrelated text on the same line.
+_VERDICT_TOKEN = r"(?:verdict|status|result|final|outcome|overall)"
+_VERDICT_KEY = rf"(?:[A-Za-z]{{1,15}}\s+){{0,2}}{_VERDICT_TOKEN}"
 FORBIDDEN_AGGREGATE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"audit\s+summary[^\n]{0,80}\bPASSED\b", re.IGNORECASE),
     re.compile(rf"^\s*{_VERDICT_KEY}\s*:\s*PASSED\b", re.IGNORECASE | re.MULTILINE),
@@ -250,11 +257,20 @@ def check(target: Path) -> tuple[int, list[str]]:
     # (e.g. an "Appendix" or "historical reference" carrying the exact
     # header) cannot falsely satisfy R1 when the real Section 0 block
     # is missing the canonical header.
-    if SCOPE_REPORT_HEADER not in section_0_only:
+    # Codex round-6 P2-8: anchor to a real heading line. A prose mention
+    # of the header literal (`The required header is "## Codex Audit Round
+    # N — Scope Report"`) inside Section 0 must NOT satisfy the contract
+    # because the rendered audit prompt needs the actual heading line.
+    scope_header_line_re = re.compile(
+        r"^##\s+Codex Audit Round N\s+—\s+Scope Report\b",
+        re.MULTILINE,
+    )
+    if scope_header_line_re.search(section_0_only) is None:
         failed = True
         report.append(
-            f"  FAIL [R1]: Scope Report header literal {SCOPE_REPORT_HEADER!r} "
-            "missing from Section 0 (spec line 134)."
+            f"  FAIL [R1]: Scope Report header line {SCOPE_REPORT_HEADER!r} "
+            "missing from Section 0 (spec line 134; must appear as a real "
+            "heading line, not a prose mention)."
         )
 
     # ---- R6 firm-rule check: no pass/fail summary ahead of Section 0 ----

--- a/scripts/test_audit_snapshot_render_section_0.py
+++ b/scripts/test_audit_snapshot_render_section_0.py
@@ -1,0 +1,105 @@
+"""Render-side regression test for v3.7.1 Step 2 — Section 0 Scope Report.
+
+Codex round-1 review of PR #78 surfaced a P1 architectural finding: the static
+Section 0 block was prepended to `shared/templates/codex_audit_multifile_template.md`
+and lint-enforced, but `scripts/audit_snapshot.py::render_prompt` extracted only
+sections [3, 6, 7] from the template. Section 0 was therefore absent from every
+wrapper-dispatched audit prompt, defeating the spec §3.2 contract that the
+Scope Report rides verbatim every round.
+
+This test pins the render-side contract: render_prompt MUST emit a Section 0
+Scope Report block ahead of the Section 1 Round metadata block so the audit
+target sees the scope-disclosure framing before any pass/fail summary.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.audit_snapshot import render_prompt
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_PATH = (
+    REPO_ROOT / "shared" / "templates" / "codex_audit_multifile_template.md"
+)
+
+
+def _render_minimal_prompt() -> bytes:
+    """Run render_prompt with minimal valid arguments."""
+    return render_prompt(
+        audit_template=TEMPLATE_PATH.read_bytes(),
+        primary_paths=["primary/file.md"],
+        primary_contents=[b"primary content"],
+        supporting_paths=[],
+        supporting_contents=[],
+        round_n=1,
+        target_rounds=3,
+        git_sha="0123456789ab",
+        stage=2,
+        agent="synthesis_agent",
+        prior_findings=None,
+    )
+
+
+def test_render_prompt_emits_section_0_scope_report_header() -> None:
+    """The rendered prompt MUST contain the Section 0 H2 anchor."""
+    rendered = _render_minimal_prompt()
+    assert b"## Section 0 \xe2\x80\x94 Scope Report" in rendered, (
+        "render_prompt does not emit Section 0 Scope Report header — "
+        "spec §3.2 contract violated (codex round-1 PR #78 P1)."
+    )
+
+
+def test_render_prompt_emits_scope_report_codex_round_header() -> None:
+    """The rendered prompt MUST contain the canonical Scope Report header."""
+    rendered = _render_minimal_prompt()
+    assert b"## Codex Audit Round N \xe2\x80\x94 Scope Report" in rendered, (
+        "render_prompt does not emit the canonical Scope Report header "
+        "literal (spec line 134)."
+    )
+
+
+def test_render_prompt_section_0_appears_before_section_1() -> None:
+    """Spec line 146 firm rule: Scope Report must appear BEFORE any pass/fail summary."""
+    rendered = _render_minimal_prompt()
+    section_0_pos = rendered.find(b"## Section 0 \xe2\x80\x94 Scope Report")
+    section_1_pos = rendered.find(b"## Section 1 \xe2\x80\x94 Round metadata")
+    assert section_0_pos != -1 and section_1_pos != -1, (
+        "fixture assumption violated: both Section 0 and Section 1 must be present"
+    )
+    assert section_0_pos < section_1_pos, (
+        f"Scope Report (offset {section_0_pos}) does not appear before Section 1 "
+        f"(offset {section_1_pos}); spec line 146 firm rule violated."
+    )
+
+
+def test_render_prompt_emits_required_scope_report_fields() -> None:
+    """The four required Scope Report content fields must appear (spec lines 136-140)."""
+    rendered = _render_minimal_prompt()
+    text = rendered.decode("utf-8")
+    required_fields = [
+        "**Total entries audited:**",
+        "**Entries with retrieved original source:**",
+        "**Entries description-only (no retrieved source):**",
+        "**Audit scope warning:**",
+    ]
+    missing = [f for f in required_fields if f not in text]
+    assert not missing, (
+        f"render_prompt output missing required Scope Report fields: {missing}"
+    )
+
+
+def test_render_prompt_emits_aggregate_status_splits() -> None:
+    """The three aggregate-status splits must appear (spec lines 147-150)."""
+    rendered = _render_minimal_prompt()
+    text = rendered.decode("utf-8")
+    required_splits = [
+        "verified-against-source",
+        "description-internally-consistent",
+        "unaudited-due-to-missing-source",
+    ]
+    missing = [s for s in required_splits if s not in text]
+    assert not missing, (
+        f"render_prompt output missing aggregate-status splits: {missing}"
+    )

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -362,6 +362,86 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+def test_t18_scope_report_header_prose_mention_does_not_satisfy_r1() -> None:
+    """T18 (codex round-6 P2-8): SCOPE_REPORT_HEADER check must be
+    line-anchored, not substring. A prose mention like
+    `The required header is "## Codex Audit Round N — Scope Report"`
+    inside Section 0 must NOT satisfy R1 if the real header line is
+    missing or renamed.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        section_1_pos = text.find("## Section 1 — Round metadata")
+        assert section_0_pos != -1 and section_1_pos != -1
+        section_0_block = text[section_0_pos:section_1_pos]
+        # Rename the real fenced header so it no longer matches the literal,
+        # then add a prose mention carrying the literal text.
+        section_0_mutated = section_0_block.replace(
+            "## Codex Audit Round N — Scope Report",
+            "## Codex Audit Round N — REDACTED",
+            1,
+        )
+        prose_mention = (
+            "\n\nNote: the required header line is "
+            '`## Codex Audit Round N — Scope Report` (do not literally embed in prose).\n\n'
+        )
+        section_0_mutated = section_0_mutated.replace(
+            "## Section 0 — Scope Report",
+            "## Section 0 — Scope Report" + prose_mention,
+            1,
+        )
+        mutated = (
+            text[:section_0_pos]
+            + section_0_mutated
+            + text[section_1_pos:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to require the canonical Scope Report header to "
+            "be a real heading line (not a prose mention). Substring match "
+            "lets a documentation reference satisfy R1 even when the real "
+            "header is missing.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize(
+    "multi_word_summary",
+    [
+        # P2-9 (round-6): multi-word verdict keys before single-word PASSED.
+        "\n\nFinal verdict: PASSED\n\n",
+        "\n\nAudit status: PASSED\n\n",
+        "\n\nOverall verdict: PASSED\n\n",
+        "\n\nFinal status: PASSED\n\n",
+        "\n\nFinal Result: PASSED\n\n",
+    ],
+)
+def test_t19_multi_word_verdict_key_with_passed_fails(multi_word_summary: str) -> None:
+    """T19 (codex round-6 P2-9): R4 must catch multi-word verdict keys
+    (e.g. 'Final verdict: PASSED', 'Audit status: PASSED'). The combined-
+    aggregate verb is the violation regardless of the key word count.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Inject after Section 0 / before Section 1 (anywhere outside the
+        # spec self-explanation prose).
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            multi_word_summary + SECTION_1_HEADING,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject multi-word verdict-key + PASSED line "
+            f"({multi_word_summary!r}). Spec line 152 forbids the verb "
+            f"regardless of how many words the key has.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 @pytest.mark.parametrize(
     "summary_block",
     [

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -362,6 +362,43 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+def test_t15_forbidden_passed_verb_inside_fenced_block_fails() -> None:
+    """T15 (codex round-4 P2): combined-aggregate 'PASSED' inside a fenced
+    code block must FAIL. Fenced blocks are the actual prompt content sent
+    to codex (the canonical Scope Report header lives in a fence), so the
+    forbidden verb appearing there defeats the spec line 152 contract just
+    as much as outside a fence.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Locate Section 0 fenced block and inject the forbidden verb there.
+        fence_start = text.find("```\n## Codex Audit Round N — Scope Report")
+        assert fence_start != -1, (
+            "fixture assumption violated: canonical fenced Scope Report header missing"
+        )
+        # Inject "verdict: PASSED" line right after the header. This is
+        # inside the fenced block — fence-strip would blank it, but the
+        # rendered prompt sent to codex preserves it verbatim.
+        injection_target = "## Codex Audit Round N — Scope Report\n\n"
+        injection_pos = text.find(injection_target, fence_start)
+        assert injection_pos != -1
+        insert_at = injection_pos + len(injection_target)
+        mutated = (
+            text[:insert_at]
+            + "verdict: PASSED\n\n"
+            + text[insert_at:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to reject combined-aggregate 'PASSED' verb even "
+            "inside a fenced code block (the fenced content IS the prompt "
+            "codex sees). Spec line 152 forbids the combined-aggregate verb "
+            "anywhere in the audit summary surface.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 def test_t13_section_1_decoy_inside_fence_does_not_satisfy_invariant() -> None:
     """T13 (codex round-3 P2-3): a fenced-block decoy carrying the exact
     Section 1 heading text must NOT satisfy the byte-equivalence sentinel.

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -364,6 +364,37 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        " (draft)",
+        " v2",
+        ": revised",
+        " — Updated",
+    ],
+)
+def test_t26_scope_report_header_with_suffix_fails(suffix: str) -> None:
+    """T26 (codex round-12 P2): R1 Scope Report header must be a complete
+    canonical line, not a prefix. A suffixed form like
+    `## Codex Audit Round N — Scope Report (draft)` must FAIL because the
+    rendered prompt would carry a non-canonical header. Symmetric to T21
+    (round 8) which closed the same gap on Section 1.
+    """
+    canonical = "## Codex Audit Round N — Scope Report"
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Mutate inside the live fenced Section 0 block.
+        mutated = text.replace(canonical + "\n", canonical + suffix + "\n", 1)
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject Scope Report header with suffix "
+            f"{suffix!r}. The canonical bytes appear as a prefix only; the "
+            f"actual heading title has changed.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 def test_t25_preamble_header_decoy_does_not_short_circuit_ordering() -> None:
     """T25 (codex round-11 P2): if a preamble decoy of the canonical
     `## Codex Audit Round N — Scope Report` line exists ahead of the

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -362,6 +362,41 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "summary_block",
+    [
+        # P2 (round-7): multi-line audit summary forms.
+        "\n## Audit Summary\n\nThis audit PASSED.\n\n",
+        "\n## Audit Summary\n\nPASSED\n\n",
+        "\n## Final Verdict\n\nThis run PASSED comprehensively.\n\n",
+        "\n## Audit Summary\n\nThe audit PASSED for all dimensions.\n\n",
+    ],
+)
+def test_t20_multi_line_audit_summary_with_passed_fails(summary_block: str) -> None:
+    """T20 (codex round-7 P2): R4 must catch multi-line audit summaries
+    where `## Audit Summary` (or similar heading) is followed on subsequent
+    lines by `PASSED` — bare or in prose like `This audit PASSED.`.
+    The combined-aggregate verb is the violation regardless of whether it
+    sits on the same line as the summary key.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Inject after Section 0 / before Section 1.
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            summary_block + SECTION_1_HEADING,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject multi-line audit summary with PASSED "
+            f"({summary_block!r}). Spec line 152 forbids the combined-aggregate "
+            f"verb across all audit-summary surfaces.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 def test_t18_scope_report_header_prose_mention_does_not_satisfy_r1() -> None:
     """T18 (codex round-6 P2-8): SCOPE_REPORT_HEADER check must be
     line-anchored, not substring. A prose mention like

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -362,6 +362,87 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+def test_t13_section_1_decoy_inside_fence_does_not_satisfy_invariant() -> None:
+    """T13 (codex round-3 P2-3): a fenced-block decoy carrying the exact
+    Section 1 heading text must NOT satisfy the byte-equivalence sentinel.
+    The real top-level Section 1 heading is removed/renamed; lint must FAIL.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # 1) Rename the real top-level Section 1 heading (capitalization swap).
+        # 2) Inject a fenced-code-block carrying the exact original heading
+        #    text so a whole-file find() would falsely satisfy R5.
+        renamed = text.replace(
+            "## Section 1 — Round metadata",
+            "## Section 1 — Round Metadata",  # title-case mutation
+            1,
+        )
+        decoy_fence = (
+            "\n\n## Appendix — historical example\n\n"
+            "```\n"
+            "## Section 1 — Round metadata\n"
+            "Sample round metadata content (decoy).\n"
+            "```\n"
+        )
+        TEMPLATE.write_text(renamed + decoy_fence, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to enforce Section 1 byte-equivalence at top level, "
+            "rejecting decoy heading inside a fenced block.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def test_t14_scope_report_header_decoy_in_preamble_does_not_satisfy_r1() -> None:
+    """T14 (codex round-3 P2-4): a decoy SCOPE_REPORT_HEADER appearing in
+    the preamble before Section 0 must NOT satisfy R1 if the real header
+    is missing from Section 0. The lint must check the canonical header
+    inside Section 0, not whole-file find().
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # 1) Inject the canonical Scope Report header into the preamble
+        #    (in a fenced block so it doesn't break Section 0 anchor detection).
+        # 2) Remove the canonical Scope Report header from Section 0.
+        preamble_decoy = (
+            "## Preamble historical reference\n\n"
+            "```\n"
+            "## Codex Audit Round N — Scope Report\n"
+            "(decoy: this is documentation, not the live block)\n"
+            "```\n\n"
+        )
+        # Find Section 0 so the decoy is inserted before it.
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        assert section_0_pos != -1
+        # Remove the canonical header inside Section 0 (it lives in a fenced block).
+        section_1_pos = text.find("## Section 1 — Round metadata")
+        section_0_block = text[section_0_pos:section_1_pos]
+        section_0_mutated = section_0_block.replace(
+            "## Codex Audit Round N — Scope Report",
+            "## Codex Audit Round N — REDACTED",
+            1,
+        )
+        mutated = (
+            text[:section_0_pos]
+            + section_0_mutated
+            + text[section_1_pos:]
+        )
+        # Insert preamble decoy before Section 0.
+        section_0_pos_after = mutated.find("## Section 0 — Scope Report")
+        mutated = (
+            mutated[:section_0_pos_after]
+            + preamble_decoy
+            + mutated[section_0_pos_after:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to enforce SCOPE_REPORT_HEADER presence inside "
+            "Section 0, rejecting preamble decoy that satisfies whole-file find().\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 def test_t12_target_outside_repo_does_not_crash(tmp_path) -> None:
     """T12 (codex round-2 P2-2): --target with an absolute path outside
     the repo must not crash. Lint should display the raw path and proceed.

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -363,6 +363,41 @@ def test_t11_target_relative_path_does_not_crash() -> None:
 
 
 @pytest.mark.parametrize(
+    "appended",
+    [
+        # P2 (round-8): Section 1 heading mutated by appending text.
+        " (renamed)",
+        " v2",
+        ": revised",
+        " — Round Metadata Override",
+    ],
+)
+def test_t21_section_1_heading_with_appended_text_fails(appended: str) -> None:
+    """T21 (codex round-8 P2): R5 Section 1 byte-equivalence sentinel must
+    reject heading lines mutated by appending text. find() previously
+    matched the canonical bytes as a prefix even when the line continued
+    with extra title text — that's a real heading change (rendered prompt
+    has different Section 1 framing) and must FAIL the byte-equivalence
+    invariant.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        mutated = text.replace(
+            SECTION_1_HEADING + "\n",
+            SECTION_1_HEADING + appended + "\n",
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject Section 1 heading mutated by appending "
+            f"text ({appended!r}). The canonical bytes appear as a prefix only; "
+            f"the actual heading title has changed.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize(
     "summary_block",
     [
         # P2 (round-7): multi-line audit summary forms.

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -1,0 +1,254 @@
+"""Mutation tests for ARS v3.7.1 Step 2 — D2 audit Scope Report lint.
+
+Spec: docs/design/2026-04-30-ars-v3.6.8-trust-provenance-and-drift-transparency-spec.md
+      §3.2 (D2 — Audit scope coverage non-disclosure)
+      §4 Step 2 — Audit report Scope Report block
+
+Tests verify that the lint:
+
+  1. PASSES on the audit template AS SHIPPED (baseline carries the
+     Section 0 Scope Report block prepended in Step 2).
+  2. PASSES that the Scope Report header appears strictly BEFORE the
+     Section 1 heading (the firm rule from spec line 146).
+  3. FAILS when the Section 0 H2 anchor is removed.
+  4. FAILS when the combined-aggregate "PASSED" verb appears in the audit
+     summary scope (spec line 152).
+  5. FAILS when the aggregate status is missing one of the three required
+     splits per spec lines 147-150.
+  6. FAILS when a pass/fail summary is positioned BEFORE Section 0
+     (spec line 146 firm rule).
+  7. FAILS when the Section 1 heading bytes mutate (regression sentinel
+     for the additive-prepend invariant per Q5 amend).
+  8. FAILS when any of the four required Scope Report content fields is
+     removed.
+
+Baseline assumption: Step 2 commit prepends the Scope Report block to
+`shared/templates/codex_audit_multifile_template.md`. Each mutation test
+snapshots the template, mutates a single attribute of that baseline,
+runs the lint as a subprocess, and restores the file in `finally`
+(mirrors test_check_v3_6_8_pattern_protection.py snapshot pattern).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LINT = REPO_ROOT / "scripts" / "check_v3_6_8_audit_scope_block.py"
+TEMPLATE = REPO_ROOT / "shared" / "templates" / "codex_audit_multifile_template.md"
+
+# Anchors that MUST appear in the baseline (Step 2 ships these). If any
+# is absent, the baseline contract has drifted and tests are vacuous.
+SECTION_0_H2_ANCHOR = "## Section 0 — Scope Report"
+SCOPE_REPORT_HEADER = "## Codex Audit Round N — Scope Report"
+SECTION_1_HEADING = "## Section 1 — Round metadata"
+UNAUDITED_SPLIT_LINE = "  - `unaudited-due-to-missing-source: <count>` (always reported, never hidden)\n"
+
+REQUIRED_FIELDS = [
+    "**Total entries audited:**",
+    "**Entries with retrieved original source:**",
+    "**Entries description-only (no retrieved source):**",
+    "**Audit scope warning:**",
+]
+
+
+def _run_lint() -> subprocess.CompletedProcess[str]:
+    """Run the v3.7.1 audit-scope lint as a subprocess (so sys.exit propagates)."""
+    return subprocess.run(
+        [sys.executable, str(LINT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------- Helpers for snapshot + restore ----------
+
+
+class _Snapshot:
+    """Backs up a file's bytes; restores on context exit."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._bytes: bytes | None = None
+        self._existed: bool = False
+
+    def __enter__(self) -> "_Snapshot":
+        self._existed = self.path.exists()
+        if self._existed:
+            self._bytes = self.path.read_bytes()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._existed and self._bytes is not None:
+            self.path.write_bytes(self._bytes)
+        elif not self._existed and self.path.exists():
+            self.path.unlink()
+
+
+def _baseline_text() -> str:
+    """Return template text and assert baseline anchors are present."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    for anchor in (SECTION_0_H2_ANCHOR, SCOPE_REPORT_HEADER, SECTION_1_HEADING):
+        assert anchor in text, (
+            f"baseline contract drift: {anchor!r} missing from template; "
+            "Step 2 prepend may have been reverted."
+        )
+    return text
+
+
+# ---------- Tests ----------
+
+
+def test_t1_baseline_template_passes() -> None:
+    """T1: template AS SHIPPED carries a valid Scope Report block → PASS."""
+    _baseline_text()  # asserts baseline anchors present
+    result = _run_lint()
+    assert result.returncode == 0, (
+        f"Expected exit 0 on baseline template; got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "PASS" in result.stdout
+
+
+def test_t2_scope_report_header_strictly_before_section_1() -> None:
+    """T2: baseline Scope Report header anchored before Section 1 → PASS + ordering verified."""
+    text = _baseline_text()
+    result = _run_lint()
+    assert result.returncode == 0
+    # Sanity check: the lint actually verified ordering, not just header presence.
+    assert text.find(SECTION_0_H2_ANCHOR) < text.find(SECTION_1_HEADING)
+    assert text.find(SCOPE_REPORT_HEADER) < text.find(SECTION_1_HEADING)
+
+
+def test_t3_missing_section_0_anchor_fails() -> None:
+    """T3: Section 0 H2 anchor removed → FAIL."""
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Mutate the Section 0 H2 heading so the lint cannot anchor it.
+        # We change the heading bytes so it no longer matches '^## Section 0'.
+        mutated = text.replace(SECTION_0_H2_ANCHOR, "## Sectionless 0 — Scope Report", 1)
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to reject template after Section 0 anchor mutation.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "Section 0" in result.stdout
+        assert "missing" in result.stdout.lower() or "absent" in result.stdout.lower()
+
+
+def test_t4_combined_aggregate_passed_verb_in_summary_fails() -> None:
+    """T4: inject a combined-aggregate 'PASSED' verb in summary context → FAIL (spec line 152)."""
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Inject a forbidden combined-aggregate verdict line just before Section 1.
+        injection = "\n## Audit Summary\n\nverdict: PASSED\n\n---\n"
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            injection + SECTION_1_HEADING,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to reject combined-aggregate 'PASSED' verb per spec line 152.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        # The combined-aggregate verb is what's forbidden; the rule code
+        # should surface either R4 or the verb itself.
+        out = result.stdout
+        assert "PASSED" in out or "combined-aggregate" in out.lower()
+
+
+def test_t5_missing_unaudited_split_fails() -> None:
+    """T5: drop the 'unaudited-due-to-missing-source' split row → FAIL (spec line 150)."""
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        assert UNAUDITED_SPLIT_LINE in text, (
+            "fixture assumption violated: unaudited split line not present in baseline"
+        )
+        mutated = text.replace(UNAUDITED_SPLIT_LINE, "", 1)
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to reject Scope Report missing the "
+            "'unaudited-due-to-missing-source' split per spec line 150.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "unaudited-due-to-missing-source" in result.stdout
+
+
+def test_t6_pass_fail_summary_before_section_0_fails() -> None:
+    """T6: inject a pass/fail summary BEFORE Section 0 → FAIL (spec line 146)."""
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Inject a fake pass/fail summary heading + verdict row BEFORE Section 0.
+        injection = (
+            "\n## Audit Summary\n\nverified-against-source: PASS\n\n---\n\n"
+        )
+        mutated = text.replace(
+            SECTION_0_H2_ANCHOR,
+            injection + SECTION_0_H2_ANCHOR,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to reject pass/fail summary placed before Section 0 "
+            "(spec line 146 firm rule).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def test_t7_section_1_heading_byte_mutation_fails() -> None:
+    """T7: Section 1 heading bytes change → FAIL (additive-prepend invariant per Q5)."""
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Mutate the Section 1 heading's title (capitalization swap).
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            "## Section 1 — Round Metadata",  # capitalization changed
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to enforce Section 1 byte-equivalence per Q5 amend "
+            "(spec §3.2 line 131: Sections 1-7 stay byte-equivalent in title, "
+            "ordinal label, and order).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize("missing_field", REQUIRED_FIELDS)
+def test_t8_missing_required_content_field_fails(missing_field: str) -> None:
+    """T8: drop one of the four required Scope Report fields → FAIL (spec lines 136-140)."""
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        assert missing_field in text, (
+            f"fixture assumption violated: field {missing_field!r} not present in baseline"
+        )
+        # Drop the entire line that contains the field marker.
+        lines = text.splitlines(keepends=True)
+        # Drop only the FIRST line that contains the marker, to avoid
+        # accidentally removing a Template-structure summary line that
+        # also references the field name.
+        new_lines: list[str] = []
+        dropped = False
+        for line in lines:
+            if not dropped and missing_field in line:
+                dropped = True
+                continue
+            new_lines.append(line)
+        assert dropped, "fixture assumption violated: no line dropped"
+        TEMPLATE.write_text("".join(new_lines), encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject Scope Report missing field {missing_field!r}.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -364,6 +364,41 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+def test_t25_preamble_header_decoy_does_not_short_circuit_ordering() -> None:
+    """T25 (codex round-11 P2): if a preamble decoy of the canonical
+    `## Codex Audit Round N — Scope Report` line exists ahead of the
+    real Section 0 (e.g. inside a documentation block), a verdict line
+    placed BETWEEN that decoy and the real Scope Report content must
+    still FAIL. Round-10 derived ordering_boundary from the first
+    whole-file occurrence; with a preamble decoy that boundary lands too
+    early and the verdict escapes the scan. Boundary must instead derive
+    from the Section-0-validated header position.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        assert section_0_pos != -1
+        # Inject (a) a preamble decoy header line before Section 0,
+        # (b) a verdict line between the decoy and Section 0.
+        decoy_block = (
+            "## Documentation reference\n\n"
+            "## Codex Audit Round N — Scope Report\n\n"
+            "(decoy header — purely informational, real block lives below)\n\n"
+            "verdict: PASS\n\n"
+            "---\n\n"
+        )
+        mutated = text[:section_0_pos] + decoy_block + text[section_0_pos:]
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            "Expected lint to reject verdict line between preamble decoy "
+            "header and the real Scope Report content. Boundary derivation "
+            "must use the Section-0-validated header, not first whole-file "
+            "occurrence.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 @pytest.mark.parametrize(
     "verdict_line",
     [

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -252,3 +252,150 @@ def test_t8_missing_required_content_field_fails(missing_field: str) -> None:
             f"Expected lint to reject Scope Report missing field {missing_field!r}.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
+
+
+# ---- Round-2 codex review findings ----
+
+
+@pytest.mark.parametrize("missing_field", REQUIRED_FIELDS)
+def test_t9_required_field_check_scoped_to_section_0(missing_field: str) -> None:
+    """T9 (codex round-2 P2-1): required-field scan must be scoped to Section 0,
+    not whole-file. If the field is dropped from Section 0 but the same marker
+    appears in a later appendix or documentation block, the lint must still FAIL.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Find the Section 0 block boundaries: from "## Section 0" anchor
+        # to the next "## Section 1" anchor.
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        section_1_pos = text.find("## Section 1 — Round metadata")
+        assert section_0_pos != -1 and section_1_pos != -1
+        section_0_block = text[section_0_pos:section_1_pos]
+        assert missing_field in section_0_block, (
+            f"fixture assumption violated: field {missing_field!r} missing from Section 0 baseline"
+        )
+        # Remove the field from Section 0 only, then inject a decoy line
+        # carrying the same marker AFTER Section 7 so a whole-file scan
+        # would falsely PASS.
+        section_0_mutated = section_0_block.replace(missing_field, "REDACTED-FIELD-MARKER", 1)
+        appendix_decoy = (
+            f"\n\n## Appendix — documentation reference\n\n"
+            f"For historical context, the Scope Report contract requires "
+            f"{missing_field} to appear in every audit round.\n"
+        )
+        mutated = (
+            text[:section_0_pos]
+            + section_0_mutated
+            + text[section_1_pos:]
+            + appendix_decoy
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject when {missing_field!r} is missing from Section 0 "
+            f"(even though the marker appears in an appendix after Section 7).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize("missing_split", [
+    "verified-against-source",
+    "description-internally-consistent",
+    "unaudited-due-to-missing-source",
+])
+def test_t10_required_split_check_scoped_to_section_0(missing_split: str) -> None:
+    """T10 (codex round-2 P2-1, applies to R3 too): aggregate-status split
+    scan must be scoped to Section 0. Decoy in appendix must not falsely PASS.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        section_1_pos = text.find("## Section 1 — Round metadata")
+        section_0_block = text[section_0_pos:section_1_pos]
+        assert missing_split in section_0_block
+        section_0_mutated = section_0_block.replace(missing_split, "REDACTED-SPLIT-NAME", 1)
+        appendix_decoy = (
+            f"\n\n## Appendix — split nomenclature\n\n"
+            f"Note: the {missing_split} verdict is computed by the orchestrator.\n"
+        )
+        mutated = (
+            text[:section_0_pos]
+            + section_0_mutated
+            + text[section_1_pos:]
+            + appendix_decoy
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject when {missing_split!r} is missing from Section 0 "
+            f"(even though the marker appears in an appendix).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def test_t11_target_relative_path_does_not_crash() -> None:
+    """T11 (codex round-2 P2-2): --target with a relative repo path must
+    not crash with ValueError. Lint should resolve the path and proceed.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(LINT),
+            "--target",
+            "shared/templates/codex_audit_multifile_template.md",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # The lint must produce a deterministic exit code (0 or 1 — both indicate
+    # the lint ran), NOT crash with ValueError or ImportError.
+    assert result.returncode in (0, 1), (
+        f"Expected exit 0 or 1 on relative --target; got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # Crash signature: ValueError traceback in stderr.
+    assert "Traceback" not in result.stderr, (
+        f"Expected --target with relative path to be handled gracefully; "
+        f"got Python traceback in stderr:\n{result.stderr}"
+    )
+
+
+def test_t12_target_outside_repo_does_not_crash(tmp_path) -> None:
+    """T12 (codex round-2 P2-2): --target with an absolute path outside
+    the repo must not crash. Lint should display the raw path and proceed.
+    """
+    fixture = tmp_path / "fake_template.md"
+    # Minimal valid Scope Report fixture so the lint reports PASS not FAIL.
+    fixture.write_text(
+        "# Test\n\n"
+        "## Section 0 — Scope Report\n\n"
+        "```\n"
+        "## Codex Audit Round N — Scope Report\n\n"
+        "**Total entries audited:** <N>\n"
+        "**Entries with retrieved original source:** <N>\n"
+        "**Entries description-only (no retrieved source):** <N>\n"
+        "**Audit scope warning:** test\n"
+        "```\n\n"
+        "verified-against-source\n"
+        "description-internally-consistent\n"
+        "unaudited-due-to-missing-source\n\n"
+        "## Section 1 — Round metadata\n\n"
+        "body\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(LINT), "--target", str(fixture)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "Traceback" not in result.stderr, (
+        f"Expected --target outside the repo to be handled gracefully; "
+        f"got Python traceback in stderr:\n{result.stderr}"
+    )
+    assert result.returncode in (0, 1), (
+        f"Expected deterministic exit code; got {result.returncode}"
+    )

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -365,6 +365,78 @@ def test_t11_target_relative_path_does_not_crash() -> None:
 
 
 @pytest.mark.parametrize(
+    "passed_line",
+    [
+        # P2 (round-13): bare PASSED in output instructions (Section 6
+        # area or anywhere after Scope Report) without verdict-key or
+        # summary-heading framing.
+        "If zero findings, output exactly: PASSED",
+        "On success: PASSED",  # `success` would not match _VERDICT_TOKEN
+        "Mark the run PASSED in the manifest.",
+        "Emit a single token: PASSED.",
+    ],
+)
+def test_t27_unquoted_passed_post_section_0_fails(passed_line: str) -> None:
+    """T27 (codex round-13 P2 → architectural cap rule): any UNQUOTED
+    `PASSED` token appearing after the Scope Report content violates the
+    spec line 152 contract. Lexical pattern enumeration (rounds 5-7, 13)
+    cannot cover every future combination of verdict keys, summary
+    headings, and instruction phrasings. The cap rule denies any bare
+    PASSED on the post-Section-0 surface and allows only quoted forms
+    (`"PASSED"` or backtick `` `PASSED` ``) used in spec self-explanation.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Inject after Section 0 / before Section 1.
+        injection = "\n\n" + passed_line + "\n\n"
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            injection + SECTION_1_HEADING,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject bare PASSED token ({passed_line!r}) on "
+            f"post-Section-0 surface. Spec line 152 forbids the combined-"
+            f"aggregate verb regardless of phrasing.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize(
+    "self_explanation",
+    [
+        # Quoted forms used in spec self-explanation must NOT trip the cap rule.
+        '\n\nThe combined-aggregate "PASSED" verb is forbidden.\n\n',
+        "\n\nUse backtick form: `PASSED` is the literal token.\n\n",
+        '\n\nNote: "PASSED" appears as documentation only.\n\n',
+    ],
+)
+def test_t28_quoted_passed_self_explanation_allowed(self_explanation: str) -> None:
+    """T28 (codex round-13 cap rule, allow side): the cap rule must NOT
+    fire on PASSED tokens enclosed in straight quotes or backticks —
+    those are the spec self-explanation forms used in the canonical
+    template (lines 26 and 49) and must remain valid.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            self_explanation + SECTION_1_HEADING,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 0, (
+            f"Expected lint to ACCEPT quoted PASSED self-explanation "
+            f"({self_explanation!r}). Cap rule must allow `\"PASSED\"` and "
+            f"backtick `PASSED` forms used in spec documentation prose.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize(
     "suffix",
     [
         " (draft)",

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -362,6 +362,73 @@ def test_t11_target_relative_path_does_not_crash() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "summary_block",
+    [
+        # P2-5 (round-5): non-`verdict` key followed by combined-aggregate PASSED.
+        "\n## Audit Summary\n\nOverall status: PASSED\n\n---\n",
+        "\n## Audit Summary\n\nResult: PASSED\n\n---\n",
+        "\n## Audit Summary\n\nFinal: PASSED\n\n---\n",
+    ],
+)
+def test_t16_non_verdict_key_with_passed_fails(summary_block: str) -> None:
+    """T16 (codex round-5 P2-5): R4 must reject combined-aggregate 'PASSED'
+    summaries that use any key, not just `verdict`. The spec line 152
+    contract is on the *verb*, not the surrounding key.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Inject the summary block just before Section 1 (after Section 0).
+        mutated = text.replace(
+            SECTION_1_HEADING,
+            summary_block + SECTION_1_HEADING,
+            1,
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject combined-aggregate 'PASSED' under non-verdict key "
+            f"({summary_block!r}). Spec line 152 forbids the verb regardless of the key.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize(
+    "bare_verdict_line",
+    [
+        # P2-6 (round-5): bare verdict line before Section 0 with no `## Summary` heading.
+        "verdict: PASS\n\n",
+        "overall: FAIL\n\n",
+        "result: PASSED\n\n",
+        "final status: PASS\n\n",
+    ],
+)
+def test_t17_bare_verdict_before_section_0_fails(bare_verdict_line: str) -> None:
+    """T17 (codex round-5 P2-6): R1 ordering check must reject ANY pass/fail
+    summary line ahead of Section 0, not only ones with a `## ... Summary`
+    heading. A bare `verdict: PASS` line still counts as a pass/fail summary
+    per spec line 146.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        assert section_0_pos != -1
+        # Inject bare verdict line BEFORE Section 0 (no heading framing).
+        mutated = (
+            text[:section_0_pos]
+            + bare_verdict_line
+            + text[section_0_pos:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject bare verdict line before Section 0 "
+            f"({bare_verdict_line!r}). Spec line 146 firm rule: Scope Report "
+            f"must appear BEFORE any pass/fail summary, regardless of heading framing.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 def test_t15_forbidden_passed_verb_inside_fenced_block_fails() -> None:
     """T15 (codex round-4 P2): combined-aggregate 'PASSED' inside a fenced
     code block must FAIL. Fenced blocks are the actual prompt content sent

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -30,6 +30,7 @@ runs the lint as a subprocess, and restores the file in `finally`
 """
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -361,6 +362,53 @@ def test_t11_target_relative_path_does_not_crash() -> None:
         f"Expected --target with relative path to be handled gracefully; "
         f"got Python traceback in stderr:\n{result.stderr}"
     )
+
+
+@pytest.mark.parametrize(
+    "verdict_line",
+    [
+        "verdict: PASS",
+        "result: FAIL",
+        "Final status: PASSED",
+    ],
+)
+def test_t24_verdict_inside_fenced_block_before_canonical_header_fails(
+    verdict_line: str,
+) -> None:
+    """T24 (codex round-10 P2): a verdict line inserted INSIDE the fenced
+    Scope Report block but BEFORE the canonical
+    `## Codex Audit Round N — Scope Report` header still violates spec
+    line 146. Round-9 ordering fix used text_no_fences for both anchor
+    discovery and prefix scan, which masked the live block entirely
+    (canonical header lives in fence, so it could not be found, and any
+    verdict line inside the same fence was hidden too).
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        # Find the opening fence right after the Section 0 H2.
+        # In the canonical template this is `\n```\n## Codex Audit Round N — Scope Report`.
+        fence_open_match = re.search(r"^```\s*\n", text, re.MULTILINE)
+        assert fence_open_match is not None, (
+            "fixture assumption violated: opening fence not found"
+        )
+        fence_open_end = fence_open_match.end()
+        # Inject the verdict line right after the opening fence, BEFORE
+        # the canonical Scope Report header line.
+        mutated = (
+            text[:fence_open_end]
+            + verdict_line
+            + "\n\n"
+            + text[fence_open_end:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject verdict line ({verdict_line!r}) inside "
+            f"the fenced Scope Report block but before the canonical header. "
+            f"Spec line 146 firm rule applies regardless of fence framing — "
+            f"the fence IS the prompt content sent to codex.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
 
 
 def test_t22_affected_refcodes_field_required() -> None:

--- a/scripts/test_check_v3_6_8_audit_scope_block.py
+++ b/scripts/test_check_v3_6_8_audit_scope_block.py
@@ -52,6 +52,7 @@ REQUIRED_FIELDS = [
     "**Entries with retrieved original source:**",
     "**Entries description-only (no retrieved source):**",
     "**Audit scope warning:**",
+    "**Affected refcodes (description-only):**",
 ]
 
 
@@ -360,6 +361,83 @@ def test_t11_target_relative_path_does_not_crash() -> None:
         f"Expected --target with relative path to be handled gracefully; "
         f"got Python traceback in stderr:\n{result.stderr}"
     )
+
+
+def test_t22_affected_refcodes_field_required() -> None:
+    """T22 (codex round-9 P2a): `**Affected refcodes (description-only):**`
+    is part of the spec line 142 contract and must be a required field.
+    Removing it from Section 0 must FAIL the lint.
+    """
+    field = "**Affected refcodes (description-only):**"
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        section_0_pos = text.find("## Section 0 — Scope Report")
+        section_1_pos = text.find("## Section 1 — Round metadata")
+        assert section_0_pos != -1 and section_1_pos != -1
+        section_0_block = text[section_0_pos:section_1_pos]
+        assert field in section_0_block, (
+            f"fixture assumption violated: field {field!r} not present in baseline Section 0"
+        )
+        # Drop the line carrying the field marker (within Section 0).
+        section_0_lines = section_0_block.splitlines(keepends=True)
+        section_0_mutated = "".join(
+            ln for ln in section_0_lines if field not in ln
+        )
+        mutated = (
+            text[:section_0_pos]
+            + section_0_mutated
+            + text[section_1_pos:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject Scope Report missing field {field!r} "
+            f"(spec line 142 — the required affected-refcodes disclosure).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+@pytest.mark.parametrize(
+    "verdict_line",
+    [
+        # P2b (round-9): verdict line between Section 0 H2 and canonical header.
+        "verdict: PASS\n\n",
+        "result: FAIL\n\n",
+        "Final status: PASSED\n\n",
+    ],
+)
+def test_t23_verdict_between_section_0_h2_and_canonical_header_fails(
+    verdict_line: str,
+) -> None:
+    """T23 (codex round-9 P2b): a verdict line inserted AFTER `## Section 0`
+    but BEFORE the canonical `## Codex Audit Round N — Scope Report`
+    header still violates spec line 146 (Scope Report before any pass/fail
+    summary). The ordering check previously scoped to text before Section
+    0 H2; this layout slips through.
+    """
+    with _Snapshot(TEMPLATE):
+        text = _baseline_text()
+        section_0_h2 = "## Section 0 — Scope Report (mandatory; v3.7.1 D2)\n"
+        section_0_pos = text.find(section_0_h2)
+        assert section_0_pos != -1, "fixture assumption violated"
+        # Inject verdict line right after the Section 0 H2, before any
+        # other Section-0 content (and before the canonical fenced header).
+        insert_at = section_0_pos + len(section_0_h2)
+        mutated = (
+            text[:insert_at]
+            + "\n"
+            + verdict_line
+            + text[insert_at:]
+        )
+        TEMPLATE.write_text(mutated, encoding="utf-8")
+        result = _run_lint()
+        assert result.returncode == 1, (
+            f"Expected lint to reject verdict line ({verdict_line!r}) inserted "
+            f"between Section 0 H2 and the canonical Scope Report header. "
+            f"Spec line 146 requires Scope Report content to precede any "
+            f"pass/fail summary surface.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/shared/templates/codex_audit_multifile_template.md
+++ b/shared/templates/codex_audit_multifile_template.md
@@ -12,8 +12,9 @@ This template fixes a single audit-prompt structure so the orchestrator's audit 
 
 ## Template structure
 
-A v3.6.7 multi-file audit prompt has seven sections in this order:
+A v3.7.1 multi-file audit prompt has eight sections in this order (Section 0 prepended additively per v3.7.1 D2; Sections 1–7 stay byte-equivalent to v3.6.7):
 
+0. Scope Report (mandatory; rides verbatim in every round; v3.7.1 D2)
 1. Round metadata
 2. Bundle inventory
 3. Audit dimensions (the 7 specified below)
@@ -22,7 +23,35 @@ A v3.6.7 multi-file audit prompt has seven sections in this order:
 6. Output format
 7. Anti-fake-audit guard (mandatory; rides verbatim in every audit dispatch)
 
-The orchestrator fills the placeholders in `{curly_braces}`. Everything else rides verbatim. Section 7 is non-negotiable — omitting it leaves sub-agents free to fake audit-passed metadata, which is the failure mode v3.6.7 spec §5.3 + Pattern C3 + `feedback_subagent_tool_hallucination.md` exist to prevent.
+The orchestrator fills the placeholders in `{curly_braces}`. Everything else rides verbatim. Section 0 is non-negotiable — its purpose is to disclose the audit's actual coverage so a "PASSED" verdict cannot mask un-retrieved sources (spec v3.7.1 §3.2 / Pattern D2). Section 7 is non-negotiable — omitting it leaves sub-agents free to fake audit-passed metadata, which is the failure mode v3.6.7 spec §5.3 + Pattern C3 + `feedback_subagent_tool_hallucination.md` exist to prevent.
+
+---
+
+## Section 0 — Scope Report (mandatory; v3.7.1 D2)
+
+Every audit round MUST open with a Scope Report that quantifies how many of the audited entries had a retrieved original source vs. were verified only against derivative bibliography or self-consistency. The block below rides verbatim in every audit dispatch, ahead of any pass/fail summary.
+
+```
+## Codex Audit Round N — Scope Report
+
+**Total entries audited:** <N_total>
+**Entries with retrieved original source:** <N_with_source> (verified against original publication)
+**Entries description-only (no retrieved source):** <N_without_source> (verified only against derivative bibliography or self-consistency)
+
+**Audit scope warning:** <N_without_source> entries cannot be independently verified by this audit round. Their `verified` status reflects internal consistency between entry .md and the derivative bibliography source, NOT correctness against the original publication. These entries should be treated as **unverifiable until original sources are retrieved**.
+
+**Affected refcodes (description-only):** <comma-separated list>
+```
+
+**Two firm rules (spec v3.7.1 §3.2):**
+
+- The Scope Report block must appear **before** any pass/fail summary in the audit output.
+- The aggregate verdict MUST be split into the following three reporting lines (the combined-aggregate "PASSED" verb is forbidden in the audit summary):
+  - `verified-against-source: PASS | FAIL` (over the retrieved-source subset)
+  - `description-internally-consistent: PASS | FAIL` (over the non-retrieved subset)
+  - `unaudited-due-to-missing-source: <count>` (always reported, never hidden)
+
+**Why this exists:** in the 2026-04-30 HEEACT chapter session, a codex round-3 report stated "ADDRESSED" without disclosing that only 22 of 53 entries had retrieved original sources; the remaining 31 description-only entries inherited the "verified" verdict by aggregation. The Scope Report renders that split first-class so a reader cannot conflate self-consistency with retrieval-grounded verification.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements **Step 2** of the v3.7.1 implementation roadmap (Pattern D2 — *Audit scope coverage non-disclosure*) per `docs/design/2026-04-30-ars-v3.6.8-trust-provenance-and-drift-transparency-spec.md` §3.2 + §3.7 + §4 Step 2.

**The fix in one sentence:** every codex audit prompt now opens with a mandatory Section 0 Scope Report disclosing how many audited entries were verified against original publications vs. only against derivative bibliography, so a "PASSED" verdict cannot mask un-retrieved sources.

## What Pattern D2 is

Observed live in the 2026-04-30 HEEACT chapter session: codex round 3 reported "ADDRESSED" without disclosing that only 22 of 53 entries had retrieved original sources. The remaining 31 description-only entries inherited the "verified" verdict by aggregation. Section 0 renders that split first-class so a reader cannot conflate self-consistency with retrieval-grounded verification.

## Files changed

- `shared/templates/codex_audit_multifile_template.md` — additive prepend of Section 0 Scope Report block ahead of Section 1; Template-structure prose updated from "seven sections" to "eight sections". **Sections 1-7 stay byte-equivalent** per Q5 amend (spec line 131).
- `scripts/check_v3_6_8_audit_scope_block.py` — new lint enforcing 5 rules (Section 0 anchor + ordering; 4 required content fields; 3 required aggregate-status splits; forbidden combined-aggregate "PASSED" verb; Section 1 byte-equivalence sentinel).
- `scripts/test_check_v3_6_8_audit_scope_block.py` — 11 mutation tests (1 baseline + 6 negative-mutation classes + T8 parametrized over 4 required fields).
- `.github/workflows/spec-consistency.yml` — wire new lint + pytest into CI.

## Issue-#77-aware design

The new lint preempts the same architectural traps surfaced by codex challenge round 1 against PR #76's SHA gate:

- **Heading-anchored extraction** (not first-match `re.search`) — duplicate Section 0 H2 anchors are rejected explicitly (R1).
- **Fenced-code-block exclusion** when locating the top-level Section 0 H2 anchor (the canonical Scope Report header lives inside a fenced block per spec line 134; the H2 anchor at top level is what we count).
- **No advisory degradation** — every rule fails closed.

These guardrails are independent of the SHA gate v2 hardening tracked in #77 (which addresses base-ref derivation and PR-base anchoring for the v3.6.7 protected blocks).

## Verification

Three-lint regression gate (spec §3.7 line 367-372) PASSES on the modified template:

```
python scripts/check_v3_6_7_pattern_protection.py                   → exit 0 (12/12)
pytest scripts/test_check_v3_6_7_pattern_protection.py              → 58/58 PASS
python scripts/check_audit_artifact_consistency.py
  --example-validation-harness                                      → exit 0
```

v3.7.1 lint suite full sweep:

```
python scripts/check_v3_6_8_pattern_protection.py                   → exit 0 (3/3)
python scripts/check_v3_6_8_frontmatter_trust_schema.py             → exit 0
python scripts/check_v3_6_8_audit_scope_block.py                    → exit 0 (NEW)
python scripts/check_spec_consistency.py                            → exit 0
pytest scripts/test_check_v3_6_8_pattern_protection.py              → 20/20
pytest scripts/test_check_v3_6_8_frontmatter_trust_schema.py        → 24/24
pytest scripts/test_check_v3_6_8_audit_scope_block.py               → 11/11 (NEW)
```

Total: 6 lints exit 0; 113 pytest PASS.

## Test plan

- [x] Lint baseline against modified template — PASS
- [x] Lint baseline against unmodified template — FAIL (correctly rejects missing Section 0)
- [x] All 11 mutation tests verify the lint catches each violation class
- [x] Three v3.6.7 regression lints pass on modified template
- [x] CI workflow includes new lint + pytest steps

## Roadmap

| Step | Status |
|---|---|
| Step 0 (lint manifest separation) | ✅ MERGED PR #76 |
| Step 1 (D1 frontmatter schema split) | ✅ MERGED PR #76 |
| **Step 2 (D2 audit Scope Report)** | **THIS PR** |
| Step 3 (D3 cite-time provenance) | NEXT |
| Step 4 (D4 Session Drift Log) | future |
| Step 5 (D5 retrieval fallback chain) | future |
| Step 6 (Integration tests) | future |
| Step 7 (`/ars-mark-read` plugin commands) | future |
| #77 (SHA gate v2 hardening) | parked — needs spec round-9 amend |

🤖 Generated with [Claude Code](https://claude.com/claude-code)