### PR TITLE
docs: generalize local maintainer paths

### DIFF
--- a/docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-plan.md
+++ b/docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-plan.md
@@ -12,7 +12,7 @@
 
 **Spec:** `docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-design.md` (already in branch).
 
-**Working directory:** `/Users/imbad/Projects/academic-research-skills/`
+**Working directory:** `/path/to/academic-research-skills/`
 
 ---
 

--- a/docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md
+++ b/docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md
@@ -299,7 +299,7 @@ run_id: 2026-04-30T15-22-04Z-d8f3
 codex_cli_version: 0.128.0                 # from `codex --version`
 runner:
   hostname: imbad-mbp.local                 # `uname -n`
-  cwd: /Users/imbad/Projects/academic-research-skills
+  cwd: /path/to/academic-research-skills
   git_sha: b4fbffd                          # repo HEAD at audit start
   git_dirty: false                          # uncommitted changes flag
 timing:

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -142,7 +142,7 @@ SIDECAR_CLEAN: dict[str, Any] = {
     "codex_cli_version": "0.125.0",
     "runner": {
         "hostname": "imbad-mbp.local",
-        "cwd": "/Users/imbad/Projects/academic-research-skills",
+        "cwd": "/path/to/academic-research-skills",
         "git_sha": "b4fbffd",
         "git_dirty": False,
     },

--- a/scripts/test_check_audit_artifact_consistency.py
+++ b/scripts/test_check_audit_artifact_consistency.py
@@ -178,7 +178,7 @@ def make_valid_sidecar(template_sha: str = "1" * 64) -> dict[str, Any]:
         "codex_cli_version": "0.128.0",
         "runner": {
             "hostname": "imbad-mbp.local",
-            "cwd": "/Users/imbad/Projects/academic-research-skills",
+            "cwd": "/path/to/academic-research-skills",
             "git_sha": "b4fbffd",
             "git_dirty": False,
         },


### PR DESCRIPTION
Replace maintainer-specific local filesystem paths in ARS docs and audit test fixtures.\nKeeps public-facing examples repo-neutral before the repository stays public.