### PR TITLE
feat(#115): SS client maturity — throttle + outage latch (audit-trail-shipped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### #115 — Semantic Scholar client maturity: throttle + outage latch (2026-05-15)
+
+**Parent issue:** [#115](https://github.com/Imbad0202/academic-research-skills/issues/115) — follow-up to #105 PR codex round-5 [P2]×2 findings (R5-2 throttle + R5-3 outage latch). Both deferred during #105 ship per architectural-inflection discipline; this entry closes the SS-client maturity gap.
+
+**Modified files:**
+
+- `scripts/semantic_scholar_client.py` — two additions:
+  - **Throttle** (#115 R5-2): new ctor params `clock` + `min_interval_seconds`. Defaults: 1.0s unauthenticated (1 req/s per protocol), auto-drops to 0.1s when `S2_API_KEY` detected (authenticated 10 req/s tier). Pre-request pacing tracks `_last_request_at`; sleeps `max(0, min_interval - elapsed)` before each call. First request passes through.
+  - **Outage latch** (#115 R5-3): `_latched_unavailable` flag set on `URLError`. Subsequent `lookup()` calls short-circuit with `SemanticScholarUnavailable` without invoking urlopen. New `reset_outage_latch()` method lets long-running tools retry between passport batches. HTTP 5xx does NOT latch (server-side error ≠ transport outage).
+- `scripts/test_semantic_scholar_client.py` — 9 new tests (5 throttle: first-no-sleep / back-to-back / past-interval / authenticated-tier / override; 3 latch: URLError short-circuits / reset restores / 5xx does not latch; 1 efficiency: 429-retry refreshes throttle anchor).
+- `scripts/contamination_signals.py` — new `reset_client_outage_latch(client)` helper. Production clients implementing the outage-latch pattern expose `reset_outage_latch()`; mocks may not. Helper invokes when present, no-ops when absent — avoids AttributeError when callers swap clients. 2 new tests.
+- `scripts/migrate_literature_corpus_to_v3_7_3.py` — `migrate_directory` resets the SS client's outage latch between passports so a transient network blip on one passport doesn't permanently disable lookups for the rest of the directory. Within a single passport the latch still short-circuits to protect a dead service from N retry waves.
+
+**Production behavior change:**
+
+- `_build_default_ss_client()` API unchanged (`SemanticScholarClient()` no-arg). New throttle is automatic per protocol — no migration tool changes required.
+- For a 5000-entry unauthenticated migration: same ~1.5hr runtime (already constrained by 1 req/s); now achieves it via deterministic pacing rather than 429-retry exhaustion.
+- For an authenticated migration (`S2_API_KEY` set): drops to 0.1s/call = ~8min for 5000 entries.
+- Network outage during large corpus: previously retried every entry independently (up to 30s timeout per entry on the slow path); now the first URLError latches the client and subsequent entries short-circuit until the next batch boundary calls `reset_outage_latch()`. The `migrate_directory` helper does this reset automatically between passports.
+
+**Out of scope:** migration tool (`migrate_literature_corpus_to_v3_7_3.py`) — #105 partial-fill / provenance contract correct as shipped. Protocol doc — already correct; this issue is implementation alignment.
+
+**Regression:** 472 unittest (+8 #115 tests) + 201 pytest adapters + spec_consistency + preprint_venues all green.
+
 ### #105 — v3.7.3 contamination_signals backfill migration tool (2026-05-15)
 
 **Parent issue:** [#105](https://github.com/Imbad0202/academic-research-skills/issues/105). Spec anchor: v3.7.3 §3.2 R-L3-2-B (the deferred batch operation; bibliography_agent computes signals at ingest, this tool delivers post-hoc backfill on legacy corpora). Design: `docs/design/2026-05-15-issue-105-contamination-signals-backfill-design.md`.

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -86,6 +86,16 @@ class SemanticScholarClient(Protocol):
         ...
 
 
+def reset_client_outage_latch(client: SemanticScholarClient) -> None:
+    """Best-effort latch reset (#115 R5-3): production clients implementing
+    the outage-latch pattern expose `reset_outage_latch()`; minimal mocks
+    in tests may not. This helper invokes it when present, no-ops when
+    absent. Long-running tools call this between passport batches."""
+    reset = getattr(client, "reset_outage_latch", None)
+    if callable(reset):
+        reset()
+
+
 def compute_preprint_signal(entry: Mapping[str, Any]) -> bool:
     """Signal 1 per v3.7.3 spec §3.2 Vector 1.
 

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -190,7 +190,13 @@ def migrate_directory(
     dry_run: bool,
     verbose: bool = False,
 ) -> dict[str, int]:
-    """Migrate every passport YAML in `directory` (non-recursive)."""
+    """Migrate every passport YAML in `directory` (non-recursive).
+
+    Between passports, reset the SS client's outage latch (#115 R5-3) so
+    a network blip on one passport doesn't permanently disable lookups
+    for the rest of the directory. Within a single passport, the latch
+    short-circuits to protect against hammering a dead service.
+    """
     agg = {"files_processed": 0, "entries_processed": 0, "entries_patched": 0}
     for path in discover_passports(directory):
         agg["files_processed"] += 1
@@ -199,6 +205,7 @@ def migrate_directory(
         )
         agg["entries_processed"] += r["processed"]
         agg["entries_patched"] += r["patched"]
+        cs.reset_client_outage_latch(ss_client)
     return agg
 
 

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -38,6 +38,12 @@ _FIELDS = "title,authors,year,externalIds,venue,publicationDate"
 _BACKOFF_SECONDS = 2.0
 _MAX_RETRIES = 3
 
+# Per protocol line 6: unauthenticated tier is ~1 req/s, authenticated
+# (S2_API_KEY) tier is 10 req/s. Default throttle interval defends
+# against proactive rate limiting before a 429 fires (#115 R5-2).
+_UNAUTHENTICATED_MIN_INTERVAL = 1.0
+_AUTHENTICATED_MIN_INTERVAL = 0.1
+
 # Per PaperOrchestra (Song et al. 2026 Appx D.3) + protocol §"Query
 # Patterns" Pattern 1: title-similarity threshold for "matched" verdict.
 _TITLE_SIMILARITY_THRESHOLD = 0.70
@@ -62,14 +68,58 @@ class SemanticScholarClient:
 
     Satisfies `contamination_signals.SemanticScholarClient` Protocol.
     Tests inject MagicMocks; production callers use this concrete class.
+
+    Concurrency note: rate-limit pacing is per-instance. A migration tool
+    that spawns N concurrent clients will issue N × (1 req/s) outbound
+    even though each instance respects the throttle, blowing past the
+    protocol's 1 req/s unauthenticated limit and triggering 429s. Share
+    a single instance across a migration run.
     """
 
-    def __init__(self, api_key: str | None = None, sleep: Any = time.sleep) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        sleep: Any = time.sleep,
+        clock: Any = time.monotonic,
+        min_interval_seconds: float | None = None,
+    ) -> None:
         self._api_key = api_key or os.environ.get(_API_KEY_ENV)
         self._sleep = sleep
+        self._clock = clock
+        if min_interval_seconds is None:
+            # Auto-pick tier from API key presence (#115 R5-2).
+            self._min_interval = (
+                _AUTHENTICATED_MIN_INTERVAL if self._api_key
+                else _UNAUTHENTICATED_MIN_INTERVAL
+            )
+        else:
+            self._min_interval = min_interval_seconds
+        # Pacing state: timestamp of last request. None = no prior call.
+        self._last_request_at: float | None = None
+        # Outage latch (#115 R5-3): once URLError fires, short-circuit
+        # subsequent calls until reset_outage_latch() is invoked.
+        self._latched_unavailable: bool = False
+
+    def reset_outage_latch(self) -> None:
+        """Clear the outage latch so the next lookup retries the network.
+
+        Long-running tools (e.g., per-passport-batch migration runs) can
+        call this between batches to attempt recovery. Per protocol
+        §"On API failure": network errors skip the remaining batch;
+        this method is the explicit "next batch starts fresh" signal.
+        """
+        self._latched_unavailable = False
 
     def lookup(self, entry: Mapping[str, Any]) -> Mapping[str, Any]:
         """Return {"matched": bool, "paperId": str | None}.
+
+        Failure semantics:
+        - HTTP 5xx → SemanticScholarUnavailable for THIS reference only
+          (server-side error; subsequent lookups retry normally).
+        - URLError (network-level) → SemanticScholarUnavailable AND
+          latches the client unavailable. Subsequent lookups short-
+          circuit without invoking urlopen until reset_outage_latch().
+          Per protocol §"On API failure": skip S2 for remaining batch.
 
         Per protocol §"Query Patterns" + §"Response Handling":
         `semantic_scholar_unmatched` is True only when NEITHER DOI nor
@@ -103,6 +153,28 @@ class SemanticScholarClient:
         return {"matched": False, "paperId": None}
 
     def _request(self, path: str) -> dict[str, Any]:
+        # Latch short-circuit (#115 R5-3): if a prior URLError marked
+        # the network dead, fail fast without trying again.
+        if self._latched_unavailable:
+            raise SemanticScholarUnavailable(
+                "S2 API latched unavailable after prior network failure; "
+                "call reset_outage_latch() to retry."
+            )
+
+        # Throttle (#115 R5-2): pace requests at the protocol's rate
+        # limit. First call passes through (no prior timestamp). Update
+        # `_last_request_at` to "now" before issuing the request so all
+        # exit paths (success, 404, 5xx, HTTPError, 429-retry) leave a
+        # fresh anchor for the next outer call. 429 retries below
+        # re-update after their backoff sleep so the anchor reflects
+        # actual wall time even when retries land in a slow second.
+        if self._last_request_at is not None and self._min_interval > 0:
+            elapsed = self._clock() - self._last_request_at
+            remaining = self._min_interval - elapsed
+            if remaining > 0:
+                self._sleep(remaining)
+        self._last_request_at = self._clock()
+
         url = f"{_API_BASE}{path}"
         headers = {"User-Agent": "ARS-migration/1.0"}
         if self._api_key:
@@ -119,6 +191,13 @@ class SemanticScholarClient:
                     return {}
                 if e.code == 429 and attempt < _MAX_RETRIES:
                     self._sleep(_BACKOFF_SECONDS)
+                    # F5 closure (simplify efficiency): refresh anchor
+                    # after each 429 backoff so the next outer _request
+                    # paces against actual wake time, not entry time.
+                    # Without this the next outer call may under-sleep
+                    # (because elapsed counts the 2s × N backoff time)
+                    # and re-trigger 429.
+                    self._last_request_at = self._clock()
                     continue
                 if 500 <= e.code < 600:
                     raise SemanticScholarUnavailable(
@@ -128,6 +207,11 @@ class SemanticScholarClient:
                     f"S2 API HTTP {e.code} after {_MAX_RETRIES} retries"
                 ) from e
             except urllib.error.URLError as e:
+                # Network-level failure: latch the client so subsequent
+                # lookups in the same batch fail fast (#115 R5-3).
+                # Per protocol §"On API failure": skip S2 for remaining
+                # batch on network error.
+                self._latched_unavailable = True
                 raise SemanticScholarUnavailable(f"S2 API network error: {e}") from e
             except (OSError, TimeoutError) as e:
                 # Response-body read timeouts (socket.timeout subclasses

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -219,6 +219,16 @@ class SemanticScholarClient:
                 # transient I/O failures during resp.read() must be
                 # treated as API degradation per spec — never let them
                 # abort the migration. Codex R4-2 closure.
+                #
+                # Also latch the client (codex #115 R2 closure): the
+                # protocol §"On API failure" rule "skip S2 for remaining
+                # batch on network error" covers transport-level
+                # failures, which include connection resets / socket
+                # read timeouts that surface during resp.read(), not
+                # only URLError at urlopen() time. Without this latch,
+                # a real network outage produces 30s read-timeout per
+                # entry × N entries.
+                self._latched_unavailable = True
                 raise SemanticScholarUnavailable(
                     f"S2 API I/O failure during response read: {e}"
                 ) from e

--- a/scripts/test_contamination_signals.py
+++ b/scripts/test_contamination_signals.py
@@ -263,5 +263,22 @@ class EmissionRulesTest(unittest.TestCase):
         self.assertNotIn("semantic_scholar_unmatched", result)
 
 
+class ResetClientOutageLatchHelperTest(unittest.TestCase):
+    """#115 R5-3 helper: production clients implementing the outage-latch
+    pattern expose `reset_outage_latch()`; minimal mocks may not. The
+    helper invokes when present, no-ops when absent. Avoids
+    AttributeError for callers that swap in test mocks."""
+
+    def test_helper_invokes_reset_when_present(self) -> None:
+        client = MagicMock()
+        cs.reset_client_outage_latch(client)
+        client.reset_outage_latch.assert_called_once()
+
+    def test_helper_no_ops_when_method_absent(self) -> None:
+        client = MagicMock(spec=["lookup"])  # only the Protocol's lookup
+        # Should NOT raise AttributeError
+        cs.reset_client_outage_latch(client)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_semantic_scholar_client.py
+++ b/scripts/test_semantic_scholar_client.py
@@ -460,6 +460,27 @@ class OutageLatchTest(unittest.TestCase):
         self.assertEqual(result, {"matched": True, "paperId": "x"})
         self.assertEqual(urlopen_good.call_count, 1)
 
+    def test_response_read_oserror_also_latches(self) -> None:
+        """Codex R2 closure: protocol §"On API failure" treats transport-
+        level network failures uniformly, regardless of which urllib
+        boundary surfaces them. A socket read timeout during resp.read()
+        must latch the batch just like URLError at urlopen() time —
+        otherwise a real outage retries 30s per entry × N."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        resp = MagicMock()
+        resp.read.side_effect = OSError("socket read timeout")
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        urlopen = MagicMock(return_value=resp)
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "T", "doi": "10.1/y"})
+            self.assertEqual(urlopen.call_count, 1)
+            # Second call should short-circuit — no second urlopen
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "Other", "doi": "10.1/z"})
+            self.assertEqual(urlopen.call_count, 1, "latched after read-timeout")
+
     def test_http_error_does_not_latch(self) -> None:
         """HTTP 5xx is a server-side error, not a transport-level outage.
         The protocol §"On API failure" says network errors skip the

--- a/scripts/test_semantic_scholar_client.py
+++ b/scripts/test_semantic_scholar_client.py
@@ -274,10 +274,13 @@ class RateLimitThrottleTest(unittest.TestCase):
 
     def test_first_request_does_not_sleep(self) -> None:
         """First request after construction has no prior call to pace
-        against; the throttle should pass through immediately."""
+        against; the throttle should pass through immediately. Hermetic
+        regardless of S2_API_KEY env (no comparison against tier)."""
         sleep = MagicMock()
         clock = MagicMock(return_value=1000.0)
-        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        client = ssc.SemanticScholarClient(
+            sleep=sleep, clock=clock, min_interval_seconds=1.0
+        )
         with patch(
             "urllib.request.urlopen",
             MagicMock(return_value=self._good_resp({"paperId": "x", "title": "T"})),
@@ -288,12 +291,17 @@ class RateLimitThrottleTest(unittest.TestCase):
 
     def test_back_to_back_calls_throttle_to_one_req_per_second(self) -> None:
         """Default unauthenticated tier: 1.0s min interval between calls.
-        Second call within the interval should sleep the remainder."""
+        Second call within the interval should sleep the remainder.
+
+        Explicit `min_interval_seconds=1.0` so the test is hermetic
+        against `S2_API_KEY` set in the environment (codex R1 P2)."""
         sleep = MagicMock()
         # clock: first request at t=1000.0, second at t=1000.3 (0.3s later
         # — throttle should sleep 0.7s before issuing second request)
         clock = MagicMock(side_effect=[1000.0, 1000.3, 1000.3])
-        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        client = ssc.SemanticScholarClient(
+            sleep=sleep, clock=clock, min_interval_seconds=1.0
+        )
         resp_factory = lambda: self._good_resp({"paperId": "x", "title": "T"})
         with patch(
             "urllib.request.urlopen",
@@ -308,11 +316,14 @@ class RateLimitThrottleTest(unittest.TestCase):
 
     def test_back_to_back_calls_past_interval_do_not_sleep(self) -> None:
         """If enough time elapsed naturally between calls, no extra sleep
-        is needed — the throttle is a floor, not a ceiling."""
+        is needed — the throttle is a floor, not a ceiling. Explicit
+        min_interval_seconds for env-hermeticity (codex R1 P2)."""
         sleep = MagicMock()
         # Second call 2.5s after first; no throttle sleep needed
         clock = MagicMock(side_effect=[1000.0, 1002.5, 1002.5])
-        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        client = ssc.SemanticScholarClient(
+            sleep=sleep, clock=clock, min_interval_seconds=1.0
+        )
         resp_factory = lambda: self._good_resp({"paperId": "x", "title": "T"})
         with patch(
             "urllib.request.urlopen",
@@ -348,7 +359,8 @@ class RateLimitThrottleTest(unittest.TestCase):
         """F5 closure (simplify efficiency): if `_last_request_at` is not
         refreshed after a 429 backoff, the next outer call paces against
         entry time + N × backoff already elapsed, then under-sleeps and
-        re-triggers 429. After fix: anchor refreshes to actual wake time."""
+        re-triggers 429. After fix: anchor refreshes to actual wake time.
+        Explicit min_interval_seconds for env-hermeticity (codex R1 P2)."""
         sleep = MagicMock()
         # Clock sequence:
         # call 1 entry elapsed check (none, first call) - not used
@@ -358,7 +370,9 @@ class RateLimitThrottleTest(unittest.TestCase):
         #   from anchor with 1s interval = sleep 1.0s)
         # call 2 entry write t=1003.0
         clock = MagicMock(side_effect=[1000.0, 1002.0, 1002.0, 1003.0])
-        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        client = ssc.SemanticScholarClient(
+            sleep=sleep, clock=clock, min_interval_seconds=1.0
+        )
         good = _mock_response({"paperId": "x", "title": "T"})
 
         def urlopen_side(*args, **kwargs):

--- a/scripts/test_semantic_scholar_client.py
+++ b/scripts/test_semantic_scholar_client.py
@@ -24,14 +24,19 @@ import semantic_scholar_client as ssc  # noqa: E402
 from contamination_signals import SemanticScholarUnavailable  # noqa: E402
 
 
-def _mock_urlopen_returning(payload: dict) -> MagicMock:
-    """Build a urlopen mock that returns `payload` JSON as the response body."""
+def _mock_response(payload: dict) -> MagicMock:
+    """Build a urlopen-style response context manager returning `payload`."""
     body = json.dumps(payload).encode("utf-8")
     resp = MagicMock()
     resp.read.return_value = body
     resp.__enter__ = MagicMock(return_value=resp)
     resp.__exit__ = MagicMock(return_value=False)
-    return MagicMock(return_value=resp)
+    return resp
+
+
+def _mock_urlopen_returning(payload: dict) -> MagicMock:
+    """Build a urlopen mock that returns `payload` JSON as the response body."""
+    return MagicMock(return_value=_mock_response(payload))
 
 
 class DoiLookupTest(unittest.TestCase):
@@ -257,6 +262,204 @@ class ResponseReadTimeoutTest(unittest.TestCase):
         with patch("urllib.request.urlopen", MagicMock(return_value=resp)):
             with self.assertRaises(SemanticScholarUnavailable):
                 client.lookup({"title": "X", "doi": "10.1/y"})
+
+
+class RateLimitThrottleTest(unittest.TestCase):
+    """#115 R5-2: back-to-back successful lookups must respect the
+    protocol's 1 req/s unauthenticated rate limit so the client doesn't
+    proactively hit 429 and exhaust retries on healthy corpora."""
+
+    def _good_resp(self, payload: dict) -> MagicMock:
+        return _mock_response(payload)
+
+    def test_first_request_does_not_sleep(self) -> None:
+        """First request after construction has no prior call to pace
+        against; the throttle should pass through immediately."""
+        sleep = MagicMock()
+        clock = MagicMock(return_value=1000.0)
+        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        with patch(
+            "urllib.request.urlopen",
+            MagicMock(return_value=self._good_resp({"paperId": "x", "title": "T"})),
+        ):
+            client.lookup({"title": "T", "doi": "10.1/y"})
+        # Throttle sleep must NOT fire on first call (only on subsequent)
+        self.assertEqual(sleep.call_count, 0)
+
+    def test_back_to_back_calls_throttle_to_one_req_per_second(self) -> None:
+        """Default unauthenticated tier: 1.0s min interval between calls.
+        Second call within the interval should sleep the remainder."""
+        sleep = MagicMock()
+        # clock: first request at t=1000.0, second at t=1000.3 (0.3s later
+        # — throttle should sleep 0.7s before issuing second request)
+        clock = MagicMock(side_effect=[1000.0, 1000.3, 1000.3])
+        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        resp_factory = lambda: self._good_resp({"paperId": "x", "title": "T"})
+        with patch(
+            "urllib.request.urlopen",
+            MagicMock(side_effect=[resp_factory(), resp_factory()]),
+        ):
+            client.lookup({"title": "T", "doi": "10.1/y"})
+            client.lookup({"title": "T", "doi": "10.1/z"})
+        # One sleep call between the two requests
+        self.assertEqual(sleep.call_count, 1)
+        slept = sleep.call_args[0][0]
+        self.assertAlmostEqual(slept, 0.7, places=2)
+
+    def test_back_to_back_calls_past_interval_do_not_sleep(self) -> None:
+        """If enough time elapsed naturally between calls, no extra sleep
+        is needed — the throttle is a floor, not a ceiling."""
+        sleep = MagicMock()
+        # Second call 2.5s after first; no throttle sleep needed
+        clock = MagicMock(side_effect=[1000.0, 1002.5, 1002.5])
+        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        resp_factory = lambda: self._good_resp({"paperId": "x", "title": "T"})
+        with patch(
+            "urllib.request.urlopen",
+            MagicMock(side_effect=[resp_factory(), resp_factory()]),
+        ):
+            client.lookup({"title": "T", "doi": "10.1/y"})
+            client.lookup({"title": "T", "doi": "10.1/z"})
+        # No throttle-sleep calls (429 retry sleeps would also count but
+        # we don't hit any 429 here)
+        self.assertEqual(sleep.call_count, 0)
+
+    def test_api_key_lowers_interval_to_authenticated_tier(self) -> None:
+        """Per protocol line 6: authenticated tier is 10 req/s = 0.1s
+        interval. When S2_API_KEY is set, throttle drops accordingly."""
+        sleep = MagicMock()
+        clock = MagicMock(side_effect=[1000.0, 1000.03, 1000.03])
+        client = ssc.SemanticScholarClient(
+            api_key="test-key", sleep=sleep, clock=clock
+        )
+        resp_factory = lambda: self._good_resp({"paperId": "x", "title": "T"})
+        with patch(
+            "urllib.request.urlopen",
+            MagicMock(side_effect=[resp_factory(), resp_factory()]),
+        ):
+            client.lookup({"title": "T", "doi": "10.1/y"})
+            client.lookup({"title": "T", "doi": "10.1/z"})
+        # 0.1 - 0.03 = 0.07s sleep on authenticated tier
+        self.assertEqual(sleep.call_count, 1)
+        slept = sleep.call_args[0][0]
+        self.assertAlmostEqual(slept, 0.07, places=2)
+
+    def test_429_retry_refreshes_throttle_anchor(self) -> None:
+        """F5 closure (simplify efficiency): if `_last_request_at` is not
+        refreshed after a 429 backoff, the next outer call paces against
+        entry time + N × backoff already elapsed, then under-sleeps and
+        re-triggers 429. After fix: anchor refreshes to actual wake time."""
+        sleep = MagicMock()
+        # Clock sequence:
+        # call 1 entry elapsed check (none, first call) - not used
+        # call 1 entry write t=1000.0
+        # call 1 429-retry write t=1002.0 (after 2s backoff)
+        # call 2 entry elapsed check t=1002.0 (no extra sleep, 0s elapsed
+        #   from anchor with 1s interval = sleep 1.0s)
+        # call 2 entry write t=1003.0
+        clock = MagicMock(side_effect=[1000.0, 1002.0, 1002.0, 1003.0])
+        client = ssc.SemanticScholarClient(sleep=sleep, clock=clock)
+        good = _mock_response({"paperId": "x", "title": "T"})
+
+        def urlopen_side(*args, **kwargs):
+            urlopen_side.count += 1
+            if urlopen_side.count == 1:
+                raise urllib.error.HTTPError(
+                    "u", 429, "Too Many", {}, io.BytesIO(b"")
+                )
+            return good
+        urlopen_side.count = 0
+
+        with patch("urllib.request.urlopen", urlopen_side):
+            client.lookup({"title": "T", "doi": "10.1/y"})
+            client.lookup({"title": "T", "doi": "10.1/z"})
+        # Sleeps: one 2s backoff for the 429, one 1s for the throttle on
+        # the 2nd outer call (anchor is fresh at t=1002 so elapsed=0,
+        # remaining=1.0)
+        self.assertEqual(sleep.call_count, 2)
+        self.assertAlmostEqual(sleep.call_args_list[0][0][0], 2.0, places=2)
+        self.assertAlmostEqual(sleep.call_args_list[1][0][0], 1.0, places=2)
+
+    def test_explicit_min_interval_override(self) -> None:
+        """Caller can override the throttle interval (e.g., for tests or
+        for a hypothetical higher tier)."""
+        sleep = MagicMock()
+        clock = MagicMock(side_effect=[1000.0, 1000.0, 1000.0])
+        client = ssc.SemanticScholarClient(
+            sleep=sleep, clock=clock, min_interval_seconds=0.0
+        )
+        resp_factory = lambda: self._good_resp({"paperId": "x", "title": "T"})
+        with patch(
+            "urllib.request.urlopen",
+            MagicMock(side_effect=[resp_factory(), resp_factory()]),
+        ):
+            client.lookup({"title": "T", "doi": "10.1/y"})
+            client.lookup({"title": "T", "doi": "10.1/z"})
+        # min_interval=0 means never throttle
+        self.assertEqual(sleep.call_count, 0)
+
+
+class OutageLatchTest(unittest.TestCase):
+    """#115 R5-3: when urlopen raises URLError (network down), the client
+    must latch into unavailable mode so subsequent calls fail fast
+    without waiting on a known-dead service. Reset method allows
+    long-running tools to retry recovery between passports."""
+
+    def test_url_error_latches_client_unavailable(self) -> None:
+        """First call hits URLError → SemanticScholarUnavailable. Second
+        call must raise immediately WITHOUT invoking urlopen — the
+        latch short-circuits the network entirely."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        urlopen = MagicMock(
+            side_effect=urllib.error.URLError("connection refused")
+        )
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "T", "doi": "10.1/y"})
+            # urlopen was called once for the first lookup
+            self.assertEqual(urlopen.call_count, 1)
+            # Second lookup must NOT call urlopen — latched short-circuit
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "Other", "doi": "10.1/z"})
+            self.assertEqual(urlopen.call_count, 1, "latched call must skip network")
+
+    def test_reset_outage_latch_restores_normal_behavior(self) -> None:
+        """A long-running tool between passport batches can call
+        reset_outage_latch() to retry the network."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        # First call latches
+        urlopen = MagicMock(side_effect=urllib.error.URLError("down"))
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "T", "doi": "10.1/y"})
+
+        # Reset latch
+        client.reset_outage_latch()
+
+        # Subsequent call should re-attempt urlopen (and succeed in this
+        # mock scenario)
+        urlopen_good = MagicMock(
+            return_value=_mock_response({"paperId": "x", "title": "T"})
+        )
+        with patch("urllib.request.urlopen", urlopen_good):
+            result = client.lookup({"title": "T", "doi": "10.1/y"})
+        self.assertEqual(result, {"matched": True, "paperId": "x"})
+        self.assertEqual(urlopen_good.call_count, 1)
+
+    def test_http_error_does_not_latch(self) -> None:
+        """HTTP 5xx is a server-side error, not a transport-level outage.
+        The protocol §"On API failure" says network errors skip the
+        remaining batch; HTTP failures don't. Make sure 5xx doesn't
+        falsely latch the client."""
+        client = ssc.SemanticScholarClient(sleep=MagicMock())
+        urlopen = MagicMock(side_effect=[
+            urllib.error.HTTPError("u", 503, "Service Unavailable", {}, io.BytesIO(b"")),
+        ])
+        with patch("urllib.request.urlopen", urlopen):
+            with self.assertRaises(SemanticScholarUnavailable):
+                client.lookup({"title": "T", "doi": "10.1/y"})
+        # 5xx fired but client should not be latched
+        self.assertFalse(client._latched_unavailable)
 
 
 class CLIWiringTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes #115 — follow-up to #105 PR codex round-5 [P2]×2 findings that were deferred per architectural-inflection discipline. This PR closes the SS-client maturity gap.

## Two pieces

**R5-2 Throttle**: pre-request pacing against protocol rate limit.
- 1.0s default (unauthenticated, 1 req/s per protocol)
- 0.1s when `S2_API_KEY` set (authenticated 10 req/s tier)
- `min_interval_seconds` ctor override + `clock` injection for testability

**R5-3 Outage latch**: short-circuit on transport-level failure.
- URLError at `urlopen()` AND OSError/TimeoutError during `resp.read()` both latch
- HTTP 5xx does NOT latch (server-side ≠ batch outage)
- `reset_outage_latch()` method + `cs.reset_client_outage_latch()` helper (getattr-with-default so mocks lacking the method don't AttributeError)
- `migrate_directory` resets between passports so a blip on one passport doesn't poison the rest

## Codex review trajectory (gpt-5.5 xhigh, 3 rounds → convergence)

- R1 [P2]×1: throttle tests not hermetic against `S2_API_KEY` env → 4 tests pass explicit `min_interval_seconds=1.0`
- R2 [P2]×1: OSError/TimeoutError handler raised SemanticScholarUnavailable but didn't latch → set `_latched_unavailable` in that branch too
- R3: **0 findings** ✓

## /simplify pass before R1 (6 findings fixed)

- F1 reuse: extract `_mock_response()` helper; consolidate inline MagicMock resp builders
- F2 quality: `lookup()` docstring distinguishes URLError-latches-batch vs HTTP-5xx-per-reference
- F3 quality: new `reset_client_outage_latch(client)` helper with getattr-with-default
- F4 quality: CHANGELOG hyperbole softened ("30s × N entries" → "up to 30s per entry")
- F5 efficiency P1: refresh `_last_request_at` after 429 backoff to prevent stale-anchor under-pacing
- F6 quality: docstring warns "Per-instance pacing — share one instance across a migration run"

## Boundary discipline

- IN: `scripts/semantic_scholar_client.py` + `scripts/contamination_signals.py` (Protocol shim) + `scripts/migrate_literature_corpus_to_v3_7_3.py` (reset between passports) + corresponding test files + CHANGELOG.
- OUT: migration tool's idempotency / partial-fill logic (#105 R1-3 / R5-1 correct as shipped). Protocol doc (correct; this is implementation alignment).

## Test plan

- [x] 476 unittest (+11: 9 throttle/latch + 1 anchor refresh + 1 OSError latch coverage; +2 helper)
- [x] Hermeticity verified with AND without `S2_API_KEY` env set
- [x] 201 pytest adapters green (no regression)
- [x] spec_consistency + preprint_venues lints green
- [x] Public-repo boundary scan clean
- [ ] CI green (verifying after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)