### PR TITLE
docs(contributing): add Platform ports section (community-maintained only)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,16 @@ Open an issue first before submitting a PR for these:
 - **Handoff schema changes** — modifications to `shared/handoff_schemas.md`
 - **New skills or modes** — additions to the pipeline
 
+### Platform ports (community-maintained only)
+
+ARS is built for Claude Code and dogfooded there exclusively. Ports to other agent platforms (Opencode, Cursor, Continue, Aider, etc.) are accepted as community-maintained contributions under these conditions:
+
+- **Wrapper layer, not a fork.** Keep `skills/*/SKILL.md`, `agents/*.md`, `shared/`, and `scripts/` as the source of truth. Add a top-level `<platform>/` directory (e.g. `opencode/`) for the manifest, plugin entry, and dispatch shims. PRs that modify core skill files to accommodate a target platform will be declined.
+- **Named maintainer.** The PR description must identify who will keep the port in sync with ARS minor releases (~6-week cadence) and triage platform-specific bug reports. Platform-specific issues will be redirected to that maintainer.
+- **End-to-end evidence.** Include at least one full `academic-pipeline` run on the target platform, committed under `examples/<platform>/`, so regressions are detectable.
+- **Model-portability note.** ARS prompts are calibrated against Claude (Opus for architecture/review, Sonnet for execution; never Haiku). The PR must document which providers/models were tested and where downstream-agent behavior diverged from the Claude baseline.
+- **Open a design issue first** before submitting the PR.
+
 ---
 
 ## PR guidelines


### PR DESCRIPTION
## Summary

- Add a "Platform ports (community-maintained only)" sub-section to `CONTRIBUTING.md` under § What we accept
- Codifies five conditions for accepting community ports of ARS to non-Claude-Code agent platforms (Opencode, Cursor, Continue, Aider, etc.): wrapper layer not fork, named maintainer, end-to-end evidence, model-portability note, design issue first

## Why

#85 (and similar future asks) need a written, searchable policy rather than a one-off issue reply. The conditions belong in the contributing guide so:

- New contributors see them before opening a port PR
- The maintainer doesn't re-derive the conditions per issue
- The policy is greppable for future similar requests

The wording matches existing CONTRIBUTING tiers (fast-merge / review / approval+discussion) — this becomes a fourth tier scoped to platform ports.

## Refs

- #85 (Opencode support? — the trigger; will be answered with a pointer to this section once merged)

## Test plan

- [ ] CONTRIBUTING.md renders correctly on GitHub
- [ ] Section heading "Platform ports (community-maintained only)" appears in the right place (after "Requires maintainer approval + discussion", before "PR guidelines")
- [ ] All five bullet conditions render with bold lead phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)