### PR TITLE
docs: align platform-ports policy with sibling-distribution shape

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,13 +44,17 @@ Open an issue first before submitting a PR for these:
 
 ### Platform ports (community-maintained only)
 
-ARS is built for Claude Code and dogfooded there exclusively. Ports to other agent platforms (Opencode, Cursor, Continue, Aider, etc.) are accepted as community-maintained contributions under these conditions:
+This repository is the reference distribution of ARS, built for Claude Code. Ports to other agent platforms (Opencode, Cursor, Continue, Aider, etc.) are accepted as community-maintained contributions. Two structural shapes are acceptable — both keep core ARS content as the source of truth:
 
-- **Wrapper layer, not a fork.** Keep `skills/*/SKILL.md`, `agents/*.md`, `shared/`, and `scripts/` as the source of truth. Add a top-level `<platform>/` directory (e.g. `opencode/`) for the manifest, plugin entry, and dispatch shims. PRs that modify core skill files to accommodate a target platform will be declined.
-- **Named maintainer.** The PR description must identify who will keep the port in sync with ARS minor releases (~6-week cadence) and triage platform-specific bug reports. Platform-specific issues will be redirected to that maintainer.
-- **End-to-end evidence.** Include at least one full `academic-pipeline` run on the target platform, committed under `examples/<platform>/`, so regressions are detectable.
+- **In-tree wrapper.** Add a top-level `<platform>/` directory in this repo (e.g. `opencode/`) containing the manifest, plugin entry, and dispatch shims. Core ARS files (`skills/*/SKILL.md`, `agents/*.md`, `shared/`, `scripts/`) remain unmodified.
+- **Sibling distribution.** A separate repository that vendors ARS workflow content with: (1) upstream commit hash pinned (e.g. in a `manifest.json`); (2) a written update / sync policy; (3) vendored content unmodified — only the outer routing / adapter layer is platform-specific.
+
+Either shape is accepted under the same maintainer-facing conditions:
+
+- **Named maintainer.** The PR description (in-tree) or repo README (sibling) must identify who will keep the port in sync with ARS minor releases (~6-week cadence) and triage platform-specific bug reports. Platform-specific issues will be redirected to that maintainer.
+- **End-to-end evidence.** Include at least one full `academic-pipeline` run on the target platform, committed under `examples/<platform>/` (in-tree) or under an `examples/` path in the sibling repo, so regressions are detectable.
 - **Model-portability note.** ARS prompts are calibrated against Claude (Opus for architecture/review, Sonnet for execution; never Haiku). The PR must document which providers/models were tested and where downstream-agent behavior diverged from the Claude baseline.
-- **Open a design issue first** before submitting the PR.
+- **Open a design issue first** before submitting the PR (for in-tree) or before requesting sibling-distribution recognition in this repo's README.
 
 ---
 

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-Academic Research Skills (ARS) is a **source-available academic research copilot framework** for noncommercial scholarly use. It is a suite of Claude Code skills that assists human researchers through the full research-to-publication pipeline.
+Academic Research Skills (ARS) is a **source-available academic research copilot framework** for noncommercial scholarly use. The reference distribution is a suite of Claude Code skills that assists human researchers through the full research-to-publication pipeline. Sibling distributions for other agent platforms (e.g. Codex) follow the same workflow content, the same human-in-the-loop design philosophy, and the same license terms; see [CONTRIBUTING.md § Platform ports](CONTRIBUTING.md#platform-ports-community-maintained-only).
 
 It is licensed under [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/). This is not an open source license — it restricts commercial use by design, to keep the tool free for academic communities.
 


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md § Platform ports**: relax "wrapper layer, not a fork" to recognize two acceptable structural shapes — in-tree wrapper and sibling distribution. Both keep core ARS content as the source of truth; sibling distributions must pin upstream commit hash + publish a written sync policy + leave vendored content unmodified.
- **POSITIONING.md § What this is**: reframe "a suite of Claude Code skills" as "The reference distribution is a suite of Claude Code skills" and forward-point to sibling distributions for other platforms (e.g. Codex), with same workflow content + same human-in-the-loop philosophy + same license terms.
- **License unchanged** (CC BY-NC 4.0).

## Why

PR #86 (just merged) added § Platform ports under a "wrapper-layer-only" stance. Reviewing afterwards surfaced two problems:

1. **Vendor-copy ports can achieve the same boundary** (core ARS = source of truth) without an in-tree wrapper, as long as they pin upstream commit + publish a sync policy + don't modify vendored content. Restricting to wrapper-only would needlessly exclude this shape.
2. **Author's forthcoming Codex sibling distribution uses the vendor-copy shape**. Keeping the strict wrapper-only wording would force either a double standard ("official ports may vendor; community ports must wrap") or a contradiction at the moment the Codex distribution becomes public. Either outcome is worse than just acknowledging both shapes upfront.

POSITIONING.md gets the matching narrative update so readers see "reference distribution + sibling distributions" before the Codex sibling becomes visible.

## Refs

- Builds on #86 (just merged)
- Refs #85 (the original Opencode-support ask that will be answered after this lands)

## Test plan

- [ ] CONTRIBUTING.md § Platform ports renders correctly on GitHub
- [ ] Both structural shapes (in-tree wrapper, sibling distribution) are described with concrete acceptance criteria
- [ ] Same four maintainer-facing conditions apply to both shapes
- [ ] POSITIONING.md anchor link `#platform-ports-community-maintained-only` resolves to the right section in CONTRIBUTING.md
- [ ] No license terminology drift (still CC BY-NC 4.0 throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)