### PR TITLE
v3.9.1: client hardening — wrap response-read failures (#129) + manifest_id guard (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.9.1] - 2026-05-18 — v3.9.0 client hardening (#129 + #130)
+
+Two-bug hotfix surfaced by codex review of `ars-codex` PR #13 (vendor sync to v3.9.0 `74413a4`). Both bugs exist in v3.9.0 main: #129 violates the v3.9.0 §3.7 per-API degradation contract; #130 crashes a defensive lint on malformed input. Neither changes the spec or schema.
+
+### Fixed
+
+- **#129 — OpenAlex / Crossref response-read failures now translate to `*Unavailable`.** In `scripts/openalex_client.py:_get` and `scripts/crossref_client.py:_get`, `urlopen` succeeded but `resp.read()` / `body.decode("utf-8")` / `json.loads()` failures (socket drop mid-stream, garbled UTF-8 body, HTML 503 page returned with 200 status) escaped the client as raw `OSError` / `UnicodeDecodeError` / `JSONDecodeError`. `scripts/migrate_literature_corpus_to_v3_9_0.py` only catches `OpenAlexUnavailable` / `CrossrefUnavailable`, so one transient response failure during a 500-entry backfill aborted the whole migration instead of dropping just the affected field. Narrow except block around read+decode+parse now mirrors the existing 5xx-skip pattern: per-API tolerant per the v3.9.0 spec §3.7 documented degradation contract and `bibliography_agent.md` "Triangulation Extension".
+
+- **#130 — `check_claim_audit_consistency` non-string `manifest_id` guard.** `_build_manifest_index` (line 644) and `_build_manifest_constraint_index` (line 675) used `manifest_id` as a dict key via `setdefault(mid, set())` / `out[mid] = bucket` before checking type. For malformed passports where the schema validator already noted `manifest_id` as `array` / `object`, the index builder raised `TypeError: unhashable type: 'list'` and terminated lint with a traceback before `validate_passport()` could return the schema finding cleanly. Added `isinstance(mid, str) and mid` guard at both sites, matching the surrounding `_check_inv_17_for_manifest` / `claim_id` invariant-walker pattern. Schema validator still records the type mismatch — the guard just lets the lint surface findings cleanly instead of crashing.
+
+### Tests
+
+- `scripts/test_openalex_client.py`: +3 tests covering OSError on `resp.read()`, invalid UTF-8 body, invalid JSON body.
+- `scripts/test_crossref_client.py`: +3 symmetric tests.
+- `scripts/test_claim_audit_schema.py`: new `TSManifestIdNonStringGuard` class with 2 tests (`manifest_id` as list / dict).
+- Regression baseline: 1453 → 1461 passed (+8), 3 skipped + 111 subtests unchanged, 0 failures.
+
+### Out of scope
+
+- Spec / schema / CHANGELOG narrative not touched — the degradation contract is already documented in spec §3.7; this just makes code honor it.
+- `ars-codex` adapter sibling: the same two fixes will surface on next vendor sync (v3.9.1 → ars-codex v0.1.8). No action needed in this release.
+
+---
+
 ## [3.9.0] - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,16 @@ Two-bug hotfix surfaced by codex review of `ars-codex` PR #13 (vendor sync to v3
 
 ### Fixed
 
-- **#129 — OpenAlex / Crossref response-read failures now translate to `*Unavailable`.** In `scripts/openalex_client.py:_get` and `scripts/crossref_client.py:_get`, `urlopen` succeeded but `resp.read()` / `body.decode("utf-8")` / `json.loads()` failures (socket drop mid-stream, garbled UTF-8 body, HTML 503 page returned with 200 status) escaped the client as raw `OSError` / `UnicodeDecodeError` / `JSONDecodeError`. `scripts/migrate_literature_corpus_to_v3_9_0.py` only catches `OpenAlexUnavailable` / `CrossrefUnavailable`, so one transient response failure during a 500-entry backfill aborted the whole migration instead of dropping just the affected field. Narrow except block around read+decode+parse now mirrors the existing 5xx-skip pattern: per-API tolerant per the v3.9.0 spec §3.7 documented degradation contract and `bibliography_agent.md` "Triangulation Extension".
+- **#129 — OpenAlex / Crossref response-read failures now translate to `*Unavailable`.** In `scripts/openalex_client.py:_get` and `scripts/crossref_client.py:_get`, `urlopen` succeeded but `resp.read()` / `body.decode("utf-8")` / `json.loads()` failures (socket drop mid-stream, truncated body, garbled UTF-8 body, HTML 503 page returned with 200 status) escaped the client as raw `OSError` / `http.client.IncompleteRead` / `UnicodeDecodeError` / `JSONDecodeError`. `scripts/migrate_literature_corpus_to_v3_9_0.py` only catches `OpenAlexUnavailable` / `CrossrefUnavailable`, so one transient response failure during a 500-entry backfill aborted the whole migration instead of dropping just the affected field. Narrow except block around read+decode+parse now catches `(OSError, http.client.HTTPException, UnicodeDecodeError, json.JSONDecodeError)` — `HTTPException` covers `IncompleteRead` (canonical mid-stream socket drop, inherits HTTPException not OSError, R1 codex P2 closure). Mirrors the existing 5xx-skip pattern: per-API tolerant per the v3.9.0 spec §3.7 documented degradation contract and `bibliography_agent.md` "Triangulation Extension".
 
 - **#130 — `check_claim_audit_consistency` non-string `manifest_id` guard.** `_build_manifest_index` (line 644) and `_build_manifest_constraint_index` (line 675) used `manifest_id` as a dict key via `setdefault(mid, set())` / `out[mid] = bucket` before checking type. For malformed passports where the schema validator already noted `manifest_id` as `array` / `object`, the index builder raised `TypeError: unhashable type: 'list'` and terminated lint with a traceback before `validate_passport()` could return the schema finding cleanly. Added `isinstance(mid, str) and mid` guard at both sites, matching the surrounding `_check_inv_17_for_manifest` / `claim_id` invariant-walker pattern. Schema validator still records the type mismatch — the guard just lets the lint surface findings cleanly instead of crashing.
 
 ### Tests
 
-- `scripts/test_openalex_client.py`: +3 tests covering OSError on `resp.read()`, invalid UTF-8 body, invalid JSON body.
-- `scripts/test_crossref_client.py`: +3 symmetric tests.
+- `scripts/test_openalex_client.py`: +4 tests covering OSError on `resp.read()`, invalid UTF-8 body, invalid JSON body, and `http.client.IncompleteRead` (R1 codex P2 closure).
+- `scripts/test_crossref_client.py`: +4 symmetric tests.
 - `scripts/test_claim_audit_schema.py`: new `TSManifestIdNonStringGuard` class with 2 tests (`manifest_id` as list / dict).
-- Regression baseline: 1453 → 1461 passed (+8), 3 skipped + 111 subtests unchanged, 0 failures.
+- Regression baseline: 1453 → 1463 passed (+10), 3 skipped + 111 subtests unchanged, 0 failures.
 
 ### Out of scope
 

--- a/scripts/check_claim_audit_consistency.py
+++ b/scripts/check_claim_audit_consistency.py
@@ -639,7 +639,11 @@ def _build_manifest_index(manifests: list[dict[str, Any]]) -> dict[str, set[str]
     index: dict[str, set[str]] = {}
     for m in manifests:
         mid = m.get("manifest_id")
-        if mid is None:
+        # #130: skip non-string manifest_id (list/dict would raise
+        # TypeError: unhashable type on setdefault). Schema validator
+        # already records the type mismatch as a separate finding;
+        # the cross-field invariant pass just needs to walk past it.
+        if not isinstance(mid, str) or not mid:
             continue
         index.setdefault(mid, set())
         for c in _iter_dicts(m.get("claims")):
@@ -659,7 +663,9 @@ def _build_manifest_constraint_index(
     out: dict[str, dict[str, dict[str, Any]]] = {}
     for m in manifests:
         mid = m.get("manifest_id")
-        if mid is None:
+        # #130: same guard as _build_manifest_index — non-string mid
+        # would raise TypeError on `out[mid] = bucket` (unhashable).
+        if not isinstance(mid, str) or not mid:
             continue
         bucket: dict[str, dict[str, Any]] = {}
         for mnc in _iter_dicts(m.get("manifest_negative_constraints")):

--- a/scripts/crossref_client.py
+++ b/scripts/crossref_client.py
@@ -112,7 +112,20 @@ class CrossrefClient:
         for attempt in range(_MAX_RETRIES + 1):
             try:
                 with urllib.request.urlopen(req, timeout=30) as resp:
-                    return json.loads(resp.read().decode("utf-8"))
+                    # Wrap response body read + decode + parse in a narrow
+                    # except so transient socket drops mid-stream, garbled
+                    # bodies, or HTML error pages slipped through with 200
+                    # status surface as CrossrefUnavailable — honoring the
+                    # v3.9.0 spec §3.7 per-API degradation contract (one
+                    # transient failure must drop only crossref_unmatched,
+                    # not abort the whole backfill). Mirrors openalex_client.
+                    try:
+                        body = resp.read()
+                        return json.loads(body.decode("utf-8"))
+                    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+                        raise CrossrefUnavailable(
+                            f"Crossref response read/parse failed: {e}"
+                        ) from e
             except urllib.error.HTTPError as e:
                 if e.code == 404:
                     return {}

--- a/scripts/crossref_client.py
+++ b/scripts/crossref_client.py
@@ -14,6 +14,7 @@ nested under `message`; title is a list (multi-language variants).
 """
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import string
@@ -122,7 +123,16 @@ class CrossrefClient:
                     try:
                         body = resp.read()
                         return json.loads(body.decode("utf-8"))
-                    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+                    except (
+                        OSError,
+                        http.client.HTTPException,
+                        UnicodeDecodeError,
+                        json.JSONDecodeError,
+                    ) as e:
+                        # http.client.HTTPException covers IncompleteRead
+                        # (truncated body — canonical mid-stream socket drop)
+                        # which inherits HTTPException, not OSError. Codex
+                        # review v3.9.1 R1 P2.
                         raise CrossrefUnavailable(
                             f"Crossref response read/parse failed: {e}"
                         ) from e

--- a/scripts/openalex_client.py
+++ b/scripts/openalex_client.py
@@ -82,7 +82,20 @@ class OpenAlexClient:
         for attempt in range(_MAX_RETRIES + 1):
             try:
                 with urllib.request.urlopen(req, timeout=30) as resp:
-                    return json.loads(resp.read().decode("utf-8"))
+                    # Wrap response body read + decode + parse in a narrow
+                    # except so transient socket drops mid-stream, garbled
+                    # bodies, or HTML error pages slipped through with 200
+                    # status surface as OpenAlexUnavailable — honoring the
+                    # v3.9.0 spec §3.7 per-API degradation contract (one
+                    # transient failure must drop only openalex_unmatched,
+                    # not abort the whole backfill).
+                    try:
+                        body = resp.read()
+                        return json.loads(body.decode("utf-8"))
+                    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+                        raise OpenAlexUnavailable(
+                            f"OpenAlex response read/parse failed: {e}"
+                        ) from e
             except urllib.error.HTTPError as e:
                 if e.code == 404:
                     return {}

--- a/scripts/openalex_client.py
+++ b/scripts/openalex_client.py
@@ -9,6 +9,7 @@ title cross-check (DOI_MISMATCH pattern), title-similarity fallback,
 """
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import string
@@ -92,7 +93,16 @@ class OpenAlexClient:
                     try:
                         body = resp.read()
                         return json.loads(body.decode("utf-8"))
-                    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+                    except (
+                        OSError,
+                        http.client.HTTPException,
+                        UnicodeDecodeError,
+                        json.JSONDecodeError,
+                    ) as e:
+                        # http.client.HTTPException covers IncompleteRead
+                        # (truncated body — canonical mid-stream socket drop)
+                        # which inherits HTTPException, not OSError. Codex
+                        # review v3.9.1 R1 P2.
                         raise OpenAlexUnavailable(
                             f"OpenAlex response read/parse failed: {e}"
                         ) from e

--- a/scripts/test_claim_audit_schema.py
+++ b/scripts/test_claim_audit_schema.py
@@ -1610,5 +1610,39 @@ class TS9MalformedPassportGuard(_LintTestBase):
         self.assertIn("schema", out, msg=f"expected schema finding:\n{out}")
 
 
+# v3.9.1 / #130 — manifest_id non-string guard in _build_manifest_index +
+# _build_manifest_constraint_index. Schema validator records the type
+# mismatch finding; the index builders must skip non-string IDs cleanly
+# instead of raising TypeError("unhashable type") on setdefault() / [mid]=.
+class TSManifestIdNonStringGuard(_LintTestBase):
+    """Issue #130: manifest_id of type list/dict must not crash index builders."""
+
+    def test_manifest_id_as_list_does_not_crash(self) -> None:
+        body = build_passport()
+        body["claim_intent_manifests"][0]["manifest_id"] = ["oops"]
+        path = write_passport(self.tmp, body)
+        code, out, err = run_lint(path)
+        self.assertEqual(code, 1, msg=f"expected exit=1; got {code}\nstderr:\n{err}")
+        self.assertNotIn(
+            "Traceback",
+            err,
+            msg=f"lint must not crash on list manifest_id (unhashable in setdefault):\n{err}",
+        )
+        self.assertIn("schema", out, msg=f"expected schema finding:\n{out}")
+
+    def test_manifest_id_as_dict_does_not_crash(self) -> None:
+        body = build_passport()
+        body["claim_intent_manifests"][0]["manifest_id"] = {"oops": "dict id"}
+        path = write_passport(self.tmp, body)
+        code, out, err = run_lint(path)
+        self.assertEqual(code, 1, msg=f"expected exit=1; got {code}\nstderr:\n{err}")
+        self.assertNotIn(
+            "Traceback",
+            err,
+            msg=f"lint must not crash on dict manifest_id (unhashable in setdefault):\n{err}",
+        )
+        self.assertIn("schema", out, msg=f"expected schema finding:\n{out}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_crossref_client.py
+++ b/scripts/test_crossref_client.py
@@ -223,3 +223,57 @@ def test_polite_pool_email_in_user_agent(monkeypatch):
         client.title_search("any title")
 
     assert any("mailto:test@example.com" in ua for ua in captured_headers)
+
+
+# ---------- v3.9.1: #129 response-read failure wrapping (Crossref) ----------
+
+
+def test_oserror_during_read_raises_unavailable(monkeypatch):
+    """urlopen succeeds, but resp.read() raises OSError (socket drop / timeout
+    mid-stream). Per v3.9.0 spec §3.7 degradation contract, this MUST be
+    translated to CrossrefUnavailable so migrate_literature_corpus_to_v3_9_0
+    omits crossref_unmatched instead of aborting the whole backfill."""
+    from crossref_client import CrossrefClient, CrossrefUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = OSError("socket dropped mid-read")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = CrossrefClient()
+        with pytest.raises(CrossrefUnavailable):
+            client.title_search("any title")
+
+
+def test_invalid_utf8_body_raises_unavailable(monkeypatch):
+    """resp.read() returns bytes that aren't valid UTF-8. Per v3.9.0 spec §3.7,
+    translate to CrossrefUnavailable not bubble UnicodeDecodeError."""
+    from crossref_client import CrossrefClient, CrossrefUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"\xff\xfe\xff garbage"
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = CrossrefClient()
+        with pytest.raises(CrossrefUnavailable):
+            client.title_search("any title")
+
+
+def test_invalid_json_body_raises_unavailable(monkeypatch):
+    """resp.read() returns valid utf-8 but not valid JSON (truncated body /
+    HTML error page). Per v3.9.0 spec §3.7, translate to CrossrefUnavailable
+    not bubble JSONDecodeError."""
+    from crossref_client import CrossrefClient, CrossrefUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"<html>503 backend unavailable</html>"
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = CrossrefClient()
+        with pytest.raises(CrossrefUnavailable):
+            client.title_search("any title")

--- a/scripts/test_crossref_client.py
+++ b/scripts/test_crossref_client.py
@@ -277,3 +277,24 @@ def test_invalid_json_body_raises_unavailable(monkeypatch):
         client = CrossrefClient()
         with pytest.raises(CrossrefUnavailable):
             client.title_search("any title")
+
+
+def test_truncated_read_raises_unavailable(monkeypatch):
+    """http.client.IncompleteRead = mid-stream socket drop (200 + truncated
+    body). Inherits HTTPException not OSError. v3.9.1 codex R1 P2 — symmetric
+    to OpenAlex client."""
+    import http.client
+
+    from crossref_client import CrossrefClient, CrossrefUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = http.client.IncompleteRead(
+        partial=b'{"message":', expected=200
+    )
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = CrossrefClient()
+        with pytest.raises(CrossrefUnavailable):
+            client.title_search("any title")

--- a/scripts/test_openalex_client.py
+++ b/scripts/test_openalex_client.py
@@ -218,3 +218,58 @@ def test_title_search_prefers_matching_year(monkeypatch):
 
     assert result is not None
     assert result["publication_year"] == 2017
+
+
+# ---------- v3.9.1: #129 response-read failure wrapping ----------
+
+
+def test_oserror_during_read_raises_unavailable(monkeypatch):
+    """urlopen succeeds, but resp.read() raises OSError (socket drop / timeout
+    mid-stream). Per v3.9.0 spec §3.7 degradation contract, this MUST be
+    translated to OpenAlexUnavailable so migrate_literature_corpus_to_v3_9_0
+    omits openalex_unmatched instead of aborting the whole backfill."""
+    from openalex_client import OpenAlexClient, OpenAlexUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = OSError("socket dropped mid-read")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = OpenAlexClient()
+        with pytest.raises(OpenAlexUnavailable):
+            client.title_search("any title")
+
+
+def test_invalid_utf8_body_raises_unavailable(monkeypatch):
+    """resp.read() returns bytes that aren't valid UTF-8 (garbled CDN response).
+    Per v3.9.0 spec §3.7, translate to OpenAlexUnavailable not bubble out as
+    UnicodeDecodeError."""
+    from openalex_client import OpenAlexClient, OpenAlexUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"\xff\xfe\xff garbage"
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = OpenAlexClient()
+        with pytest.raises(OpenAlexUnavailable):
+            client.title_search("any title")
+
+
+def test_invalid_json_body_raises_unavailable(monkeypatch):
+    """resp.read() returns valid utf-8 but not valid JSON (e.g. truncated body,
+    HTML error page slipped through). Per v3.9.0 spec §3.7, translate to
+    OpenAlexUnavailable not bubble JSONDecodeError."""
+    from openalex_client import OpenAlexClient, OpenAlexUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"<html>503 backend unavailable</html>"
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = OpenAlexClient()
+        with pytest.raises(OpenAlexUnavailable):
+            client.title_search("any title")

--- a/scripts/test_openalex_client.py
+++ b/scripts/test_openalex_client.py
@@ -273,3 +273,26 @@ def test_invalid_json_body_raises_unavailable(monkeypatch):
         client = OpenAlexClient()
         with pytest.raises(OpenAlexUnavailable):
             client.title_search("any title")
+
+
+def test_truncated_read_raises_unavailable(monkeypatch):
+    """http.client.IncompleteRead is the canonical mid-stream socket-drop
+    exception (200 status with truncated body). Inherits HTTPException, NOT
+    OSError — so an OSError-only handler still lets it escape. v3.9.1 codex
+    R1 P2: catch this explicitly to honor the v3.9.0 §3.7 per-API
+    degradation contract."""
+    import http.client
+
+    from openalex_client import OpenAlexClient, OpenAlexUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = http.client.IncompleteRead(
+        partial=b'{"results":', expected=200
+    )
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = OpenAlexClient()
+        with pytest.raises(OpenAlexUnavailable):
+            client.title_search("any title")


### PR DESCRIPTION
## Summary

Two-bug hotfix surfaced by codex review of `ars-codex` PR #13 (vendor sync to v3.9.0 `74413a4`). Both bugs exist on v3.9.0 main; neither changes spec or schema.

- **#129** — OpenAlex / Crossref `_get` had narrow `try` covering urlopen errors but left `resp.read()` / `.decode()` / `json.loads()` unwrapped. Transient socket drops, truncated bodies (`http.client.IncompleteRead`), garbled UTF-8, HTML 503 pages with 200 status escaped as raw exceptions instead of `OpenAlexUnavailable` / `CrossrefUnavailable`. Migration aborts whole backfill on one transient failure instead of dropping just the affected field per v3.9.0 spec §3.7 degradation contract. Fix wraps read+decode+parse with `(OSError, http.client.HTTPException, UnicodeDecodeError, json.JSONDecodeError)`.

- **#130** — `check_claim_audit_consistency._build_manifest_index` (line 644) and `_build_manifest_constraint_index` (line 675) used `manifest_id` as dict key via `setdefault` / `out[mid]=` before type check. Malformed passports with `manifest_id` as list/dict crashed lint with `TypeError: unhashable type` before `validate_passport()` could return clean schema finding. Fix adds `isinstance(mid, str) and mid` guard at both sites.

## Codex review trail

- R1 (xhigh) on `a8f473e`: **1 P2** — `http.client.IncompleteRead` inherits `HTTPException` not `OSError`; canonical mid-stream socket drop still escaping. Closed in `b5e92e4`.
- R2 (xhigh) on `b5e92e4`: **0 findings**, gate PASS.

## Test plan

- [x] TDD'd both bugs: RED test first, watched fail with expected exception, then GREEN.
- [x] +3 OpenAlex tests + +3 Crossref tests for #129 (OSError on read, invalid utf-8, invalid json).
- [x] +1 OpenAlex test + +1 Crossref test for R1 P2 closure (`IncompleteRead`).
- [x] +2 `TSManifestIdNonStringGuard` tests for #130 (list / dict manifest_id).
- [x] Baseline 1453 → **1463 passed** (+10), 3 skipped + 111 subtests unchanged, **0 regression**.
- [x] Personal-boundary lint: **exit 0**, 0 violation.
- [x] Codex review xhigh ×2 rounds, ship gate PASS.

Closes #129
Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)