### PR TITLE
docs: signpost Codex users to ars-codex sibling distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The architecture doc supersedes the sprawling pipeline description that used to 
 
 **👉 [docs/SETUP.md](docs/SETUP.md)** — full guide: install Claude Code, set up API keys, optional Pandoc/tectonic for DOCX/PDF, cross-model verification (`ARS_CROSS_MODEL`), and five installation methods (Plugin, project skills, global skills, claude.ai Project, repo-cloned).
 
-**Codex sibling distribution:** [academic-research-skills-codex](https://github.com/Imbad0202/academic-research-skills-codex).
+**Using Codex CLI?** Install the sibling distribution instead: [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) — same workflow content, Codex-native packaging as a single `$academic-research-suite` skill with `ars-*` aliases.
 
 ## Performance & cost
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -56,6 +56,8 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 
 **👉 [docs/SETUP.zh-TW.md](docs/SETUP.zh-TW.md)** — 完整指南：安裝 Claude Code、設定 API key、選用的 Pandoc/tectonic（DOCX/PDF）、跨模型驗證（`ARS_CROSS_MODEL`），以及五種安裝方式（Plugin、專案 skills、全域 skills、claude.ai Project、repo clone）。
 
+**用 Codex CLI？** 請改裝姊妹版：[`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex)。同一套 workflow 內容，Codex 原生包裝為單一 `$academic-research-suite` skill，提供 `ars-*` 別名。
+
 ## 效能與費用
 
 **👉 [docs/PERFORMANCE.zh-TW.md](docs/PERFORMANCE.zh-TW.md)** — 各模式 token 預算、完整 pipeline 估算（~$4–6 for 一篇 15k 字論文），以及建議的 Claude Code 設定（Skip Permissions；Agent Team 選用）。

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -191,7 +191,7 @@ The four skills (`deep-research`, `academic-paper`, `academic-paper-reviewer`, `
 **Plugin platform scope:**
 - ✅ Claude Code CLI / VS Code extension / JetBrains extension — full support
 - ❌ claude.ai web / Claude for Work / Anthropic API direct calls — plugins not supported; use Method 1 / 2 / 3 below
-- ❌ Codex CLI — use the [`academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) fork
+- ➡️ Codex CLI — install the sibling distribution [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) (same workflow content, Codex-native packaging)
 
 ### Method 1: As project skills (recommended)
 

--- a/docs/SETUP.zh-TW.md
+++ b/docs/SETUP.zh-TW.md
@@ -191,7 +191,7 @@ Claude 會在 `<install-root>/<skill-name>/SKILL.md` 尋找 skills。這個 repo
 **Plugin 平台支援範圍：**
 - ✅ Claude Code CLI / VS Code extension / JetBrains extension — 完整支援
 - ❌ claude.ai 網頁版 / Claude for Work / Anthropic API 直呼 — 不支援 plugin，請改用方法一 / 二 / 三
-- ❌ Codex CLI — 改用 [`academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) fork
+- ➡️ Codex CLI — 改裝姊妹版 [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex)（同一套 workflow 內容、Codex 原生包裝）
 
 ### 方法一：作為專案 Skills（推薦）
 


### PR DESCRIPTION
## Summary

- README.md L59: 把被動 "Codex sibling distribution: ..." 改成主動引導句 **"Using Codex CLI?"**，補上 packaging 形態描述（單一 `\$academic-research-suite` skill + `ars-*` 別名）
- README.zh-TW.md: 補上對應中文段落 — `8988ca4` 當時漏了中文版同步
- docs/SETUP.md L194 + SETUP.zh-TW.md L194: Plugin platform scope 區塊內 `❌ Codex CLI — use the fork` → `➡️ Codex CLI — install the sibling distribution`。從「不支援」框架改成「往哪走」框架

## Why

ars-codex 已公開（PR 之前 commit `7fb93ce` / `a2ab330` / `32ad574` 都已 ship），但本 repo 既有指引只有一行被動句，且中文版 README 完全沒提；SETUP 還掛 ❌。本 PR 讓既有 ars-codex link 在四個 surface 都成為主動引導，scope 只動文案不改連結。

## What did NOT change

- POSITIONING.md 既有 sibling distribution 連結保留不動（在政策段落 inline 已足夠）
- CONTRIBUTING.md § Platform ports 政策面不動
- 不改任何 install command、URL、license terminology

## Test plan

- [x] `python scripts/check_spec_consistency.py` 通過（README markdown link validation 自 v3.3.4 進 CI）
- [ ] Codex review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)