### PR TITLE
feat(#105): v3.7.3 contamination_signals backfill migration tool (audit-trail-shipped)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Check PREPRINT_VENUES list consistency (#105)
         run: python3 scripts/check_preprint_venues_consistency.py
 
+      - name: Run #105 migration unit tests
+        env:
+          PYTHONPATH: .
+        run: python3 -m unittest scripts.test_contamination_signals scripts.test_migrate_literature_corpus_to_v3_7_3 scripts.test_semantic_scholar_client -v
+
       - name: Check data_access_level declarations
         env:
           PYTHONPATH: scripts

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run spec consistency check
         run: python3 scripts/check_spec_consistency.py
 
+      - name: Check PREPRINT_VENUES list consistency (#105)
+        run: python3 scripts/check_preprint_venues_consistency.py
+
       - name: Check data_access_level declarations
         env:
           PYTHONPATH: scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### #105 — v3.7.3 contamination_signals backfill migration tool (2026-05-15)
+
+**Parent issue:** [#105](https://github.com/Imbad0202/academic-research-skills/issues/105). Spec anchor: v3.7.3 §3.2 R-L3-2-B (the deferred batch operation; bibliography_agent computes signals at ingest, this tool delivers post-hoc backfill on legacy corpora). Design: `docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md`.
+
+**New files:**
+
+- `scripts/contamination_signals.py` — two pure-function resolvers + emission rules + `SemanticScholarClient` protocol. `compute_preprint_signal()` (Signal 1, deterministic year+venue check against 10-server closed list). `compute_ss_unmatched_signal()` (Signal 2, dependency-injected SS client, returns `None` on manual exemption + API degradation per spec).
+- `scripts/migrate_literature_corpus_to_v3_7_3.py` — CLI tool: `[--dry-run] [--verbose] <passport_or_dir>`. Uses `ruamel.yaml` round-trip to preserve comments + key order + quoting style. Reports `processed / patched / skipped_already_migrated / skipped_insufficient_data` counts. Idempotent.
+- `scripts/test_contamination_signals.py` — 25 unit tests covering Signal 1 (15 cases: 10 preprint venues × year boundary, non-preprint venue, missing year, missing venue), Signal 2 (6 cases: manual exemption / match / no-match / API degradation × 2 paths / unexpected exception), emission rules (4 cases).
+- `scripts/test_migrate_literature_corpus_to_v3_7_3.py` — 9 unittest cases covering dry-run, full migration per emission rules, idempotency, insufficient-data skip, empty-corpus passport, directory scan (non-recursive), comment preservation.
+- `docs/migration/v3.7.3-contamination-signals-backfill.md` — user-facing migration guide (when to run, dry-run workflow, idempotency, SS API rate-limit considerations, what's out of scope).
+
+**Modified files:**
+
+- `shared/contracts/passport/literature_corpus_entry.schema.json` — purely additive: new optional `contamination_signals_backfilled_at` field (ISO-8601 date-time string). Existing v3.7.3 ingest-time entries (which lack this field) remain valid; pre-v3.7.3 entries (which lack both this field and `contamination_signals`) remain valid.
+- `scripts/adapters/tests/test_literature_corpus_entry_schema.py` — 3 new tests for the additive field (valid present / absent / non-string rejected).
+- `requirements-dev.txt` — add `ruamel.yaml>=0.17`.
+
+**Open-question resolutions (user-chosen 2026-05-15):**
+
+- Q1 API rate-limit handling: backoff-only via existing SS protocol (429 → 2s × 3); no resumable checkpoint (YAGNI per minimal scope)
+- Q2 schema field naming: scalar `contamination_signals_backfilled_at` ISO-8601 timestamp; strictly additive upgrade path if v3.7.4 needs structured provenance
+- Q3 multi-passport batch mode: directory-scan only; no `--input-list` (YAGNI)
+- Q4 YAML library: `ruamel.yaml` round-trip to preserve user-owned passport formatting (memory `feedback_toml_duplicate_table_corruption` spirit)
+
+**Spec discipline (per v3.7.3 R-L3-2-B):**
+
+- Migration is offline + opt-in: user explicitly invokes; pipeline doesn't auto-trigger
+- Idempotency keyed on `contamination_signals` presence: first-migration timestamp preserved across re-runs
+- `obtained_via=manual` exemption preserved at migration time (semantic_scholar_unmatched field omitted, matches the v3.7.3 schema cross-field rule)
+- API degradation → field omitted (NOT set to False, per "absence ≠ negative confirmation" rule)
+
+**Files explicitly NOT touched:**
+
+- `deep-research/agents/bibliography_agent.md` — v3.7.3 ingest-time computation frozen
+- `academic-pipeline/agents/pipeline_orchestrator_agent.md` — finalizer behavior unchanged
+- Existing `scripts/adapters/*` — adapters produce ingest-time entries; migration is downstream
+
+**Regression status:** 1053 #108 baseline + 17 #111 baseline + 25 resolver + 9 migration + 3 schema = 1107 total. All green. No regression on the existing 4 `allOf` cross-field invariants (manual exemption + preprint year=2024 boundary verified by adapter pytest).
+
 ### #104 — README motivation: add Zhao et al. corpus-scale evidence anchor (2026-05-15)
 
 **Parent issue:** [#104](https://github.com/Imbad0202/academic-research-skills/issues/104). Doc-only — no code changes.

--- a/academic-pipeline/references/adapters/overview.md
+++ b/academic-pipeline/references/adapters/overview.md
@@ -44,6 +44,7 @@ Refer to the [`literature_corpus_entry` schema](../../../shared/contracts/passpo
 | `adapter_name` | string | Optional. |
 | `adapter_version` | string | — |
 | `contamination_signals` | object | v3.7.3 contaminated-source advisory field (spec §3.2, L3-2). |
+| `contamination_signals_backfilled_at` | string | v3.7.3 backfill provenance (issue #105). |
 | `description_last_audit` | null \| string | v3.7.1 trust-chain field. |
 | `description_source` | string | v3.7.1 trust-chain field. |
 | `doi` | string | DOI without leading 'doi:' or URL prefix. |

--- a/docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md
+++ b/docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md
@@ -1,0 +1,184 @@
+# Design — #105 v3.7.3 contamination_signals backfill migration tool
+
+**Date**: 2026-05-15
+**Issue**: #105 (v3.7.3 release completeness follow-up)
+**Status**: design — ready for TDD implementation
+**Scope**: minimal — single tool, directory-scan, scalar provenance, ruamel round-trip. No batch mode, no resumable checkpoint, no structured backfill provenance.
+
+---
+
+## 1. Problem
+
+v3.7.3 spec §3.2 R-L3-2-B says: "bibliography_agent computes contamination_signals at ingest time, not at audit time. Re-running the check post-hoc on existing entries is **a separate batch operation (deferred to user invocation; not part of v3.7.3 finalizer)**."
+
+Pre-v3.7.3 passport entries lack `contamination_signals`. Without a backfill tool:
+
+- Users with existing corpora cannot get CONTAMINATED-PREPRINT / CONTAMINATED-UNMATCHED advisories on pre-v3.7.3 entries
+- The v3.7.3 finalizer treats absence as "signals not computed → no advisory fires", which is technically correct but operationally degrades the v3.7.3 protection layer for legacy corpora
+- This issue (#105) is v3.7.3 release completeness: the spec already promised the backfill path exists; this tool delivers it
+
+## 2. Spec anchors (frozen, do not re-litigate)
+
+- §3.2 Signal 1: `year >= 2024 AND venue ∈ {arXiv, bioRxiv, medRxiv, SSRN, Research Square, Preprints.org, ChemRxiv, EarthArXiv, OSF Preprints, TechRxiv}` (10-server closed list)
+- §3.2 Signal 2: SS API lookup per `deep-research/references/semantic_scholar_api_protocol.md`; OMIT field on `obtained_via=manual` (exemption); OMIT field on API degradation (absence ≠ negative confirmation)
+- §3.2 emission rules: emit object with both fields `false` when computed-and-clean; emit partial object when only one signal computable; never set `semantic_scholar_unmatched: false` on API degradation
+- Schema cross-field rules: 4 `allOf` branches already cover (a) manual + semantic_scholar_unmatched present = INVALID; (b) preprint_post_llm_inflection=true + year<2024 = INVALID
+
+## 3. Open-question resolutions (user-chosen 2026-05-15)
+
+| # | Question | Resolution | Rationale |
+|---|---|---|---|
+| Q1 | API rate-limit handling | backoff-only (existing SS protocol: 429→2s×3); **no resumable checkpoint** | YAGNI for minimal scope; large-corpus users add checkpoint in follow-up if needed |
+| Q2 | Schema field naming | scalar `contamination_signals_backfilled_at: ISO-8601 timestamp string` | issue body itself suggested "start with scalar"; strictly additive upgrade path to structured if v3.7.4 needs it |
+| Q3 | Multi-passport batch mode | directory-scan only (no `--input-list`) | YAGNI for minimal scope; user passport is typically 1 active session |
+| Q4 | YAML library | ruamel.yaml | passport is user-owned file; preserve comments + key order (memory `feedback_toml_duplicate_table_corruption` discipline spirit) |
+
+## 4. Design — three pieces
+
+### 4.1 Resolver module
+
+`scripts/contamination_signals.py` — pure functions:
+
+```python
+PREPRINT_VENUES = frozenset({
+    "arXiv", "bioRxiv", "medRxiv", "SSRN", "Research Square",
+    "Preprints.org", "ChemRxiv", "EarthArXiv", "OSF Preprints", "TechRxiv",
+})
+
+def compute_preprint_signal(entry: Mapping) -> bool:
+    """Signal 1 per spec §3.2 Vector 1."""
+
+def compute_ss_unmatched_signal(entry, ss_client) -> bool | None:
+    """Signal 2 per spec §3.2 Vector 2. Returns None on (a) manual exemption,
+    (b) API degradation; returns True/False otherwise."""
+```
+
+The two signals are independently testable. SS API call is dependency-injected so tests use a mock; production uses a real client.
+
+### 4.2 Migration script
+
+`scripts/migrate_literature_corpus_to_v3_7_3.py` — CLI tool:
+
+```
+usage: migrate_literature_corpus_to_v3_7_3.py [--dry-run] [--verbose] <passport_or_dir>
+
+Arguments:
+  passport_or_dir   Path to a single passport YAML or a directory containing passports.
+                    Directory scan finds *.yaml files non-recursively.
+
+Options:
+  --dry-run         Print proposed changes; write no files.
+  --verbose         Per-entry logging.
+```
+
+**Behavior:**
+
+1. Load passport via `ruamel.yaml` (round-trip — preserve comments + key order)
+2. For each entry in `literature_corpus[]`:
+   - If `contamination_signals` already present → SKIP (idempotency)
+   - If entry's schema state is "insufficient-data" (no year, or no venue + no source_pointer hint) → SKIP, log reason
+   - Compute Signal 1
+   - Compute Signal 2 (skip on manual; omit on API degradation)
+   - Construct `contamination_signals` object per emission rules
+   - Set `contamination_signals_backfilled_at` to current UTC ISO-8601 timestamp
+3. If `--dry-run`, print diff and exit. Else, write back via `ruamel.yaml` round-trip.
+4. Emit migration report at stdout: `processed=N patched=M skipped=K errored=E`, plus per-skip-category counts.
+
+**SS API client:** reuse existing `references/semantic_scholar_api_protocol.md` logic. Implementation: thin wrapper around `requests` with 429 backoff per protocol. Single shared client across the migration run (HTTP keepalive).
+
+### 4.3 Schema extension
+
+`shared/contracts/passport/literature_corpus_entry.schema.json` — add one optional field:
+
+```json
+"contamination_signals_backfilled_at": {
+  "type": "string",
+  "format": "date-time",
+  "description": "v3.7.3 backfill provenance. ISO-8601 UTC timestamp set by scripts/migrate_literature_corpus_to_v3_7_3.py when contamination_signals was computed post-hoc rather than at ingest. Absence means signals were either computed at ingest (bibliography_agent v3.7.3+) or not computed at all. Backward compat: pre-v3.7.3 entries lack both contamination_signals and this field; ingest-time entries lack only this field."
+}
+```
+
+Pure additive — existing v3.7.3 ingest-time entries (which don't carry this field) remain valid.
+
+### 4.4 Migration guide doc
+
+`docs/migration/v3.7.3-contamination-signals-backfill.md` — user-facing:
+
+- When to run (after upgrading to v3.7.3+)
+- Dry-run-first workflow
+- Idempotency guarantee
+- Semantic Scholar API rate-limit considerations (1 req/s unauthenticated; large corpora take time)
+- What to do on API degradation (re-run later)
+
+## 5. Files touched
+
+| File | Change kind |
+|---|---|
+| `scripts/contamination_signals.py` | new — Signal 1 + Signal 2 resolvers |
+| `scripts/migrate_literature_corpus_to_v3_7_3.py` | new — CLI migration tool |
+| `scripts/test_contamination_signals.py` | new — unit tests for resolvers |
+| `scripts/test_migrate_literature_corpus_to_v3_7_3.py` | new — pytest for migration tool (mocks SS API) |
+| `shared/contracts/passport/literature_corpus_entry.schema.json` | additive — new optional `contamination_signals_backfilled_at` field |
+| `scripts/adapters/tests/test_literature_corpus_entry_schema.py` | extend — 2-3 tests for the new field (valid present / valid absent / invalid type) |
+| `docs/migration/v3.7.3-contamination-signals-backfill.md` | new — user-facing migration guide |
+| `requirements-dev.txt` | add `ruamel.yaml>=0.18` |
+| `CHANGELOG.md` | Unreleased entry under #105 |
+
+### Files explicitly NOT touched
+
+| File | Reason |
+|---|---|
+| `deep-research/agents/bibliography_agent.md` | v3.7.3 spec frozen; ingest-time computation unchanged |
+| `academic-pipeline/agents/pipeline_orchestrator_agent.md` | Finalizer behavior unchanged; migration is offline |
+| Existing `scripts/adapters/*` | Adapters produce ingest-time entries; migration is downstream |
+
+## 6. Test discipline
+
+Per `superpowers:test-driven-development`:
+
+**Resolver tests (`test_contamination_signals.py`):**
+
+- Signal 1: 11 cases (one per preprint venue × year boundary; non-preprint venue; year < 2024)
+- Signal 2: 6 cases (manual exemption → None; API match → False; API no-match → True; API 429×3 backoff → None; API 5xx → None; API network failure → None)
+
+**Migration tests (`test_migrate_literature_corpus_to_v3_7_3.py`):**
+
+- Dry-run mode: no file writes, stdout shows proposed changes
+- Idempotency: re-run on migrated passport produces zero changes (byte-equivalent)
+- Manual entry skipped: `obtained_via=manual` → signals computed but `semantic_scholar_unmatched` omitted
+- Insufficient-data entry: missing year → skipped, logged
+- Already-migrated entry (has `contamination_signals`): skipped, no re-computation
+- Directory scan: 2 passports in a dir, both migrated independently
+- Report counts: processed/patched/skipped accurate
+
+**Schema tests (extend `test_literature_corpus_entry_schema.py`):**
+
+- `contamination_signals_backfilled_at` present + valid ISO-8601 → valid
+- field absent → valid (backward compat)
+- field as non-string → rejected
+- field as malformed timestamp → rejected by format validator
+
+## 7. Regression budget
+
+- 1053 + 17 (#111) baseline must stay green
+- All new tests must pass
+- 4 schema cross-field rules (allOf branches) must continue to fire correctly on edge inputs
+- No frontmatter change to existing skills
+- No new lint (schema lint already covers the new field via `additionalProperties: false` permission)
+
+## 8. Out of scope (defer)
+
+- Resumable checkpoint (deferred until a user reports a 10k-entry corpus)
+- `--input-list` batch mode (deferred until multi-corpus user emerges)
+- v3.7.4 OpenAlex / Crossref signals (covered by #102)
+- Structured `_backfill_provenance: {at, version, by}` object (upgrade path: scalar `_backfilled_at` → structured object remains backward-compatible if needed)
+
+---
+
+## Related
+
+- Parent v3.7.3 spec: `docs/design/2026-05-12-ars-v3.7.3-claim-faithfulness-and-contaminated-source-spec.md` §3.2 (Vector 1 + Vector 2 + R-L3-2-B)
+- Schema: `shared/contracts/passport/literature_corpus_entry.schema.json` (existing contamination_signals + 4 allOf invariants)
+- v3.7.3 PR #98: ship commit `4cc880f` — added contamination_signals to schema + bibliography_agent computation
+- Migration discipline precedent: memory `feedback_toml_duplicate_table_corruption` — round-trip parser principle (applied here via ruamel.yaml for YAML)
+- External motivation: Zhao et al. arXiv:2605.07723 (2026-05) — corpus-scale evidence anchor (README #104 propagation)

--- a/docs/migration/v3.7.3-contamination-signals-backfill.md
+++ b/docs/migration/v3.7.3-contamination-signals-backfill.md
@@ -1,0 +1,86 @@
+# v3.7.3 contamination_signals backfill — migration guide
+
+**Tool:** `scripts/migrate_literature_corpus_to_v3_7_3.py`
+**Issue:** [#105](https://github.com/Imbad0202/academic-research-skills/issues/105)
+**Spec:** v3.7.3 §3.2 R-L3-2-B (the deferred batch operation)
+
+---
+
+## When to run
+
+After upgrading to ARS v3.7.3+ if your Material Passport's `literature_corpus[]` was populated by an adapter run **before** v3.7.3 was deployed.
+
+How to tell: open the passport YAML and look for `contamination_signals` under any `literature_corpus[]` entry. If absent on entries you trust were produced by an adapter, you have a pre-v3.7.3 corpus and this tool is for you.
+
+If `contamination_signals` is already present (because bibliography_agent v3.7.3+ produced the entry at ingest time), the tool will detect that and skip — idempotent re-run is safe.
+
+## What it does
+
+For each pre-v3.7.3 entry in `literature_corpus[]`, the tool computes both v3.7.3 advisory signals:
+
+- **Signal 1 (preprint_post_llm_inflection):** `year >= 2024 AND venue ∈ {arXiv, bioRxiv, medRxiv, SSRN, Research Square, Preprints.org, ChemRxiv, EarthArXiv, OSF Preprints, TechRxiv}`. Deterministic; no API needed.
+- **Signal 2 (semantic_scholar_unmatched):** Semantic Scholar API lookup per `deep-research/references/semantic_scholar_api_protocol.md`. Returns `True` on no-match, `False` on match.
+
+It then writes `contamination_signals: {preprint_post_llm_inflection, semantic_scholar_unmatched}` plus a scalar provenance timestamp `contamination_signals_backfilled_at` (ISO-8601 UTC) onto the entry.
+
+**Exemptions (per spec §3.2):**
+
+- `obtained_via=manual` entries: Signal 2 is OMITTED (user has vouched; running automated unmatched check on grey literature / books / working papers would surface false positives).
+- Semantic Scholar API degradation (network failure / rate-limit exhausted / 5xx): Signal 2 is OMITTED, not set to False. Absence ≠ negative confirmation. Re-run later when API is healthy to fill in the field.
+
+## How to run
+
+```bash
+# Always dry-run first
+python scripts/migrate_literature_corpus_to_v3_7_3.py --dry-run --verbose /path/to/passport.yaml
+
+# Single passport
+python scripts/migrate_literature_corpus_to_v3_7_3.py /path/to/passport.yaml
+
+# Directory scan (non-recursive; only *.yaml at the top level)
+python scripts/migrate_literature_corpus_to_v3_7_3.py /path/to/passports/
+```
+
+The tool prints a one-line report on stdout:
+
+```
+processed=42 patched=37 skipped_already_migrated=5 skipped_insufficient_data=0 dry_run=False
+```
+
+`skipped_already_migrated` = entries that already had `contamination_signals` set (idempotency guarantee).
+`skipped_insufficient_data` = entries missing `year` (a schema invariant; only reachable if the YAML was hand-edited).
+
+## Idempotency guarantee
+
+Re-running the tool on a migrated passport produces zero changes. The detection rule is "skip if `contamination_signals` is present on the entry"; this rule is keyed on object presence, not on the `contamination_signals_backfilled_at` timestamp, so the first migration's timestamp is preserved across re-runs.
+
+The tool uses `ruamel.yaml` round-trip serialization to preserve comments, key order, and quoting style. Diffs across an idempotent re-run are byte-identical.
+
+## Semantic Scholar rate-limit considerations
+
+The unauthenticated Semantic Scholar API allows ~1 request per second. The migration tool retries on HTTP 429 per the existing protocol (`deep-research/references/semantic_scholar_api_protocol.md` — 2s backoff × 3). For a corpus of 5,000 entries this means ~1.5 hours of API time.
+
+If the migration is interrupted (Ctrl+C, network drop, system restart), re-run the tool — the idempotency rule ensures already-migrated entries are skipped. Entries that got `semantic_scholar_unmatched` omitted due to API failure during the interrupted run will have the field filled in on the next successful pass.
+
+Resumable checkpoint state is **not** implemented in v3.7.3; see #105 design doc §8 for the deferred-scope rationale (will be reconsidered if a user reports a corpus > 10,000 entries).
+
+## What this tool does NOT do
+
+- Does not modify `bibliography_agent` ingest behavior (v3.7.3 already computes signals at ingest).
+- Does not touch the orchestrator's cite-time finalizer (v3.7.3 finalizer reads `contamination_signals` directly from each entry).
+- Does not validate the rest of the passport schema (other v3.7.x lints handle that).
+- Does not migrate `literature_corpus_entry.schema.json` itself (the schema field is purely additive; no breaking change).
+- Does not implement OpenAlex / Crossref Vector 3 signals (see #102 for the v3.7.4 plan).
+
+## Backward compatibility
+
+- Pre-v3.7.3 entries lacking `contamination_signals` remain schema-valid.
+- v3.7.3 ingest-time entries (which lack `contamination_signals_backfilled_at`) remain schema-valid.
+- Migrated entries carry both fields and remain schema-valid.
+
+## Related
+
+- v3.7.3 spec: `docs/design/2026-05-12-ars-v3.7.3-claim-faithfulness-and-contaminated-source-spec.md` §3.2
+- #105 design: `docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md`
+- Schema: `shared/contracts/passport/literature_corpus_entry.schema.json`
+- Tests: `scripts/test_contamination_signals.py` + `scripts/test_migrate_literature_corpus_to_v3_7_3.py`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pyyaml
+ruamel.yaml>=0.17
 jsonschema[format]>=4.17

--- a/scripts/adapters/tests/test_literature_corpus_entry_schema.py
+++ b/scripts/adapters/tests/test_literature_corpus_entry_schema.py
@@ -409,3 +409,43 @@ def test_non_manual_entry_with_ss_unmatched_passes():
         "contamination_signals": {"semantic_scholar_unmatched": True},
     }
     _validator(schema).validate(entry)
+
+
+# --- #105 contamination_signals_backfilled_at -------------------------
+
+
+def test_contamination_signals_backfilled_at_valid_iso8601_passes():
+    """#105: scalar ISO-8601 timestamp recording when post-hoc backfill ran."""
+    schema = _load_schema()
+    entry = _base_entry() | {
+        "contamination_signals": {
+            "preprint_post_llm_inflection": False,
+            "semantic_scholar_unmatched": False,
+        },
+        "contamination_signals_backfilled_at": "2026-05-15T10:30:00Z",
+    }
+    _validator(schema).validate(entry)
+
+
+def test_contamination_signals_backfilled_at_absent_passes():
+    """#105 backward compat: ingest-time entries (computed by
+    bibliography_agent v3.7.3+) lack this field, which is valid."""
+    schema = _load_schema()
+    entry = _base_entry() | {
+        "contamination_signals": {
+            "preprint_post_llm_inflection": False,
+            "semantic_scholar_unmatched": False,
+        },
+    }
+    _validator(schema).validate(entry)
+
+
+def test_contamination_signals_backfilled_at_non_string_rejected():
+    """#105: field type is string (date-time format); integers / objects
+    are rejected by JSON Schema validation."""
+    import jsonschema
+
+    schema = _load_schema()
+    entry = _base_entry() | {"contamination_signals_backfilled_at": 1234567890}
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        _validator(schema).validate(entry)

--- a/scripts/check_preprint_venues_consistency.py
+++ b/scripts/check_preprint_venues_consistency.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""#105 lint — PREPRINT_VENUES 10-server list must agree across files.
+
+v3.7.3 spec §3.2 Vector 1 fixes the closed list at 10 preprint servers
+(gemini review F6 / codex F13 expansion from initial 6). The list lives
+in two places:
+
+1. `deep-research/agents/bibliography_agent.md` § "Signal 1 —
+   preprint_post_llm_inflection" — bullet list (prose source of truth
+   the bibliography_agent reads at ingest time).
+2. `scripts/contamination_signals.py` `PREPRINT_VENUES` frozenset — the
+   migration tool's Python constant.
+
+If these drift, post-hoc migration would surface different CONTAMINATED-
+PREPRINT advisories than ingest-time computation. This lint extracts
+both lists, compares as sorted sets, and fails on mismatch.
+
+Exit codes:
+  0 = lists agree
+  1 = mismatch (prints both sets + the diff)
+  2 = could not parse either file (file move / heading rename / regex break)
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROSE_PATH = REPO_ROOT / "deep-research" / "agents" / "bibliography_agent.md"
+PYTHON_PATH = REPO_ROOT / "scripts" / "contamination_signals.py"
+
+
+# Venue strings in the spec carry mixed casing + spaces (e.g.,
+# "Research Square", "OSF Preprints"); normalize for comparison.
+def _normalize(s: str) -> str:
+    return " ".join(s.split())
+
+
+def _extract_prose_venues(text: str) -> set[str]:
+    """Pull the bullet list under § Signal 1.
+
+    The prose block looks like:
+        2. The entry's `venue` field ...:
+           - arXiv
+           - bioRxiv
+           - medRxiv
+           ...
+           - TechRxiv
+
+    We slice from "preprint_post_llm_inflection" heading to "Otherwise
+    set to" sentinel, then pull every `- <name>` line whose name comes
+    before any inline comment.
+    """
+    start = text.find("preprint_post_llm_inflection")
+    end = text.find("Otherwise set to", start) if start >= 0 else -1
+    if start < 0 or end < 0:
+        raise RuntimeError(
+            "could not locate Signal 1 section in bibliography_agent.md "
+            "(heading or 'Otherwise set to' sentinel changed)"
+        )
+    block = text[start:end]
+    venues: set[str] = set()
+    for line in block.splitlines():
+        m = re.match(r"^\s*-\s+([A-Za-z0-9][A-Za-z0-9 .]*?)(\s*\(.*)?$", line)
+        if m:
+            venues.add(_normalize(m.group(1)))
+    return venues
+
+
+def _extract_python_venues(text: str) -> set[str]:
+    """Pull the items from the `PREPRINT_VENUES = frozenset({ ... })` literal."""
+    m = re.search(
+        r"PREPRINT_VENUES\s*=\s*frozenset\(\{([^}]+)\}\)",
+        text,
+        flags=re.DOTALL,
+    )
+    if not m:
+        raise RuntimeError(
+            "could not locate PREPRINT_VENUES literal in contamination_signals.py"
+        )
+    body = m.group(1)
+    venues = {
+        _normalize(s.strip().strip('"').strip("'"))
+        for s in body.split(",")
+        if s.strip().strip('"').strip("'")
+    }
+    return venues
+
+
+def main() -> int:
+    try:
+        prose = _extract_prose_venues(PROSE_PATH.read_text(encoding="utf-8"))
+        py = _extract_python_venues(PYTHON_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, RuntimeError) as e:
+        print(f"PREPRINT_VENUES lint ERROR: {e}", file=sys.stderr)
+        return 2
+
+    if prose == py:
+        print(
+            f"PREPRINT_VENUES lint OK: {len(prose)} venues agree across "
+            f"bibliography_agent.md and contamination_signals.py."
+        )
+        return 0
+
+    only_prose = sorted(prose - py)
+    only_py = sorted(py - prose)
+    print("PREPRINT_VENUES lint FAILED — venue list drift detected:", file=sys.stderr)
+    if only_prose:
+        print(f"  only in bibliography_agent.md: {only_prose}", file=sys.stderr)
+    if only_py:
+        print(f"  only in contamination_signals.py: {only_py}", file=sys.stderr)
+    print(
+        "Reconcile by updating both files in lockstep. Spec §3.2 Vector 1 + "
+        "schema description in literature_corpus_entry.schema.json must also agree.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""#105 v3.7.3 contamination_signals resolvers.
+
+Pure functions implementing v3.7.3 spec §3.2 Vector 1 + Vector 2 for use
+by the migration tool. bibliography_agent computes these at ingest time;
+this module gives the migration tool the equivalent computation for
+post-hoc backfill on pre-v3.7.3 entries.
+
+Design: docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md
+Spec: docs/design/2026-05-12-ars-v3.7.3-claim-faithfulness-and-contaminated-source-spec.md §3.2
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+
+# 10-server closed list per v3.7.3 spec §3.2 + schema description.
+# Expanded from 6 to 10 venues per gemini review F6 / codex round-4 F13.
+# This list is intentionally redundant with the bibliography_agent's
+# in-prose list — adapters and migration tools both need the literal set.
+PREPRINT_VENUES = frozenset({
+    "arXiv",
+    "bioRxiv",
+    "medRxiv",
+    "SSRN",
+    "Research Square",
+    "Preprints.org",
+    "ChemRxiv",
+    "EarthArXiv",
+    "OSF Preprints",
+    "TechRxiv",
+})
+
+
+class SemanticScholarUnavailable(Exception):
+    """SS API degraded (network failure / rate limit exhausted / 5xx).
+
+    Per spec §3.2 emission rules, this triggers OMIT of the
+    `semantic_scholar_unmatched` field rather than setting it to False.
+    Absence ≠ negative confirmation."""
+
+
+class SemanticScholarClient(Protocol):
+    """Minimal contract for the SS API client passed into Signal 2.
+
+    Production callers pass a real client implementing the protocol at
+    `deep-research/references/semantic_scholar_api_protocol.md`
+    (429 → 2s backoff × 3, DOI-first then title-similarity fallback).
+    Tests pass a MagicMock returning whatever shape the test specifies."""
+
+    def lookup(self, entry: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Return {"matched": bool, ...}. Raise SemanticScholarUnavailable
+        on transient API failures (after the protocol's retry budget is
+        exhausted)."""
+        ...
+
+
+def compute_preprint_signal(entry: Mapping[str, Any]) -> bool:
+    """Signal 1 per v3.7.3 spec §3.2 Vector 1.
+
+    True iff `year >= 2024 AND venue in PREPRINT_VENUES`. Missing year
+    or missing venue resolves to False — both are required for the
+    spec's AND.
+    """
+    year = entry.get("year")
+    venue = entry.get("venue")
+    if not isinstance(year, int):
+        return False
+    if venue not in PREPRINT_VENUES:
+        return False
+    return year >= 2024
+
+
+def compute_ss_unmatched_signal(
+    entry: Mapping[str, Any],
+    client: SemanticScholarClient,
+) -> bool | None:
+    """Signal 2 per v3.7.3 spec §3.2 Vector 2.
+
+    Returns:
+      - None if `obtained_via='manual'` (spec exemption) OR API degradation
+      - True if SS lookup returns no match
+      - False if SS lookup returns a match
+
+    Per spec emission rules, None means OMIT the field from the
+    contamination_signals object (NOT set to False — that would imply
+    "checked and found", which is not what happened).
+    """
+    if entry.get("obtained_via") == "manual":
+        return None
+    try:
+        result = client.lookup(entry)
+    except SemanticScholarUnavailable:
+        return None
+    return not result.get("matched", False)
+
+
+def build_signals_object(
+    entry: Mapping[str, Any],
+    client: SemanticScholarClient,
+) -> dict[str, bool]:
+    """Construct the `contamination_signals` object for `entry`.
+
+    Per v3.7.3 spec §3.2 emission rules:
+      - Both signals computed → emit both fields (even when both False:
+        "computed and found clean" is distinct from "not computed")
+      - Manual entry → omit `semantic_scholar_unmatched` field
+      - API degradation → omit `semantic_scholar_unmatched` field
+    """
+    obj: dict[str, bool] = {
+        "preprint_post_llm_inflection": compute_preprint_signal(entry),
+    }
+    ss = compute_ss_unmatched_signal(entry, client)
+    if ss is not None:
+        obj["semantic_scholar_unmatched"] = ss
+    return obj

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -32,6 +32,37 @@ PREPRINT_VENUES = frozenset({
 })
 
 
+# source_pointer → venue inference table. Per v3.7.3 spec §3.2 + schema
+# rule, when `venue` is absent the resolver must check `source_pointer`
+# for a preprint-server URL/identifier. Substring match against
+# lower-cased pointer; keys must be lower-cased and unambiguous.
+_POINTER_VENUE_HINTS: tuple[tuple[str, str], ...] = (
+    ("arxiv.org", "arXiv"),
+    ("biorxiv.org", "bioRxiv"),
+    ("medrxiv.org", "medRxiv"),
+    ("ssrn.com", "SSRN"),
+    ("papers.ssrn.com", "SSRN"),
+    ("researchsquare.com", "Research Square"),
+    ("preprints.org", "Preprints.org"),
+    ("chemrxiv.org", "ChemRxiv"),
+    ("eartharxiv.org", "EarthArXiv"),
+    ("osf.io/preprints", "OSF Preprints"),
+    ("techrxiv.org", "TechRxiv"),
+)
+
+
+def _infer_venue_from_pointer(source_pointer: str) -> str | None:
+    """Return the preprint venue inferred from the source_pointer URL,
+    or None if no preprint-server hint is present. Per v3.7.3 spec §3.2
+    Vector 1: 'venue field (or, when venue is absent, inference from
+    source_pointer)'."""
+    pointer = source_pointer.lower()
+    for hint, venue in _POINTER_VENUE_HINTS:
+        if hint in pointer:
+            return venue
+    return None
+
+
 class SemanticScholarUnavailable(Exception):
     """SS API degraded (network failure / rate limit exhausted / 5xx).
 
@@ -58,17 +89,27 @@ class SemanticScholarClient(Protocol):
 def compute_preprint_signal(entry: Mapping[str, Any]) -> bool:
     """Signal 1 per v3.7.3 spec §3.2 Vector 1.
 
-    True iff `year >= 2024 AND venue in PREPRINT_VENUES`. Missing year
-    or missing venue resolves to False — both are required for the
-    spec's AND.
+    True iff `year >= 2024 AND venue resolves to a preprint server`.
+    Venue resolution per spec: prefer the explicit `venue` field; when
+    absent, infer from `source_pointer` (e.g., 'https://arxiv.org/abs/...'
+    → arXiv). Missing year, or venue that resolves to neither a preprint
+    server nor an inferable pointer, returns False.
+
+    Source-pointer inference is the codex R2-1 closure: legacy entries
+    that schema-validly omit `venue` but carry a preprint URL must still
+    surface CONTAMINATED-PREPRINT.
     """
     year = entry.get("year")
+    if not isinstance(year, int) or year < 2024:
+        return False
     venue = entry.get("venue")
-    if not isinstance(year, int):
-        return False
-    if venue not in PREPRINT_VENUES:
-        return False
-    return year >= 2024
+    if venue in PREPRINT_VENUES:
+        return True
+    if not isinstance(venue, str):
+        pointer = entry.get("source_pointer")
+        if isinstance(pointer, str):
+            return _infer_venue_from_pointer(pointer) in PREPRINT_VENUES
+    return False
 
 
 def compute_ss_unmatched_signal(

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -135,10 +135,18 @@ def migrate_passport(
             # that hit API degradation wrote contamination_signals with
             # only `preprint_post_llm_inflection`. Merge any newly-
             # computable fields without overwriting the original
-            # backfilled_at timestamp.
+            # backfilled_at timestamp. Codex R2-3 closure: only count
+            # this as a patch when a NEW field was actually added —
+            # otherwise dry-run misreports + non-dry-run rewrites a
+            # byte-identical passport.
+            added_any = False
             for key, value in signals.items():
                 if key not in existing:
                     existing[key] = value
+                    added_any = True
+            if not added_any:
+                report[_SKIP_ALREADY_MIGRATED] += 1
+                continue
         else:
             entry["contamination_signals"] = signals
             entry["contamination_signals_backfilled_at"] = now_iso()

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -104,9 +104,14 @@ def migrate_passport(
     *,
     ss_client: cs.SemanticScholarClient,
     dry_run: bool,
+    verbose: bool = False,
 ) -> dict[str, int]:
     """Migrate a single passport file. Returns a report dict counting
-    processed / patched / various skip categories."""
+    processed / patched / various skip categories.
+
+    `verbose=True` emits per-entry decision lines to stderr (codex R3-2
+    closure). Quiet by default; the CLI's --verbose flag wires this up.
+    """
     doc = load_passport(path)
     corpus = doc.get("literature_corpus") if doc else None
     report = {
@@ -119,15 +124,22 @@ def migrate_passport(
     if not corpus:
         return report
 
+    def _log(msg: str) -> None:
+        if verbose:
+            print(f"[{path}] {msg}", file=sys.stderr)
+
     mutated = False
     for entry in corpus:
         report["processed"] += 1
+        key = entry.get("citation_key", "<no-citation-key>")
         existing = entry.get("contamination_signals")
         if existing is not None and _is_complete(existing, entry):
             report[_SKIP_ALREADY_MIGRATED] += 1
+            _log(f"{key}: skip (already migrated)")
             continue
         if _is_insufficient(entry):
             report[_SKIP_INSUFFICIENT_DATA] += 1
+            _log(f"{key}: skip (insufficient data — missing year)")
             continue
         signals = cs.build_signals_object(entry, ss_client)
         if existing is not None:
@@ -140,16 +152,19 @@ def migrate_passport(
             # otherwise dry-run misreports + non-dry-run rewrites a
             # byte-identical passport.
             added_any = False
-            for key, value in signals.items():
-                if key not in existing:
-                    existing[key] = value
+            for sig_key, value in signals.items():
+                if sig_key not in existing:
+                    existing[sig_key] = value
                     added_any = True
             if not added_any:
                 report[_SKIP_ALREADY_MIGRATED] += 1
+                _log(f"{key}: skip (partial entry, no new fields computable)")
                 continue
+            _log(f"{key}: patch (partial-fill recovery, fields added)")
         else:
             entry["contamination_signals"] = signals
             entry["contamination_signals_backfilled_at"] = now_iso()
+            _log(f"{key}: patch (signals={dict(signals)})")
         report["patched"] += 1
         if entry.get("obtained_via") == "manual":
             report[_MANUAL_UNMATCHED_OMITTED] += 1
@@ -165,12 +180,15 @@ def migrate_directory(
     *,
     ss_client: cs.SemanticScholarClient,
     dry_run: bool,
+    verbose: bool = False,
 ) -> dict[str, int]:
     """Migrate every passport YAML in `directory` (non-recursive)."""
     agg = {"files_processed": 0, "entries_processed": 0, "entries_patched": 0}
     for path in discover_passports(directory):
         agg["files_processed"] += 1
-        r = migrate_passport(path, ss_client=ss_client, dry_run=dry_run)
+        r = migrate_passport(
+            path, ss_client=ss_client, dry_run=dry_run, verbose=verbose
+        )
         agg["entries_processed"] += r["processed"]
         agg["entries_patched"] += r["patched"]
     return agg
@@ -211,7 +229,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 2
     if args.path.is_dir():
-        agg = migrate_directory(args.path, ss_client=client, dry_run=args.dry_run)
+        agg = migrate_directory(
+            args.path,
+            ss_client=client,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+        )
         print(
             f"files_processed={agg['files_processed']} "
             f"entries_processed={agg['entries_processed']} "
@@ -220,7 +243,10 @@ def main(argv: list[str] | None = None) -> int:
         )
     else:
         report = migrate_passport(
-            args.path, ss_client=client, dry_run=args.dry_run
+            args.path,
+            ss_client=client,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
         )
         print(
             f"processed={report['processed']} patched={report['patched']} "

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -61,18 +61,42 @@ def discover_passports(directory: Path) -> Iterable[Path]:
     return [p for p in directory.iterdir() if p.is_file() and p.suffix == ".yaml"]
 
 
+def _is_complete(signals: Mapping[str, Any], entry: Mapping[str, Any]) -> bool:
+    """An existing contamination_signals object is "complete" iff every
+    field that COULD be computed for this entry is already present.
+
+    `preprint_post_llm_inflection` is always computable when the entry
+    has year+venue, so its presence is required.
+
+    `semantic_scholar_unmatched` is required UNLESS the entry is exempt
+    (obtained_via='manual', where the field is permanently omitted per
+    spec §3.2). For non-manual entries lacking this field, an earlier
+    migration must have hit API degradation; re-running fills it in.
+
+    This is the codex R1-3 closure: presence-only idempotency was
+    correct for first-time migrations but blocked partial-fill recovery.
+    """
+    if "preprint_post_llm_inflection" not in signals:
+        return False
+    if entry.get("obtained_via") == "manual":
+        return True
+    return "semantic_scholar_unmatched" in signals
+
+
 def _is_insufficient(entry: Mapping[str, Any]) -> bool:
-    """An entry missing either `year` or `venue` cannot have Signal 1
-    computed reliably (both are in the spec AND). Without venue, Signal 1
-    would silently emit `preprint_post_llm_inflection: false` on an entry
-    where we genuinely don't know — half-truth the migration tool must
-    avoid (spec §3.2 emission rules distinguish "computed and clean" from
-    "not computed"). Real corpora won't hit this since schema requires
-    both fields; defensive against hand-edited YAML."""
-    return (
-        not isinstance(entry.get("year"), int)
-        or not isinstance(entry.get("venue"), str)
-    )
+    """An entry missing `year` cannot have Signal 1 computed at all (year
+    is the unconditional gate of the AND; without it, both branches of
+    the spec rule are undefined). Schema marks `year` as required so this
+    only fires on hand-edited YAML.
+
+    `venue` is INTENTIONALLY not in this check (codex R1-2 closure).
+    venue is schema-optional. When absent, `compute_preprint_signal`
+    correctly returns False (venue not in PREPRINT_VENUES) — that's a
+    defined emission ("computed and the venue isn't a preprint server"),
+    not half-truth. Skipping on venue absence would prevent Signal 2 from
+    running on schema-valid entries that simply omitted the optional
+    field, which is the bug codex R1-2 caught."""
+    return not isinstance(entry.get("year"), int)
 
 
 def migrate_passport(
@@ -98,15 +122,26 @@ def migrate_passport(
     mutated = False
     for entry in corpus:
         report["processed"] += 1
-        if "contamination_signals" in entry:
+        existing = entry.get("contamination_signals")
+        if existing is not None and _is_complete(existing, entry):
             report[_SKIP_ALREADY_MIGRATED] += 1
             continue
         if _is_insufficient(entry):
             report[_SKIP_INSUFFICIENT_DATA] += 1
             continue
         signals = cs.build_signals_object(entry, ss_client)
-        entry["contamination_signals"] = signals
-        entry["contamination_signals_backfilled_at"] = now_iso()
+        if existing is not None:
+            # Partial-fill recovery (codex R1-3 closure): an earlier run
+            # that hit API degradation wrote contamination_signals with
+            # only `preprint_post_llm_inflection`. Merge any newly-
+            # computable fields without overwriting the original
+            # backfilled_at timestamp.
+            for key, value in signals.items():
+                if key not in existing:
+                    existing[key] = value
+        else:
+            entry["contamination_signals"] = signals
+            entry["contamination_signals_backfilled_at"] = now_iso()
         report["patched"] += 1
         if entry.get("obtained_via") == "manual":
             report[_MANUAL_UNMATCHED_OMITTED] += 1
@@ -134,17 +169,12 @@ def migrate_directory(
 
 
 def _build_default_ss_client() -> cs.SemanticScholarClient:
-    """Production SS client following references/semantic_scholar_api_protocol.md
-    (429 → 2s backoff × 3, DOI-first then title-similarity). Intentionally
-    fails loudly when called from a context that hasn't supplied a real
-    client — the migration CLI imports its production wiring lazily so
-    test runs (which inject a mock) don't require network."""
-    raise NotImplementedError(
-        "Production Semantic Scholar client wiring is not part of #105 scope. "
-        "Tests inject a mock; real-world callers should import from "
-        "deep-research/references/semantic_scholar_api_protocol.md once that "
-        "module is exposed as a Python helper. See migration guide doc."
-    )
+    """Production SS client per deep-research/references/semantic_scholar_api_protocol.md
+    (DOI-first then title-similarity, 429 → 2s backoff × 3, S2_API_KEY env
+    var optional). Lazy-imported so test code (which injects a mock)
+    doesn't trigger a network-dependent module load."""
+    from semantic_scholar_client import SemanticScholarClient
+    return SemanticScholarClient()
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -17,7 +17,6 @@ Design: docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.m
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 import sys
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -25,6 +24,7 @@ from typing import Any, Iterable, Mapping
 from ruamel.yaml import YAML
 
 import contamination_signals as cs
+from adapters._common import now_iso
 
 
 # Single shared YAML round-tripper. ruamel.yaml preserves comments,
@@ -38,10 +38,10 @@ _yaml.indent(mapping=2, sequence=4, offset=2)
 # see what wasn't migrated and why.
 _SKIP_ALREADY_MIGRATED = "skipped_already_migrated"
 _SKIP_INSUFFICIENT_DATA = "skipped_insufficient_data"
-
-
-def _now_utc_iso() -> str:
-    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+# Counts entries where the manual exemption fired (the entry was still
+# patched, but `semantic_scholar_unmatched` was omitted per spec §3.2).
+# Distinct from skip categories above — these entries DO get patched.
+_MANUAL_UNMATCHED_OMITTED = "manual_unmatched_omitted"
 
 
 def load_passport(path: Path) -> Any:
@@ -62,10 +62,17 @@ def discover_passports(directory: Path) -> Iterable[Path]:
 
 
 def _is_insufficient(entry: Mapping[str, Any]) -> bool:
-    """An entry without `year` cannot have Signal 1 computed reliably
-    (year is in the spec AND). Real corpora won't hit this since schema
-    requires year; defensive against hand-edited YAML."""
-    return not isinstance(entry.get("year"), int)
+    """An entry missing either `year` or `venue` cannot have Signal 1
+    computed reliably (both are in the spec AND). Without venue, Signal 1
+    would silently emit `preprint_post_llm_inflection: false` on an entry
+    where we genuinely don't know — half-truth the migration tool must
+    avoid (spec §3.2 emission rules distinguish "computed and clean" from
+    "not computed"). Real corpora won't hit this since schema requires
+    both fields; defensive against hand-edited YAML."""
+    return (
+        not isinstance(entry.get("year"), int)
+        or not isinstance(entry.get("venue"), str)
+    )
 
 
 def migrate_passport(
@@ -83,7 +90,7 @@ def migrate_passport(
         "patched": 0,
         _SKIP_ALREADY_MIGRATED: 0,
         _SKIP_INSUFFICIENT_DATA: 0,
-        "skipped_manual_unmatched_omit": 0,
+        _MANUAL_UNMATCHED_OMITTED: 0,
     }
     if not corpus:
         return report
@@ -99,10 +106,10 @@ def migrate_passport(
             continue
         signals = cs.build_signals_object(entry, ss_client)
         entry["contamination_signals"] = signals
-        entry["contamination_signals_backfilled_at"] = _now_utc_iso()
+        entry["contamination_signals_backfilled_at"] = now_iso()
         report["patched"] += 1
         if entry.get("obtained_via") == "manual":
-            report["skipped_manual_unmatched_omit"] += 1
+            report[_MANUAL_UNMATCHED_OMITTED] += 1
         mutated = True
 
     if mutated and not dry_run:
@@ -160,7 +167,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv or sys.argv[1:])
-    client = _build_default_ss_client()
+    try:
+        client = _build_default_ss_client()
+    except NotImplementedError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
     if args.path.is_dir():
         agg = migrate_directory(args.path, ss_client=client, dry_run=args.dry_run)
         print(

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -160,6 +160,14 @@ def migrate_passport(
                 report[_SKIP_ALREADY_MIGRATED] += 1
                 _log(f"{key}: skip (partial entry, no new fields computable)")
                 continue
+            # Codex R5-1 closure: if the partial entry pre-dates the
+            # backfilled_at field (e.g., v3.7.3 ingest-time partial that
+            # came from a degraded S2 lookup), record provenance now so
+            # the post-hoc mutation is distinguishable from ingest-time
+            # data. Preserve any existing timestamp — that's the original
+            # backfill record per the R1-3 contract.
+            if "contamination_signals_backfilled_at" not in entry:
+                entry["contamination_signals_backfilled_at"] = now_iso()
             _log(f"{key}: patch (partial-fill recovery, fields added)")
         else:
             entry["contamination_signals"] = signals

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""#105 v3.7.3 contamination_signals backfill migration tool.
+
+Re-runs the v3.7.3 spec §3.2 contamination_signals check post-hoc on
+pre-v3.7.3 literature_corpus[] entries. Per spec §3.2 R-L3-2-B:
+bibliography_agent computes signals at ingest time; this tool delivers
+the deferred batch operation for legacy corpora.
+
+Usage:
+    python migrate_literature_corpus_to_v3_7_3.py [--dry-run] [--verbose] PATH
+
+PATH is either a passport YAML file or a directory containing passport
+YAML files (directory scan is non-recursive).
+
+Design: docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from ruamel.yaml import YAML
+
+import contamination_signals as cs
+
+
+# Single shared YAML round-tripper. ruamel.yaml preserves comments,
+# key order, and quoting style across read → mutate → write.
+_yaml = YAML()
+_yaml.preserve_quotes = True
+_yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+# Skip-reason categories surface in the migration report so users can
+# see what wasn't migrated and why.
+_SKIP_ALREADY_MIGRATED = "skipped_already_migrated"
+_SKIP_INSUFFICIENT_DATA = "skipped_insufficient_data"
+
+
+def _now_utc_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_passport(path: Path) -> Any:
+    """Round-trip load a passport YAML file. Returns the ruamel-yaml
+    representation (a CommentedMap), not a plain dict."""
+    with path.open("r", encoding="utf-8") as f:
+        return _yaml.load(f)
+
+
+def _dump_passport(path: Path, doc: Any) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        _yaml.dump(doc, f)
+
+
+def discover_passports(directory: Path) -> Iterable[Path]:
+    """Non-recursive scan for *.yaml files in `directory`."""
+    return [p for p in directory.iterdir() if p.is_file() and p.suffix == ".yaml"]
+
+
+def _is_insufficient(entry: Mapping[str, Any]) -> bool:
+    """An entry without `year` cannot have Signal 1 computed reliably
+    (year is in the spec AND). Real corpora won't hit this since schema
+    requires year; defensive against hand-edited YAML."""
+    return not isinstance(entry.get("year"), int)
+
+
+def migrate_passport(
+    path: Path,
+    *,
+    ss_client: cs.SemanticScholarClient,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Migrate a single passport file. Returns a report dict counting
+    processed / patched / various skip categories."""
+    doc = load_passport(path)
+    corpus = doc.get("literature_corpus") if doc else None
+    report = {
+        "processed": 0,
+        "patched": 0,
+        _SKIP_ALREADY_MIGRATED: 0,
+        _SKIP_INSUFFICIENT_DATA: 0,
+        "skipped_manual_unmatched_omit": 0,
+    }
+    if not corpus:
+        return report
+
+    mutated = False
+    for entry in corpus:
+        report["processed"] += 1
+        if "contamination_signals" in entry:
+            report[_SKIP_ALREADY_MIGRATED] += 1
+            continue
+        if _is_insufficient(entry):
+            report[_SKIP_INSUFFICIENT_DATA] += 1
+            continue
+        signals = cs.build_signals_object(entry, ss_client)
+        entry["contamination_signals"] = signals
+        entry["contamination_signals_backfilled_at"] = _now_utc_iso()
+        report["patched"] += 1
+        if entry.get("obtained_via") == "manual":
+            report["skipped_manual_unmatched_omit"] += 1
+        mutated = True
+
+    if mutated and not dry_run:
+        _dump_passport(path, doc)
+    return report
+
+
+def migrate_directory(
+    directory: Path,
+    *,
+    ss_client: cs.SemanticScholarClient,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Migrate every passport YAML in `directory` (non-recursive)."""
+    agg = {"files_processed": 0, "entries_processed": 0, "entries_patched": 0}
+    for path in discover_passports(directory):
+        agg["files_processed"] += 1
+        r = migrate_passport(path, ss_client=ss_client, dry_run=dry_run)
+        agg["entries_processed"] += r["processed"]
+        agg["entries_patched"] += r["patched"]
+    return agg
+
+
+def _build_default_ss_client() -> cs.SemanticScholarClient:
+    """Production SS client following references/semantic_scholar_api_protocol.md
+    (429 → 2s backoff × 3, DOI-first then title-similarity). Intentionally
+    fails loudly when called from a context that hasn't supplied a real
+    client — the migration CLI imports its production wiring lazily so
+    test runs (which inject a mock) don't require network."""
+    raise NotImplementedError(
+        "Production Semantic Scholar client wiring is not part of #105 scope. "
+        "Tests inject a mock; real-world callers should import from "
+        "deep-research/references/semantic_scholar_api_protocol.md once that "
+        "module is exposed as a Python helper. See migration guide doc."
+    )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill v3.7.3 contamination_signals on pre-v3.7.3 "
+            "literature_corpus[] entries. See "
+            "docs/migration/v3.7.3-contamination-signals-backfill.md"
+        )
+    )
+    parser.add_argument("path", type=Path, help="Passport YAML file or directory")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show proposed changes, write nothing"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Per-entry logging to stderr"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    client = _build_default_ss_client()
+    if args.path.is_dir():
+        agg = migrate_directory(args.path, ss_client=client, dry_run=args.dry_run)
+        print(
+            f"files_processed={agg['files_processed']} "
+            f"entries_processed={agg['entries_processed']} "
+            f"entries_patched={agg['entries_patched']} "
+            f"dry_run={args.dry_run}"
+        )
+    else:
+        report = migrate_passport(
+            args.path, ss_client=client, dry_run=args.dry_run
+        )
+        print(
+            f"processed={report['processed']} patched={report['patched']} "
+            f"skipped_already_migrated={report[_SKIP_ALREADY_MIGRATED]} "
+            f"skipped_insufficient_data={report[_SKIP_INSUFFICIENT_DATA]} "
+            f"dry_run={args.dry_run}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -57,12 +57,19 @@ class SemanticScholarClient:
     def lookup(self, entry: Mapping[str, Any]) -> Mapping[str, Any]:
         """Return {"matched": bool, "paperId": str | None}.
 
-        Per protocol §"Query Patterns":
+        Per protocol §"Query Patterns" + §"Response Handling":
+        `semantic_scholar_unmatched` is True only when NEITHER DOI nor
+        title lookup yields a hit. So:
+
         1. If `doi` present → GET /paper/DOI:{doi}; on hit, cross-check
-           returned title (Levenshtein ≥ 0.70) — DOI_MISMATCH (title
-           differs) counts as no-match in this binary semantic.
-        2. Else → GET /paper/search?query={url-encoded-title}; pick the
-           top result with title similarity ≥ 0.70, prefer matching year.
+           returned title (Levenshtein ≥ 0.70). DOI_MISMATCH (title
+           differs despite DOI hit) AND DOI-404 BOTH fall through to (2)
+           rather than returning no-match immediately — the v3.7.3
+           Vector 2 contract requires both DOI AND title to miss before
+           setting the signal. Codex R2-2 closure.
+        2. Title search: GET /paper/search?query={url-encoded-title};
+           pick the top result with title similarity ≥ 0.70, prefer
+           matching year.
 
         Raises SemanticScholarUnavailable on:
         - HTTP 429 after exhausting `_MAX_RETRIES` retries
@@ -72,7 +79,11 @@ class SemanticScholarClient:
         doi = entry.get("doi")
         title = entry.get("title") or ""
         if doi:
-            return self._lookup_by_doi(doi, title)
+            doi_result = self._lookup_by_doi(doi, title)
+            if doi_result["matched"]:
+                return doi_result
+            # DOI miss or DOI_MISMATCH: fall through to title search
+            # per protocol §Vector 2 "neither DOI nor title" rule.
         if title:
             return self._lookup_by_title(title, entry.get("year"))
         return {"matched": False, "paperId": None}

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Minimal Semantic Scholar API client wrapper.
+
+Implements the lookup contract documented at
+`deep-research/references/semantic_scholar_api_protocol.md` for the
+v3.7.3 contamination-signals migration tool (#105). DOI-first, title-
+similarity fallback, 429 backoff per the protocol's retry budget.
+
+Not a general-purpose S2 client — this is the migration tool's narrow
+need (single-paper existence check). When ARS later adds a broader S2
+helper, this module's `SemanticScholarClient` class should satisfy the
+contamination_signals.SemanticScholarClient Protocol so the migration
+tool can switch over without code changes.
+"""
+from __future__ import annotations
+
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from difflib import SequenceMatcher
+from typing import Any, Mapping
+
+from contamination_signals import SemanticScholarUnavailable
+
+
+# Per protocol: api.semanticscholar.org/graph/v1, 1 req/s unauthenticated.
+_API_BASE = "https://api.semanticscholar.org/graph/v1"
+_API_KEY_ENV = "S2_API_KEY"
+_FIELDS = "title,authors,year,externalIds,venue,publicationDate"
+
+# Per protocol: 429 → 2s backoff × 3 retries.
+_BACKOFF_SECONDS = 2.0
+_MAX_RETRIES = 3
+
+# Per PaperOrchestra (Song et al. 2026 Appx D.3) + protocol §"Query
+# Patterns" Pattern 1: title-similarity threshold for "matched" verdict.
+_TITLE_SIMILARITY_THRESHOLD = 0.70
+
+
+def _similarity(a: str, b: str) -> float:
+    return SequenceMatcher(None, a.lower().strip(), b.lower().strip()).ratio()
+
+
+class SemanticScholarClient:
+    """Production lookup-by-(doi-then-title) client for v3.7.3 backfill.
+
+    Satisfies `contamination_signals.SemanticScholarClient` Protocol.
+    Tests inject MagicMocks; production callers use this concrete class.
+    """
+
+    def __init__(self, api_key: str | None = None, sleep: Any = time.sleep) -> None:
+        self._api_key = api_key or os.environ.get(_API_KEY_ENV)
+        self._sleep = sleep
+
+    def lookup(self, entry: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Return {"matched": bool, "paperId": str | None}.
+
+        Per protocol §"Query Patterns":
+        1. If `doi` present → GET /paper/DOI:{doi}; on hit, cross-check
+           returned title (Levenshtein ≥ 0.70) — DOI_MISMATCH (title
+           differs) counts as no-match in this binary semantic.
+        2. Else → GET /paper/search?query={url-encoded-title}; pick the
+           top result with title similarity ≥ 0.70, prefer matching year.
+
+        Raises SemanticScholarUnavailable on:
+        - HTTP 429 after exhausting `_MAX_RETRIES` retries
+        - HTTP 5xx
+        - Network error (URLError)
+        """
+        doi = entry.get("doi")
+        title = entry.get("title") or ""
+        if doi:
+            return self._lookup_by_doi(doi, title)
+        if title:
+            return self._lookup_by_title(title, entry.get("year"))
+        return {"matched": False, "paperId": None}
+
+    def _request(self, path: str) -> dict[str, Any]:
+        url = f"{_API_BASE}{path}"
+        headers = {"User-Agent": "ARS-migration/1.0"}
+        if self._api_key:
+            headers["x-api-key"] = self._api_key
+        req = urllib.request.Request(url, headers=headers)
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    import json
+                    return json.loads(resp.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    return {}
+                if e.code == 429 and attempt < _MAX_RETRIES:
+                    self._sleep(_BACKOFF_SECONDS)
+                    continue
+                if 500 <= e.code < 600:
+                    raise SemanticScholarUnavailable(
+                        f"S2 API HTTP {e.code}"
+                    ) from e
+                raise SemanticScholarUnavailable(
+                    f"S2 API HTTP {e.code} after {_MAX_RETRIES} retries"
+                ) from e
+            except urllib.error.URLError as e:
+                raise SemanticScholarUnavailable(f"S2 API network error: {e}") from e
+        raise SemanticScholarUnavailable(f"S2 API exhausted {_MAX_RETRIES} retries")
+
+    def _lookup_by_doi(self, doi: str, expected_title: str) -> dict[str, Any]:
+        data = self._request(f"/paper/DOI:{urllib.parse.quote(doi)}?fields={_FIELDS}")
+        if not data or not data.get("paperId"):
+            return {"matched": False, "paperId": None}
+        # Per protocol: cross-check title; DOI_MISMATCH counts as no-match
+        # for this binary signal.
+        returned_title = data.get("title") or ""
+        if _similarity(expected_title, returned_title) < _TITLE_SIMILARITY_THRESHOLD:
+            return {"matched": False, "paperId": None}
+        return {"matched": True, "paperId": data["paperId"]}
+
+    def _lookup_by_title(self, title: str, year: int | None) -> dict[str, Any]:
+        path = (
+            f"/paper/search?query={urllib.parse.quote(title)}"
+            f"&limit=5&fields={_FIELDS}"
+        )
+        data = self._request(path)
+        candidates = data.get("data") or []
+        best: tuple[float, dict[str, Any]] | None = None
+        for cand in candidates:
+            sim = _similarity(title, cand.get("title") or "")
+            if sim < _TITLE_SIMILARITY_THRESHOLD:
+                continue
+            # Per protocol: prefer matching year when multiple ≥0.70 results.
+            year_match = year is not None and cand.get("year") == year
+            score = sim + (0.05 if year_match else 0.0)
+            if best is None or score > best[0]:
+                best = (score, cand)
+        if best is None:
+            return {"matched": False, "paperId": None}
+        return {"matched": True, "paperId": best[1].get("paperId")}

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -15,6 +15,7 @@ tool can switch over without code changes.
 from __future__ import annotations
 
 import os
+import string
 import time
 import urllib.error
 import urllib.parse
@@ -23,6 +24,9 @@ from difflib import SequenceMatcher
 from typing import Any, Mapping
 
 from contamination_signals import SemanticScholarUnavailable
+
+
+_PUNCT_TRANSLATION = str.maketrans({c: " " for c in string.punctuation})
 
 
 # Per protocol: api.semanticscholar.org/graph/v1, 1 req/s unauthenticated.
@@ -39,8 +43,18 @@ _MAX_RETRIES = 3
 _TITLE_SIMILARITY_THRESHOLD = 0.70
 
 
+def _normalize_title(s: str) -> str:
+    """Per protocol §"Query Patterns" Pattern 1: 'case-insensitive,
+    stripped of punctuation' before computing similarity. Punctuation
+    becomes whitespace so token boundaries are preserved, then collapse
+    runs of whitespace. Codex R4-1 closure: raw lowercased comparison
+    falsely scored 'R.A.G.' vs 'RAG' below the 0.70 threshold."""
+    cleaned = s.lower().translate(_PUNCT_TRANSLATION)
+    return " ".join(cleaned.split())
+
+
 def _similarity(a: str, b: str) -> float:
-    return SequenceMatcher(None, a.lower().strip(), b.lower().strip()).ratio()
+    return SequenceMatcher(None, _normalize_title(a), _normalize_title(b)).ratio()
 
 
 class SemanticScholarClient:
@@ -115,6 +129,15 @@ class SemanticScholarClient:
                 ) from e
             except urllib.error.URLError as e:
                 raise SemanticScholarUnavailable(f"S2 API network error: {e}") from e
+            except (OSError, TimeoutError) as e:
+                # Response-body read timeouts (socket.timeout subclasses
+                # OSError; TimeoutError is the 3.10+ alias) and other
+                # transient I/O failures during resp.read() must be
+                # treated as API degradation per spec — never let them
+                # abort the migration. Codex R4-2 closure.
+                raise SemanticScholarUnavailable(
+                    f"S2 API I/O failure during response read: {e}"
+                ) from e
         raise SemanticScholarUnavailable(f"S2 API exhausted {_MAX_RETRIES} retries")
 
     def _lookup_by_doi(self, doi: str, expected_title: str) -> dict[str, Any]:

--- a/scripts/test_contamination_signals.py
+++ b/scripts/test_contamination_signals.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""#105 v3.7.3 contamination_signals resolver tests.
+
+Tests the two pure-function signals defined in v3.7.3 spec §3.2 that
+the migration tool uses to backfill pre-v3.7.3 literature_corpus entries.
+
+Signal 1 (preprint_post_llm_inflection): year >= 2024 AND venue in 10-server
+closed list (per spec §3.2 Vector 1 + schema description).
+
+Signal 2 (semantic_scholar_unmatched): SS API lookup with manual exemption
++ API degradation handling (per spec §3.2 Vector 2 + R-L3-2-B).
+
+Design: docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import contamination_signals as cs  # noqa: E402
+
+
+# ============================================================================
+# Signal 1 — preprint_post_llm_inflection
+# ============================================================================
+class PreprintSignalTest(unittest.TestCase):
+    """Signal 1 per v3.7.3 spec §3.2 Vector 1: True iff year >= 2024 AND
+    venue ∈ 10-server closed list."""
+
+    def test_arxiv_2024_returns_true(self) -> None:
+        self.assertTrue(cs.compute_preprint_signal({"year": 2024, "venue": "arXiv"}))
+
+    def test_arxiv_2023_returns_false(self) -> None:
+        # Year boundary: 2023 is below threshold
+        self.assertFalse(cs.compute_preprint_signal({"year": 2023, "venue": "arXiv"}))
+
+    def test_arxiv_2025_returns_true(self) -> None:
+        self.assertTrue(cs.compute_preprint_signal({"year": 2025, "venue": "arXiv"}))
+
+    def test_biorxiv_2024_returns_true(self) -> None:
+        self.assertTrue(cs.compute_preprint_signal({"year": 2024, "venue": "bioRxiv"}))
+
+    def test_medrxiv_2024_returns_true(self) -> None:
+        self.assertTrue(cs.compute_preprint_signal({"year": 2024, "venue": "medRxiv"}))
+
+    def test_ssrn_2024_returns_true(self) -> None:
+        self.assertTrue(cs.compute_preprint_signal({"year": 2024, "venue": "SSRN"}))
+
+    def test_research_square_2024_returns_true(self) -> None:
+        self.assertTrue(
+            cs.compute_preprint_signal({"year": 2024, "venue": "Research Square"})
+        )
+
+    def test_preprints_org_2024_returns_true(self) -> None:
+        self.assertTrue(
+            cs.compute_preprint_signal({"year": 2024, "venue": "Preprints.org"})
+        )
+
+    def test_chemrxiv_2024_returns_true(self) -> None:
+        """v3.7.3 codex F6 / gemini review F6 expansion."""
+        self.assertTrue(cs.compute_preprint_signal({"year": 2024, "venue": "ChemRxiv"}))
+
+    def test_eartharxiv_2024_returns_true(self) -> None:
+        self.assertTrue(
+            cs.compute_preprint_signal({"year": 2024, "venue": "EarthArXiv"})
+        )
+
+    def test_osf_preprints_2024_returns_true(self) -> None:
+        self.assertTrue(
+            cs.compute_preprint_signal({"year": 2024, "venue": "OSF Preprints"})
+        )
+
+    def test_techrxiv_2024_returns_true(self) -> None:
+        self.assertTrue(cs.compute_preprint_signal({"year": 2024, "venue": "TechRxiv"}))
+
+    def test_non_preprint_venue_2024_returns_false(self) -> None:
+        # Year passes threshold but venue is not in the closed list
+        self.assertFalse(
+            cs.compute_preprint_signal({"year": 2024, "venue": "Nature"})
+        )
+
+    def test_missing_venue_returns_false(self) -> None:
+        # Defensive: entries lacking venue cannot satisfy the AND
+        self.assertFalse(cs.compute_preprint_signal({"year": 2024}))
+
+    def test_missing_year_returns_false(self) -> None:
+        # Defensive: entries lacking year cannot satisfy the AND
+        self.assertFalse(cs.compute_preprint_signal({"venue": "arXiv"}))
+
+
+# ============================================================================
+# Signal 2 — semantic_scholar_unmatched
+# ============================================================================
+class SemanticScholarSignalTest(unittest.TestCase):
+    """Signal 2 per v3.7.3 spec §3.2 Vector 2: SS API lookup. Returns None
+    on (a) manual exemption (b) API degradation; True/False otherwise.
+
+    The SS client is dependency-injected — tests use a MagicMock that
+    returns whatever match shape the test specifies."""
+
+    def _entry(self, **overrides):
+        base = {
+            "citation_key": "chen2024ai",
+            "title": "Test paper",
+            "authors": [{"family": "Chen", "given": "A"}],
+            "year": 2024,
+            "doi": "10.1234/xyz",
+            "obtained_via": "folder-scan",
+        }
+        return base | overrides
+
+    def test_manual_entry_returns_none(self) -> None:
+        """v3.7.3 spec §3.2 + schema allOf rule #4: obtained_via='manual'
+        triggers SKIP — the field MUST be omitted from the emission."""
+        client = MagicMock()
+        result = cs.compute_ss_unmatched_signal(
+            self._entry(obtained_via="manual"), client
+        )
+        self.assertIsNone(result)
+        # The exemption is a skip, not an API call
+        client.lookup.assert_not_called()
+
+    def test_ss_match_returns_false(self) -> None:
+        client = MagicMock()
+        client.lookup.return_value = {"matched": True, "paperId": "abc123"}
+        self.assertFalse(cs.compute_ss_unmatched_signal(self._entry(), client))
+
+    def test_ss_no_match_returns_true(self) -> None:
+        client = MagicMock()
+        client.lookup.return_value = {"matched": False, "paperId": None}
+        self.assertTrue(cs.compute_ss_unmatched_signal(self._entry(), client))
+
+    def test_ss_api_degradation_returns_none(self) -> None:
+        """Per spec §3.2: API unreachable (network failure / rate-limit-
+        exhausted / 5xx) returns None. Absence ≠ negative confirmation;
+        setting False would imply 'checked and found'."""
+        client = MagicMock()
+        client.lookup.side_effect = cs.SemanticScholarUnavailable("rate limit exhausted")
+        self.assertIsNone(cs.compute_ss_unmatched_signal(self._entry(), client))
+
+    def test_ss_network_failure_returns_none(self) -> None:
+        client = MagicMock()
+        client.lookup.side_effect = cs.SemanticScholarUnavailable("connection refused")
+        self.assertIsNone(cs.compute_ss_unmatched_signal(self._entry(), client))
+
+    def test_unexpected_exception_propagates(self) -> None:
+        """Distinguish 'API degradation' (a known-handled signal) from
+        unknown bugs. ValueError isn't SS-API-degradation; let it surface
+        so the migration tool can fail loudly rather than silently OMIT."""
+        client = MagicMock()
+        client.lookup.side_effect = ValueError("bug in client")
+        with self.assertRaises(ValueError):
+            cs.compute_ss_unmatched_signal(self._entry(), client)
+
+
+# ============================================================================
+# Emission rules — building the contamination_signals object
+# ============================================================================
+class EmissionRulesTest(unittest.TestCase):
+    """Per spec §3.2 emission rules: emit object with both fields false
+    when computed-and-clean; emit partial object when one signal can't
+    be computed; omit semantic_scholar_unmatched on manual exemption."""
+
+    def _entry(self, **overrides):
+        base = {
+            "year": 2024,
+            "venue": "arXiv",
+            "obtained_via": "folder-scan",
+        }
+        return base | overrides
+
+    def test_both_signals_computed_emits_full_object(self) -> None:
+        client = MagicMock()
+        client.lookup.return_value = {"matched": False}
+        result = cs.build_signals_object(self._entry(), client)
+        self.assertEqual(
+            result,
+            {"preprint_post_llm_inflection": True, "semantic_scholar_unmatched": True},
+        )
+
+    def test_clean_entry_emits_both_false(self) -> None:
+        client = MagicMock()
+        client.lookup.return_value = {"matched": True}
+        result = cs.build_signals_object(self._entry(year=2023, venue="Nature"), client)
+        self.assertEqual(
+            result,
+            {"preprint_post_llm_inflection": False, "semantic_scholar_unmatched": False},
+        )
+
+    def test_manual_entry_omits_unmatched_field(self) -> None:
+        client = MagicMock()
+        result = cs.build_signals_object(
+            self._entry(obtained_via="manual"), client
+        )
+        self.assertEqual(result, {"preprint_post_llm_inflection": True})
+        self.assertNotIn("semantic_scholar_unmatched", result)
+
+    def test_api_degradation_omits_unmatched_field(self) -> None:
+        """Partial computation: Signal 1 still emits (trivial from
+        year+venue), Signal 2 omitted (API down). Per spec §3.2."""
+        client = MagicMock()
+        client.lookup.side_effect = cs.SemanticScholarUnavailable("5xx")
+        result = cs.build_signals_object(self._entry(), client)
+        self.assertEqual(result, {"preprint_post_llm_inflection": True})
+        self.assertNotIn("semantic_scholar_unmatched", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_contamination_signals.py
+++ b/scripts/test_contamination_signals.py
@@ -93,6 +93,58 @@ class PreprintSignalTest(unittest.TestCase):
         # Defensive: entries lacking year cannot satisfy the AND
         self.assertFalse(cs.compute_preprint_signal({"venue": "arXiv"}))
 
+    def test_source_pointer_infers_arxiv(self) -> None:
+        """Codex R2-1 closure: when venue is missing, source_pointer
+        URLs to preprint servers must satisfy Signal 1."""
+        self.assertTrue(
+            cs.compute_preprint_signal(
+                {"year": 2024, "source_pointer": "https://arxiv.org/abs/2401.12345"}
+            )
+        )
+
+    def test_source_pointer_infers_biorxiv(self) -> None:
+        self.assertTrue(
+            cs.compute_preprint_signal(
+                {"year": 2025, "source_pointer": "https://www.biorxiv.org/content/10.1101/2025.01.01.000000v1"}
+            )
+        )
+
+    def test_source_pointer_infers_osf_preprints(self) -> None:
+        self.assertTrue(
+            cs.compute_preprint_signal(
+                {"year": 2024, "source_pointer": "https://osf.io/preprints/socarxiv/xyz123"}
+            )
+        )
+
+    def test_source_pointer_non_preprint_returns_false(self) -> None:
+        """An arbitrary URL with no preprint-server hint stays False."""
+        self.assertFalse(
+            cs.compute_preprint_signal(
+                {"year": 2024, "source_pointer": "https://nature.com/articles/x"}
+            )
+        )
+
+    def test_source_pointer_ignored_when_venue_present(self) -> None:
+        """Explicit `venue` field takes precedence — Nature 2024 with an
+        arxiv source_pointer is still venue=Nature (Signal 1 false)."""
+        self.assertFalse(
+            cs.compute_preprint_signal(
+                {
+                    "year": 2024,
+                    "venue": "Nature",
+                    "source_pointer": "https://arxiv.org/abs/2401.x",
+                }
+            )
+        )
+
+    def test_source_pointer_pre_2024_returns_false(self) -> None:
+        """Year < 2024 short-circuits before pointer inference fires."""
+        self.assertFalse(
+            cs.compute_preprint_signal(
+                {"year": 2023, "source_pointer": "https://arxiv.org/abs/2301.x"}
+            )
+        )
+
 
 # ============================================================================
 # Signal 2 — semantic_scholar_unmatched

--- a/scripts/test_migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/test_migrate_literature_corpus_to_v3_7_3.py
@@ -219,6 +219,78 @@ literature_corpus:
                 "2026-05-15T10:30:00Z",
             )
 
+    def test_partial_fill_without_provenance_sets_backfilled_at(self) -> None:
+        """Codex R5-1 closure: an ingest-time partial entry (v3.7.3
+        bibliography_agent wrote contamination_signals during S2
+        degradation) lacks backfilled_at. When the migration fills in
+        the missing field post-hoc, record provenance — otherwise the
+        post-hoc mutation is indistinguishable from ingest-time data."""
+        ingest_partial_yaml = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: chen2024ai
+    title: AI in education
+    authors:
+      - family: Chen
+        given: A
+    year: 2024
+    venue: arXiv
+    doi: 10.1234/abc
+    obtained_via: folder-scan
+    source_pointer: file:///refs/chen2024.pdf
+    contamination_signals:
+      preprint_post_llm_inflection: true
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(ingest_partial_yaml)
+            mig.migrate_passport(
+                p,
+                ss_client=_make_ss_client(unmatched_for_keys=["chen2024ai"]),
+                dry_run=False,
+            )
+            doc = mig.load_passport(p)
+            entry = doc["literature_corpus"][0]
+            self.assertEqual(
+                entry["contamination_signals"],
+                {"preprint_post_llm_inflection": True, "semantic_scholar_unmatched": True},
+            )
+            self.assertIn("contamination_signals_backfilled_at", entry)
+
+    def test_partial_fill_with_existing_provenance_preserves_timestamp(self) -> None:
+        """R5-1 closure (companion): when partial entry already has
+        backfilled_at (R1-3 case: prior migration run that hit API
+        degradation), DON'T overwrite — the original timestamp is the
+        canonical backfill record."""
+        partial_with_ts = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: chen2024ai
+    title: AI in education
+    authors:
+      - family: Chen
+        given: A
+    year: 2024
+    venue: arXiv
+    doi: 10.1234/abc
+    obtained_via: folder-scan
+    source_pointer: file:///refs/chen2024.pdf
+    contamination_signals:
+      preprint_post_llm_inflection: true
+    contamination_signals_backfilled_at: '2025-01-01T00:00:00Z'
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(partial_with_ts)
+            mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=False
+            )
+            doc = mig.load_passport(p)
+            self.assertEqual(
+                doc["literature_corpus"][0]["contamination_signals_backfilled_at"],
+                "2025-01-01T00:00:00Z",
+            )
+
     def test_verbose_emits_per_entry_decisions(self) -> None:
         """Codex R3-2 closure: --verbose must produce per-entry lines on
         stderr so users can audit what got patched / skipped / why."""

--- a/scripts/test_migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/test_migrate_literature_corpus_to_v3_7_3.py
@@ -146,12 +146,12 @@ class SinglePassportMigrationTest(unittest.TestCase):
                 "re-run on migrated passport must be byte-identical",
             )
 
-    def test_insufficient_data_missing_venue_skipped(self) -> None:
-        """An entry missing venue cannot have Signal 1 reliably emitted
-        as False — that would be a half-truth (we don't know if the
-        venue is a preprint server). Per spec §3.2 emission rules,
-        'computed and clean' must be distinguished from 'not computed'.
-        v3.7.3 codex F3 closure (simplify round)."""
+    def test_missing_venue_does_not_skip_entry(self) -> None:
+        """Codex R1-2 closure: venue is schema-optional. When absent,
+        Signal 1 correctly evaluates to False (venue not in PREPRINT_VENUES)
+        and emission proceeds — that's a defined computation, not half-
+        truth. Signal 2 (SS API) is still attempted. Skipping on venue
+        absence would prevent the migration from filling in usable data."""
         yaml_no_venue = """\
 origin_skill: deep-research
 literature_corpus:
@@ -170,8 +170,84 @@ literature_corpus:
             report = mig.migrate_passport(
                 p, ss_client=_make_ss_client(), dry_run=False
             )
+            self.assertEqual(report["patched"], 1)
+            self.assertEqual(report["skipped_insufficient_data"], 0)
+            doc = mig.load_passport(p)
+            sig = doc["literature_corpus"][0]["contamination_signals"]
+            self.assertEqual(sig["preprint_post_llm_inflection"], False)
+            self.assertIn("semantic_scholar_unmatched", sig)
+
+    def test_partial_fill_recovery_fills_unmatched_field(self) -> None:
+        """Codex R1-3 closure: a previous run hit API degradation and
+        wrote contamination_signals with only preprint_post_llm_inflection.
+        Re-running with a healthy API must fill in semantic_scholar_unmatched
+        without overwriting the original backfilled_at timestamp."""
+        partial_yaml = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: chen2024ai
+    title: AI in education
+    authors:
+      - family: Chen
+        given: A
+    year: 2024
+    venue: arXiv
+    doi: 10.1234/abc
+    obtained_via: folder-scan
+    source_pointer: file:///refs/chen2024.pdf
+    contamination_signals:
+      preprint_post_llm_inflection: true
+    contamination_signals_backfilled_at: '2026-05-15T10:30:00Z'
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(partial_yaml)
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(unmatched_for_keys=["chen2024ai"]),
+                dry_run=False,
+            )
+            self.assertEqual(report["patched"], 1)
+            doc = mig.load_passport(p)
+            entry = doc["literature_corpus"][0]
+            self.assertEqual(
+                entry["contamination_signals"],
+                {"preprint_post_llm_inflection": True, "semantic_scholar_unmatched": True},
+            )
+            # Original timestamp preserved (no re-stamping on partial fill)
+            self.assertEqual(
+                entry["contamination_signals_backfilled_at"],
+                "2026-05-15T10:30:00Z",
+            )
+
+    def test_manual_entry_with_only_preprint_signal_is_complete(self) -> None:
+        """A manual entry permanently omits semantic_scholar_unmatched
+        (per spec §3.2 + schema allOf rule #4). An object with only
+        preprint_post_llm_inflection on a manual entry is COMPLETE, not
+        partial — re-running must skip."""
+        manual_yaml = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: lopez2024manual
+    title: Manual entry
+    authors:
+      - family: Lopez
+        given: C
+    year: 2024
+    venue: bioRxiv
+    obtained_via: manual
+    source_pointer: file:///refs/lopez2024.pdf
+    contamination_signals:
+      preprint_post_llm_inflection: true
+    contamination_signals_backfilled_at: '2026-05-15T10:30:00Z'
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(manual_yaml)
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=False
+            )
             self.assertEqual(report["patched"], 0)
-            self.assertEqual(report["skipped_insufficient_data"], 1)
+            self.assertEqual(report["skipped_already_migrated"], 1)
 
     def test_insufficient_data_entry_skipped(self) -> None:
         """An entry missing year cannot have Signal 1 computed reliably

--- a/scripts/test_migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/test_migrate_literature_corpus_to_v3_7_3.py
@@ -88,7 +88,7 @@ class SinglePassportMigrationTest(unittest.TestCase):
             after = p.read_text()
             self.assertEqual(before, after, "dry-run must not write")
             self.assertEqual(report["patched"], 3)
-            self.assertEqual(report["skipped_manual_unmatched_omit"], 1)
+            self.assertEqual(report["manual_unmatched_omitted"], 1)
 
     def test_patches_three_entries_per_emission_rules(self) -> None:
         """Per spec §3.2: emit object on every non-skipped entry, even
@@ -145,6 +145,33 @@ class SinglePassportMigrationTest(unittest.TestCase):
                 after_first, after_second,
                 "re-run on migrated passport must be byte-identical",
             )
+
+    def test_insufficient_data_missing_venue_skipped(self) -> None:
+        """An entry missing venue cannot have Signal 1 reliably emitted
+        as False — that would be a half-truth (we don't know if the
+        venue is a preprint server). Per spec §3.2 emission rules,
+        'computed and clean' must be distinguished from 'not computed'.
+        v3.7.3 codex F3 closure (simplify round)."""
+        yaml_no_venue = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: novenue2024
+    title: No venue
+    authors:
+      - family: X
+        given: Y
+    year: 2024
+    obtained_via: folder-scan
+    source_pointer: file:///refs/novenue.pdf
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(yaml_no_venue)
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=False
+            )
+            self.assertEqual(report["patched"], 0)
+            self.assertEqual(report["skipped_insufficient_data"], 1)
 
     def test_insufficient_data_entry_skipped(self) -> None:
         """An entry missing year cannot have Signal 1 computed reliably

--- a/scripts/test_migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/test_migrate_literature_corpus_to_v3_7_3.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""#105 v3.7.3 contamination_signals backfill migration tool tests.
+
+Tests scripts/migrate_literature_corpus_to_v3_7_3.py — the CLI that
+backfills `contamination_signals` on pre-v3.7.3 literature_corpus[]
+entries per v3.7.3 spec §3.2 R-L3-2-B.
+
+Design: docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import migrate_literature_corpus_to_v3_7_3 as mig  # noqa: E402
+
+
+SAMPLE_PASSPORT_YAML = """\
+# Material Passport for the SLR run
+origin_skill: deep-research
+origin_mode: systematic-review
+origin_date: '2026-05-01T10:00:00Z'
+verification_status: VERIFIED
+version_label: research_v1
+literature_corpus:
+  - citation_key: chen2024ai
+    title: AI in education
+    authors:
+      - family: Chen
+        given: A
+    year: 2024
+    venue: arXiv
+    doi: 10.1234/abc
+    obtained_via: folder-scan
+    source_pointer: file:///refs/chen2024.pdf
+  - citation_key: smith2020old
+    title: Old paper
+    authors:
+      - family: Smith
+        given: B
+    year: 2020
+    venue: Nature
+    doi: 10.5678/def
+    obtained_via: folder-scan
+    source_pointer: file:///refs/smith2020.pdf
+  - citation_key: lopez2024manual
+    title: Manual entry
+    authors:
+      - family: Lopez
+        given: C
+    year: 2024
+    venue: bioRxiv
+    obtained_via: manual
+    source_pointer: file:///refs/lopez2024.pdf
+"""
+
+
+def _make_ss_client(unmatched_for_keys=()):
+    """Build a mock SS client that returns no-match for the listed citation
+    keys (so the entry gets semantic_scholar_unmatched: true) and match
+    otherwise."""
+    client = MagicMock()
+    def lookup(entry):
+        return {"matched": entry.get("citation_key") not in set(unmatched_for_keys)}
+    client.lookup.side_effect = lookup
+    return client
+
+
+# ============================================================================
+# Single-passport migration
+# ============================================================================
+class SinglePassportMigrationTest(unittest.TestCase):
+    def test_dry_run_writes_no_file(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(SAMPLE_PASSPORT_YAML)
+            before = p.read_text()
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=True
+            )
+            after = p.read_text()
+            self.assertEqual(before, after, "dry-run must not write")
+            self.assertEqual(report["patched"], 3)
+            self.assertEqual(report["skipped_manual_unmatched_omit"], 1)
+
+    def test_patches_three_entries_per_emission_rules(self) -> None:
+        """Per spec §3.2: emit object on every non-skipped entry, even
+        when both signals are False (computed-and-clean is distinct from
+        not-computed). All 3 sample entries get the object; manual entry
+        omits the unmatched field."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(SAMPLE_PASSPORT_YAML)
+            report = mig.migrate_passport(
+                p,
+                ss_client=_make_ss_client(unmatched_for_keys=["chen2024ai"]),
+                dry_run=False,
+            )
+            self.assertEqual(report["patched"], 3)
+            doc = mig.load_passport(p)
+            entries = doc["literature_corpus"]
+            # chen2024ai: arXiv 2024 → preprint=true; SS no-match → unmatched=true
+            chen = entries[0]
+            self.assertEqual(
+                chen["contamination_signals"],
+                {"preprint_post_llm_inflection": True, "semantic_scholar_unmatched": True},
+            )
+            self.assertIn("contamination_signals_backfilled_at", chen)
+            # smith2020old: Nature 2020 → preprint=false; SS match → unmatched=false
+            smith = entries[1]
+            self.assertEqual(
+                smith["contamination_signals"],
+                {"preprint_post_llm_inflection": False, "semantic_scholar_unmatched": False},
+            )
+            # lopez2024manual: bioRxiv 2024 manual → preprint=true; unmatched OMITTED
+            lopez = entries[2]
+            self.assertEqual(
+                lopez["contamination_signals"],
+                {"preprint_post_llm_inflection": True},
+            )
+            self.assertNotIn("semantic_scholar_unmatched", lopez["contamination_signals"])
+
+    def test_idempotency_already_migrated_entry_skipped(self) -> None:
+        """Re-running on an already-migrated entry must not re-compute,
+        re-write, or update the backfilled_at timestamp."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(SAMPLE_PASSPORT_YAML)
+            mig.migrate_passport(p, ss_client=_make_ss_client(), dry_run=False)
+            after_first = p.read_text()
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=False
+            )
+            after_second = p.read_text()
+            self.assertEqual(report["patched"], 0)
+            self.assertEqual(report["skipped_already_migrated"], 3)
+            self.assertEqual(
+                after_first, after_second,
+                "re-run on migrated passport must be byte-identical",
+            )
+
+    def test_insufficient_data_entry_skipped(self) -> None:
+        """An entry missing year cannot have Signal 1 computed reliably
+        (year is in the AND); migration tool skips and logs the reason
+        rather than emitting half-truth."""
+        yaml_no_year = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: noyear2024
+    title: No year
+    authors:
+      - family: X
+        given: Y
+    venue: arXiv
+    obtained_via: folder-scan
+    source_pointer: file:///refs/noyear.pdf
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(yaml_no_year)
+            # Note: schema-invalid passport — `year` is required. This test
+            # exercises the migration tool's defensive behavior, not the
+            # schema validator. Real corpora won't reach here, but if they
+            # do (e.g., user hand-edited their YAML), we degrade gracefully.
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=False
+            )
+            self.assertEqual(report["patched"], 0)
+            self.assertEqual(report["skipped_insufficient_data"], 1)
+
+    def test_passport_without_literature_corpus_returns_zero_report(self) -> None:
+        yaml_no_corpus = """\
+origin_skill: deep-research
+verification_status: VERIFIED
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(yaml_no_corpus)
+            report = mig.migrate_passport(
+                p, ss_client=_make_ss_client(), dry_run=False
+            )
+            self.assertEqual(report["processed"], 0)
+            self.assertEqual(report["patched"], 0)
+
+
+# ============================================================================
+# Directory-scan mode
+# ============================================================================
+class DirectoryScanTest(unittest.TestCase):
+    def test_scan_dir_finds_yaml_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "passport_a.yaml").write_text(SAMPLE_PASSPORT_YAML)
+            (d / "passport_b.yaml").write_text(SAMPLE_PASSPORT_YAML)
+            (d / "notes.txt").write_text("ignore me")
+            paths = sorted(mig.discover_passports(d))
+            self.assertEqual(
+                [p.name for p in paths],
+                ["passport_a.yaml", "passport_b.yaml"],
+            )
+
+    def test_scan_dir_is_non_recursive(self) -> None:
+        """Per design §4.2: directory scan finds *.yaml non-recursively.
+        A passport in a subdir is intentionally NOT discovered."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "passport.yaml").write_text(SAMPLE_PASSPORT_YAML)
+            sub = d / "subdir"
+            sub.mkdir()
+            (sub / "nested.yaml").write_text(SAMPLE_PASSPORT_YAML)
+            paths = sorted(mig.discover_passports(d))
+            self.assertEqual([p.name for p in paths], ["passport.yaml"])
+
+    def test_migrate_dir_runs_each_passport(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            for name in ("a.yaml", "b.yaml"):
+                (d / name).write_text(SAMPLE_PASSPORT_YAML)
+            client = _make_ss_client(unmatched_for_keys=["chen2024ai"])
+            agg = mig.migrate_directory(d, ss_client=client, dry_run=False)
+            self.assertEqual(agg["files_processed"], 2)
+            self.assertEqual(agg["entries_patched"], 6)  # 3 per passport × 2
+
+
+# ============================================================================
+# Comment + key-order preservation (ruamel.yaml round-trip)
+# ============================================================================
+class RoundTripPreservationTest(unittest.TestCase):
+    def test_comments_preserved_after_migration(self) -> None:
+        yaml_with_comments = """\
+# Top-level comment about this passport
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: chen2024ai  # inline note about chen
+    title: AI in education
+    authors:
+      - family: Chen
+        given: A
+    year: 2024
+    venue: arXiv
+    obtained_via: folder-scan
+    source_pointer: file:///refs/chen2024.pdf
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(yaml_with_comments)
+            mig.migrate_passport(p, ss_client=_make_ss_client(), dry_run=False)
+            after = p.read_text()
+            self.assertIn("# Top-level comment", after)
+            self.assertIn("# inline note about chen", after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/test_migrate_literature_corpus_to_v3_7_3.py
@@ -219,6 +219,41 @@ literature_corpus:
                 "2026-05-15T10:30:00Z",
             )
 
+    def test_partial_fill_with_persistent_api_degradation_does_not_re_patch(self) -> None:
+        """Codex R2-3 closure: when a partial entry's missing field
+        STILL cannot be computed (API still degraded), the merge loop
+        adds nothing. Don't claim it was patched, don't mark mutated."""
+        partial_yaml = """\
+origin_skill: deep-research
+literature_corpus:
+  - citation_key: chen2024ai
+    title: AI in education
+    authors:
+      - family: Chen
+        given: A
+    year: 2024
+    venue: arXiv
+    doi: 10.1234/abc
+    obtained_via: folder-scan
+    source_pointer: file:///refs/chen2024.pdf
+    contamination_signals:
+      preprint_post_llm_inflection: true
+    contamination_signals_backfilled_at: '2026-05-15T10:30:00Z'
+"""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(partial_yaml)
+            before = p.read_text()
+            # Simulate API still degraded — SS lookup raises
+            from contamination_signals import SemanticScholarUnavailable
+            bad_client = MagicMock()
+            bad_client.lookup.side_effect = SemanticScholarUnavailable("still down")
+            report = mig.migrate_passport(p, ss_client=bad_client, dry_run=False)
+            after = p.read_text()
+            self.assertEqual(report["patched"], 0)
+            self.assertEqual(report["skipped_already_migrated"], 1)
+            self.assertEqual(before, after, "no rewrite when nothing was added")
+
     def test_manual_entry_with_only_preprint_signal_is_complete(self) -> None:
         """A manual entry permanently omits semantic_scholar_unmatched
         (per spec §3.2 + schema allOf rule #4). An object with only

--- a/scripts/test_migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/test_migrate_literature_corpus_to_v3_7_3.py
@@ -219,6 +219,29 @@ literature_corpus:
                 "2026-05-15T10:30:00Z",
             )
 
+    def test_verbose_emits_per_entry_decisions(self) -> None:
+        """Codex R3-2 closure: --verbose must produce per-entry lines on
+        stderr so users can audit what got patched / skipped / why."""
+        import io
+        from contextlib import redirect_stderr
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "passport.yaml"
+            p.write_text(SAMPLE_PASSPORT_YAML)
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                mig.migrate_passport(
+                    p,
+                    ss_client=_make_ss_client(unmatched_for_keys=["chen2024ai"]),
+                    dry_run=True,
+                    verbose=True,
+                )
+            output = buf.getvalue()
+            # Per-entry citation_key tags surface for all 3 entries
+            self.assertIn("chen2024ai", output)
+            self.assertIn("smith2020old", output)
+            self.assertIn("lopez2024manual", output)
+            self.assertIn("patch", output)
+
     def test_partial_fill_with_persistent_api_degradation_does_not_re_patch(self) -> None:
         """Codex R2-3 closure: when a partial entry's missing field
         STILL cannot be computed (API still degraded), the merge loop

--- a/scripts/test_semantic_scholar_client.py
+++ b/scripts/test_semantic_scholar_client.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for the minimal Semantic Scholar client backing #105 CLI.
+
+Mocks urllib at the transport layer (no real network). Verifies the
+client honors the protocol's DOI-first + title-similarity + 429-backoff
+contract and surfaces SemanticScholarUnavailable on the documented
+failure modes.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import semantic_scholar_client as ssc  # noqa: E402
+from contamination_signals import SemanticScholarUnavailable  # noqa: E402
+
+
+def _mock_urlopen_returning(payload: dict) -> MagicMock:
+    """Build a urlopen mock that returns `payload` JSON as the response body."""
+    body = json.dumps(payload).encode("utf-8")
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return MagicMock(return_value=resp)
+
+
+class DoiLookupTest(unittest.TestCase):
+    def test_doi_match_with_matching_title(self) -> None:
+        client = ssc.SemanticScholarClient()
+        payload = {"paperId": "abc123", "title": "AI in education"}
+        with patch(
+            "urllib.request.urlopen", _mock_urlopen_returning(payload)
+        ):
+            result = client.lookup(
+                {"title": "AI in education", "doi": "10.1234/xyz", "year": 2024}
+            )
+        self.assertEqual(result, {"matched": True, "paperId": "abc123"})
+
+    def test_doi_match_with_title_mismatch_counts_as_no_match(self) -> None:
+        """Per protocol §"Query Patterns": DOI_MISMATCH (title differs
+        despite DOI hit) is a known hallucination pattern. For the binary
+        contamination signal we map it to no-match."""
+        client = ssc.SemanticScholarClient()
+        payload = {"paperId": "abc123", "title": "Totally unrelated paper"}
+        with patch(
+            "urllib.request.urlopen", _mock_urlopen_returning(payload)
+        ):
+            result = client.lookup(
+                {"title": "AI in education", "doi": "10.1234/xyz", "year": 2024}
+            )
+        self.assertEqual(result, {"matched": False, "paperId": None})
+
+
+class TitleSearchTest(unittest.TestCase):
+    def test_title_search_above_threshold_matches(self) -> None:
+        client = ssc.SemanticScholarClient()
+        payload = {
+            "data": [
+                {"paperId": "abc123", "title": "AI in education", "year": 2024}
+            ]
+        }
+        with patch(
+            "urllib.request.urlopen", _mock_urlopen_returning(payload)
+        ):
+            result = client.lookup({"title": "AI in education", "year": 2024})
+        self.assertEqual(result, {"matched": True, "paperId": "abc123"})
+
+    def test_title_search_below_threshold_no_match(self) -> None:
+        client = ssc.SemanticScholarClient()
+        payload = {
+            "data": [
+                {"paperId": "xyz", "title": "Totally different", "year": 2024}
+            ]
+        }
+        with patch(
+            "urllib.request.urlopen", _mock_urlopen_returning(payload)
+        ):
+            result = client.lookup({"title": "AI in education", "year": 2024})
+        self.assertEqual(result, {"matched": False, "paperId": None})
+
+    def test_empty_results_no_match(self) -> None:
+        client = ssc.SemanticScholarClient()
+        with patch(
+            "urllib.request.urlopen", _mock_urlopen_returning({"data": []})
+        ):
+            result = client.lookup({"title": "Unknown paper"})
+        self.assertEqual(result, {"matched": False, "paperId": None})
+
+
+class FailureHandlingTest(unittest.TestCase):
+    def _raise_http(self, code: int):
+        return urllib.error.HTTPError("u", code, "msg", {}, io.BytesIO(b""))
+
+    def test_429_backoff_then_recover(self) -> None:
+        """Per protocol: HTTP 429 → 2s backoff × 3 retries before
+        giving up. The retry is transparent — successful retry returns
+        a normal result without raising."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        payload = {"paperId": "abc", "title": "AI in education"}
+        body = json.dumps(payload).encode("utf-8")
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+
+        # First two calls 429, third succeeds
+        urlopen = MagicMock(side_effect=[
+            self._raise_http(429),
+            self._raise_http(429),
+            resp,
+        ])
+        with patch("urllib.request.urlopen", urlopen):
+            result = client.lookup(
+                {"title": "AI in education", "doi": "10.1234/xyz"}
+            )
+        self.assertEqual(result, {"matched": True, "paperId": "abc"})
+
+    def test_429_after_max_retries_raises_unavailable(self) -> None:
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        # All 4 attempts (initial + 3 retries) raise 429
+        urlopen = MagicMock(side_effect=[self._raise_http(429)] * 4)
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "X", "doi": "10.1/y"})
+
+    def test_5xx_raises_unavailable(self) -> None:
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        urlopen = MagicMock(side_effect=self._raise_http(503))
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "X", "doi": "10.1/y"})
+
+    def test_404_means_no_match_not_unavailable(self) -> None:
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        urlopen = MagicMock(side_effect=self._raise_http(404))
+        with patch("urllib.request.urlopen", urlopen):
+            result = client.lookup({"title": "X", "doi": "10.1/y"})
+        self.assertEqual(result, {"matched": False, "paperId": None})
+
+    def test_network_error_raises_unavailable(self) -> None:
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        urlopen = MagicMock(side_effect=urllib.error.URLError("connection refused"))
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "X", "doi": "10.1/y"})
+
+
+class CLIWiringTest(unittest.TestCase):
+    """Codex R1-1 closure: CLI was unrunnable because NotImplementedError
+    fired before reading the passport. Verify the production wiring path
+    now actually constructs a SemanticScholarClient instance."""
+
+    def test_build_default_ss_client_returns_real_client(self) -> None:
+        import migrate_literature_corpus_to_v3_7_3 as mig
+        client = mig._build_default_ss_client()
+        self.assertIsInstance(client, ssc.SemanticScholarClient)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_semantic_scholar_client.py
+++ b/scripts/test_semantic_scholar_client.py
@@ -46,17 +46,69 @@ class DoiLookupTest(unittest.TestCase):
             )
         self.assertEqual(result, {"matched": True, "paperId": "abc123"})
 
-    def test_doi_match_with_title_mismatch_counts_as_no_match(self) -> None:
-        """Per protocol §"Query Patterns": DOI_MISMATCH (title differs
-        despite DOI hit) is a known hallucination pattern. For the binary
-        contamination signal we map it to no-match."""
-        client = ssc.SemanticScholarClient()
-        payload = {"paperId": "abc123", "title": "Totally unrelated paper"}
-        with patch(
-            "urllib.request.urlopen", _mock_urlopen_returning(payload)
-        ):
+    def test_doi_404_falls_back_to_title_search(self) -> None:
+        """Codex R2-2 closure: v3.7.3 Vector 2 says unmatched=true only
+        when NEITHER DOI nor title yields a hit. DOI 404 alone is not
+        sufficient — must fall through to title search."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        # DOI lookup 404s; title search finds match
+        title_payload = {
+            "data": [
+                {"paperId": "title-hit", "title": "AI in education", "year": 2024}
+            ]
+        }
+        title_body = json.dumps(title_payload).encode("utf-8")
+        title_resp = MagicMock()
+        title_resp.read.return_value = title_body
+        title_resp.__enter__ = MagicMock(return_value=title_resp)
+        title_resp.__exit__ = MagicMock(return_value=False)
+        urlopen = MagicMock(side_effect=[
+            urllib.error.HTTPError("u", 404, "Not Found", {}, io.BytesIO(b"")),
+            title_resp,
+        ])
+        with patch("urllib.request.urlopen", urlopen):
+            result = client.lookup(
+                {"title": "AI in education", "doi": "10.9999/bogus", "year": 2024}
+            )
+        self.assertEqual(result, {"matched": True, "paperId": "title-hit"})
+
+    def test_doi_title_mismatch_falls_back_to_title_search(self) -> None:
+        """Codex R2-2 closure: DOI returns wrong paper (title mismatch).
+        Still must try title search before declaring unmatched."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        doi_payload = {"paperId": "wrong-paper", "title": "Totally unrelated"}
+        title_payload = {
+            "data": [
+                {"paperId": "title-hit", "title": "AI in education", "year": 2024}
+            ]
+        }
+        doi_body = json.dumps(doi_payload).encode("utf-8")
+        title_body = json.dumps(title_payload).encode("utf-8")
+        doi_resp = MagicMock()
+        doi_resp.read.return_value = doi_body
+        doi_resp.__enter__ = MagicMock(return_value=doi_resp)
+        doi_resp.__exit__ = MagicMock(return_value=False)
+        title_resp = MagicMock()
+        title_resp.read.return_value = title_body
+        title_resp.__enter__ = MagicMock(return_value=title_resp)
+        title_resp.__exit__ = MagicMock(return_value=False)
+        urlopen = MagicMock(side_effect=[doi_resp, title_resp])
+        with patch("urllib.request.urlopen", urlopen):
             result = client.lookup(
                 {"title": "AI in education", "doi": "10.1234/xyz", "year": 2024}
+            )
+        self.assertEqual(result, {"matched": True, "paperId": "title-hit"})
+
+    def test_doi_404_and_title_404_returns_no_match(self) -> None:
+        """Both endpoints miss: now legitimate unmatched."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        urlopen = MagicMock(side_effect=[
+            urllib.error.HTTPError("u", 404, "Not Found", {}, io.BytesIO(b"")),
+            urllib.error.HTTPError("u", 404, "Not Found", {}, io.BytesIO(b"")),
+        ])
+        with patch("urllib.request.urlopen", urlopen):
+            result = client.lookup(
+                {"title": "Truly nonexistent", "doi": "10.0000/bogus", "year": 2024}
             )
         self.assertEqual(result, {"matched": False, "paperId": None})
 

--- a/scripts/test_semantic_scholar_client.py
+++ b/scripts/test_semantic_scholar_client.py
@@ -207,6 +207,58 @@ class FailureHandlingTest(unittest.TestCase):
                 client.lookup({"title": "X", "doi": "10.1/y"})
 
 
+class TitleNormalizationTest(unittest.TestCase):
+    """Codex R4-1 closure: protocol §"Query Patterns" Pattern 1 says
+    title matching is 'case-insensitive, stripped of punctuation'."""
+
+    def test_acronym_punctuation_clears_threshold(self) -> None:
+        """'R.A.G.' vs 'RAG' originally scored below 0.70 because raw
+        SequenceMatcher penalized the punctuation. After normalize the
+        score clears the 0.70 protocol threshold."""
+        self.assertGreaterEqual(ssc._similarity("R.A.G.", "RAG"), 0.70)
+
+    def test_punctuation_stripped_before_similarity(self) -> None:
+        """Trailing colons / em-dashes / quotes should not penalize match."""
+        self.assertGreater(
+            ssc._similarity(
+                "Attention Is All You Need: A Transformers Story",
+                "attention is all you need a transformers story",
+            ),
+            0.95,
+        )
+
+    def test_title_normalize_collapses_whitespace(self) -> None:
+        """Multiple punctuation chars become spaces; collapse them."""
+        self.assertEqual(ssc._normalize_title("Foo,  Bar... Baz!"), "foo bar baz")
+
+
+class ResponseReadTimeoutTest(unittest.TestCase):
+    """Codex R4-2 closure: resp.read() can raise OSError/TimeoutError
+    (e.g. socket.timeout on the body read) outside the URLError handler.
+    Must be wrapped as SemanticScholarUnavailable so the migration
+    degrades gracefully rather than aborting mid-run."""
+
+    def test_response_read_oserror_raises_unavailable(self) -> None:
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        resp = MagicMock()
+        resp.read.side_effect = OSError("socket read timeout")
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", MagicMock(return_value=resp)):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "X", "doi": "10.1/y"})
+
+    def test_response_read_timeout_error_raises_unavailable(self) -> None:
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        resp = MagicMock()
+        resp.read.side_effect = TimeoutError("body read timed out")
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", MagicMock(return_value=resp)):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "X", "doi": "10.1/y"})
+
+
 class CLIWiringTest(unittest.TestCase):
     """Codex R1-1 closure: CLI was unrunnable because NotImplementedError
     fired before reading the passport. Verify the production wiring path

--- a/shared/contracts/passport/literature_corpus_entry.schema.json
+++ b/shared/contracts/passport/literature_corpus_entry.schema.json
@@ -117,6 +117,11 @@
       "type": ["string", "null"],
       "description": "v3.7.1 trust-chain field. Round identifier of the most recent codex / cross-model audit that examined this entry's description, or null / the literal string 'none' when no such audit has run. The field-level type permits both null and 'none' broadly, but per spec §3.1 firm rule #2 the rule-#2 then-branch in `allOf` tightens this to the LITERAL STRING 'none' only when source_acquired=false (no original means audit cannot be substantive — round-6 codex P2 closure). null remains valid only when source_acquired=true and the entry is simply unaudited."
     },
+    "contamination_signals_backfilled_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "v3.7.3 backfill provenance (issue #105). ISO-8601 UTC timestamp set by scripts/migrate_literature_corpus_to_v3_7_3.py when contamination_signals was computed post-hoc on a pre-v3.7.3 entry rather than at ingest time. Absence means signals were either computed at ingest by bibliography_agent v3.7.3+ or have not been computed yet. Backward compat: pre-v3.7.3 entries lack both contamination_signals and this field; ingest-time entries (v3.7.3+) lack only this field."
+    },
     "contamination_signals": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

Closes #105 — delivers the deferred batch operation v3.7.3 §3.2 R-L3-2-B promised: bibliography_agent computes contamination_signals at ingest time; this tool re-runs the check post-hoc on pre-v3.7.3 literature_corpus[] entries so legacy corpora get the v3.7.3 protection layer.

## Three pieces

- **Resolver module** `scripts/contamination_signals.py`: pure-function Signal 1 + Signal 2 + emission rules + SemanticScholarClient Protocol. Signal 1 honors both explicit `venue` and `source_pointer` URL inference (10-server closed list). Signal 2 dependency-injected SS client returns None on manual exemption + API degradation per spec.
- **Migration script** `scripts/migrate_literature_corpus_to_v3_7_3.py`: CLI `[--dry-run] [--verbose] <passport_or_dir>`. ruamel.yaml round-trip preserves comments + key order + quoting. Idempotent. Partial-fill recovery for API-degraded entries. Reports `processed / patched / skipped_already_migrated / skipped_insufficient_data / manual_unmatched_omitted` counts.
- **Schema extension**: new optional `contamination_signals_backfilled_at` ISO-8601 string. Strictly additive — pre-v3.7.3 entries + v3.7.3 ingest-time entries + migrated entries all stay valid.

Plus **`scripts/semantic_scholar_client.py`**: minimal SS API wrapper (DOI-first + title-similarity 0.70 with punctuation-stripping, 429 → 2s backoff × 3, 5xx / network / response-read failures → SemanticScholarUnavailable, S2_API_KEY env var optional). Implements `deep-research/references/semantic_scholar_api_protocol.md`.

## Codex review trajectory (gpt-5.5 xhigh, 5 rounds)

- R1 [P1]+[P2]×2: wire SS client + venue not unmigratable + partial-fill recovery
- R2 [P2]×2+[P3]: source_pointer hint + DOI fallback to title + no-op partial doesn't re-patch
- R3 [P2]+[P3]: run new tests in CI + wire --verbose flag
- R4 [P2]×2: strip punctuation before title similarity + wrap response-read OSError/TimeoutError
- R5 [P2]: record backfilled_at provenance on partial-fill recovery
  - R5-2 (SS throttle to 1 req/s) + R5-3 (latch unavailable on URLError) deferred to follow-up issue per architectural-inflection discipline — both are SS-client maturity, not #105 contract drift.

## Open-question resolutions (user-chosen 2026-05-15)

- Q1 backoff-only, no resumable checkpoint
- Q2 scalar `contamination_signals_backfilled_at` ISO-8601 timestamp
- Q3 directory-scan only, no `--input-list` batch mode
- Q4 ruamel.yaml (preserve user passport formatting)

## Boundary discipline

Files explicitly NOT touched (per v3.7.3 frozen scope):

- `deep-research/agents/bibliography_agent.md` — ingest behavior unchanged
- `academic-pipeline/agents/pipeline_orchestrator_agent.md` — finalizer unchanged
- Existing `scripts/adapters/*` — adapters produce ingest-time entries; migration is downstream

CI gains:
- `check_preprint_venues_consistency.py` lint (asserts 10-venue set agrees across `bibliography_agent.md` prose + `contamination_signals.py:PREPRINT_VENUES`)
- New `Run #105 migration unit tests` step covering 3 modules with `-v`

## Test plan

- [x] 464 unittest (25 resolver + 18 migration + 15 SS client + baseline) green
- [x] 201 pytest adapters green (3 new contamination_signals_backfilled_at schema tests)
- [x] spec_consistency + preprint_venues lints green
- [x] /simplify 3-agent pass found 5 findings, all fixed (now_iso reuse, drift lint, venue scope, counter naming, NotImplementedError handling)
- [x] Codex 5 rounds, 1 P1 + 9 P2 + 2 P3 all closed; 3 P2 (R5-2/R5-3) deferred to follow-up
- [x] Public-repo boundary scan clean
- [x] arXiv link `https://arxiv.org/abs/2605.07723` valid
- [ ] CI green (verifying after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)