### PR TITLE
docs: neutralize example paths and hostnames

### DIFF
--- a/docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-design.md
+++ b/docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-design.md
@@ -148,7 +148,7 @@ File: `shared/contracts/passport/literature_corpus_entry.schema.json`.
     "source_pointer": {
       "type": "string",
       "minLength": 1,
-      "description": "Stable URI locating this work in the user's own KB. Examples: 'zotero://select/items/0_ABCD1234', 'obsidian://open?vault=kb&file=Chen2024', 'file:///Users/me/refs/chen2024.pdf', 'https://doi.org/10.1234/xyz'. ARS does NOT dereference this; consumers that want the full text fetch it from the pointer themselves."
+      "description": "Stable URI locating this work in the user's own KB. Examples: 'zotero://select/items/0_ABCD1234', 'obsidian://open?vault=kb&file=Chen2024', 'file:///path/to/refs/chen2024.pdf', 'https://doi.org/10.1234/xyz'. ARS does NOT dereference this; consumers that want the full text fetch it from the pointer themselves."
     },
 
     "venue":                  { "type": "string", "minLength": 1 },

--- a/docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-plan.md
+++ b/docs/design/2026-04-23-ars-v3.6.4-literature-corpus-adapters-plan.md
@@ -330,7 +330,7 @@ Create `shared/contracts/passport/literature_corpus_entry.schema.json`:
     "source_pointer": {
       "type": "string",
       "minLength": 1,
-      "description": "Stable URI locating this work in the user's own KB. Examples: 'zotero://select/items/0_ABCD1234', 'obsidian://open?vault=kb&file=Chen2024', 'file:///Users/me/refs/chen2024.pdf', 'https://doi.org/10.1234/xyz'. ARS does NOT dereference this; consumers that want the full text fetch it from the pointer themselves."
+      "description": "Stable URI locating this work in the user's own KB. Examples: 'zotero://select/items/0_ABCD1234', 'obsidian://open?vault=kb&file=Chen2024', 'file:///path/to/refs/chen2024.pdf', 'https://doi.org/10.1234/xyz'. ARS does NOT dereference this; consumers that want the full text fetch it from the pointer themselves."
     },
 
     "venue":                  { "type": "string", "minLength": 1 },

--- a/docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md
+++ b/docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md
@@ -298,7 +298,7 @@ Schema for the sidecar metadata file. This is the **Layer 3** anti-fake-audit ch
 run_id: 2026-04-30T15-22-04Z-d8f3
 codex_cli_version: 0.128.0                 # from `codex --version`
 runner:
-  hostname: imbad-mbp.local                 # `uname -n`
+  hostname: runner.example.local            # `uname -n`
   cwd: /path/to/academic-research-skills
   git_sha: b4fbffd                          # repo HEAD at audit start
   git_dirty: false                          # uncommitted changes flag

--- a/scripts/adapters/tests/test_common.py
+++ b/scripts/adapters/tests/test_common.py
@@ -274,10 +274,10 @@ def test_write_rejection_log_with_input_source(tmp_path: Path):
         adapter_name="x",
         adapter_version="1",
         rejected=[],
-        input_source="/Users/u/refs",
+        input_source="/path/to/refs",
     )
     loaded = yaml.safe_load(p.read_text())
-    assert loaded["input_source"] == "/Users/u/refs"
+    assert loaded["input_source"] == "/path/to/refs"
 
 
 def test_write_rejection_log_with_summary_totals(tmp_path: Path):

--- a/scripts/adapters/tests/test_rejection_log_schema.py
+++ b/scripts/adapters/tests/test_rejection_log_schema.py
@@ -224,7 +224,7 @@ def test_input_source_round_trip():
         "adapter_name": "x",
         "adapter_version": "1",
         "generated_at": "2026-04-23T00:00:00Z",
-        "input_source": "/Users/u/refs",
+        "input_source": "/path/to/refs",
         "rejected": [],
     }
     _validator(schema).validate(log)

--- a/scripts/test_audit_schemas.py
+++ b/scripts/test_audit_schemas.py
@@ -141,7 +141,7 @@ SIDECAR_CLEAN: dict[str, Any] = {
     "run_id": "2026-04-30T15-22-04Z-d8f3",
     "codex_cli_version": "0.125.0",
     "runner": {
-        "hostname": "imbad-mbp.local",
+        "hostname": "runner.example.local",
         "cwd": "/path/to/academic-research-skills",
         "git_sha": "b4fbffd",
         "git_dirty": False,

--- a/scripts/test_check_audit_artifact_consistency.py
+++ b/scripts/test_check_audit_artifact_consistency.py
@@ -177,7 +177,7 @@ def make_valid_sidecar(template_sha: str = "1" * 64) -> dict[str, Any]:
         "run_id": VALID_RUN_ID,
         "codex_cli_version": "0.128.0",
         "runner": {
-            "hostname": "imbad-mbp.local",
+            "hostname": "runner.example.local",
             "cwd": "/path/to/academic-research-skills",
             "git_sha": "b4fbffd",
             "git_dirty": False,

--- a/shared/contracts/passport/literature_corpus_entry.schema.json
+++ b/shared/contracts/passport/literature_corpus_entry.schema.json
@@ -41,7 +41,7 @@
     "source_pointer": {
       "type": "string",
       "minLength": 1,
-      "description": "Stable URI locating this work in the user's own KB. Examples: 'zotero://select/items/0_ABCD1234', 'obsidian://open?vault=kb&file=Chen2024', 'file:///Users/me/refs/chen2024.pdf', 'https://doi.org/10.1234/xyz'. ARS does NOT dereference this; consumers that want the full text fetch it from the pointer themselves."
+      "description": "Stable URI locating this work in the user's own KB. Examples: 'zotero://select/items/0_ABCD1234', 'obsidian://open?vault=kb&file=Chen2024', 'file:///path/to/refs/chen2024.pdf', 'https://doi.org/10.1234/xyz'. ARS does NOT dereference this; consumers that want the full text fetch it from the pointer themselves."
     },
 
     "venue":                  { "type": "string", "minLength": 1 },


### PR DESCRIPTION
Replace maintainer-looking hostnames and macOS-style example paths with neutral examples.\nKeeps public docs and test fixtures free of local-machine identifiers.