### PR TITLE
docs: add Review Protocol section for public-repo boundary scanning

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -154,6 +154,22 @@ Spec: `docs/design/2026-05-12-ars-v3.7.3-claim-faithfulness-and-contaminated-sou
 - AI disclosure in all reports
 - Default output language matches user input (Traditional Chinese or English)
 
+## Review Protocol (ship gate)
+
+When running `/codex review`, `/codex challenge`, or any cross-model review against ARS changes, the review prompt MUST include a **public-repo boundary axis** in addition to technical correctness. ARS is a public repo. Default codex review prompt scope is technical correctness only — it will NOT catch private-project context leakage unless explicitly instructed.
+
+**Mandatory review prompt addendum** (append to every `/codex review` invocation against this repo):
+
+> Additionally scan for public-repo boundary violations: (a) named institution + named publisher co-occurrence indicating a specific private maintainer session (e.g. `<institution> <publisher> <doc-type> session` patterns), (b) named private downstream repos (e.g. `hei-platform`, `<project-codename>`), (c) internal directory paths revealing private file structure, (d) specific session identifiers + named org names co-occurring. Generic mention of a public institution or publisher in educational content (citation guides, IRB discussion, accreditation framework explanation) is fine. The boundary lint `scripts/check_public_repo_boundary.py` blocks the pure mechanical cases at CI; codex covers the contextual cases the lint cannot pattern-match.
+
+**Ship-gate parallel reviews:** before any v3.x ship:
+
+1. `/codex review` with the addendum above
+2. `/security-review` (separate pass — privacy / PII / public-repo PII)
+3. Both must return 0 P1 / 0 P2 before merging
+
+**Why this is here:** 2026-05-12 v3.7.3 ship retrospective. 10 rounds of `/codex review` (technical-correctness scope) missed a `<institution> <publisher> chapter session` phrase reuse from v3.6.8 spec. The author had a memory rule to grep before writing but bypassed it. The mechanical CI lint `check_public_repo_boundary.py` (PR #99) blocks the recurring pattern; this Review Protocol section makes sure codex reviews also cover the contextual variant that the lint can't pattern-match (e.g. a new institution + publisher pairing the lint hasn't seen before).
+
 ## Full Academic Pipeline
 
 ```

--- a/scripts/check_public_repo_boundary.py
+++ b/scripts/check_public_repo_boundary.py
@@ -85,6 +85,9 @@ ALLOWLIST_LINE_SUBSTRINGS = [
     # Plan-doc grep pattern that TEACHES boundary scanning (the pattern
     # naturally contains the banned keyword as a search target)
     'grep -iE "(?:10|172|192)\\.[0-9]+\\.[0-9]+\\.[0-9]+|\\.local|hei-platform',
+    # Review-protocol prompt template that TEACHES which patterns codex
+    # should flag — the example list necessarily contains the keywords
+    "(b) named private downstream repos (e.g. `hei-platform`",
 ]
 
 # File patterns to scan. Markdown / YAML / Python / JSON.


### PR DESCRIPTION
## Summary

Adds **Review Protocol (ship gate)** section to `.claude/CLAUDE.md` documenting the mandatory `/codex review` addendum that scans for public-repo boundary violations. Codex `/review`'s default scope is technical correctness only — it does NOT catch private-project context leakage unless explicitly instructed (verified empirically by 10 codex review rounds during v3.7.3 ship that all missed the HEEACT/Springer phrase reuse).

The new section pairs with the mechanical CI lint shipped in #99: the lint blocks known recurring patterns at PR time; the Review Protocol section makes codex cover the contextual variants the lint can't pattern-match (new institution + publisher pairings it hasn't seen before).

This closes the **B (codex prompt axis)** and **C (security-review gate)** items from the v3.7.3 retrospective.

## Why repo-level, not gstack-upstream

gstack is a public framework with community PR guardrails. Repo-specific review prompts belong in the repo's own `.claude/CLAUDE.md` — that's the right contract surface. ARS-specific boundary risks (HEEACT, hei-platform downstream) are not generalizable to other gstack users.

## Allowlist update

The Review Protocol section's example list (e.g. "named private downstream repos like \`hei-platform\`") would be flagged by the boundary lint as a hei-platform mention. The lint's allowlist is updated to exempt this teaching content — same precedent as the v3.6.2 spec line 758 procedure block and v3.5.1 plan grep pattern.

## Test plan

- [x] `python scripts/check_public_repo_boundary.py` → PASSED 617 files
- [x] `python -m pytest scripts/test_check_public_repo_boundary.py` → 14 passed
- [x] Full regression `python -m pytest scripts/` → 981 passed / 3 skipped / 0 failed
- [ ] CI on push → verify green

🤖 Generated with [Claude Code](https://claude.com/claude-code)