### PR TITLE
v3.9.2: Phase scope inflation hot-fix (#133)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "academic-research-skills",
-  "version": "3.8.2",
-  "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 32-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate.",
+  "version": "3.9.2",
+  "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 38-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.9.2 phase boundary fence (#133).",
   "author": {
     "name": "Cheng-I Wu",
     "url": "https://github.com/Imbad0202"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,10 +6,10 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 
 | Skill | Purpose | Key Modes |
 |-------|---------|-----------|
-| `deep-research` v2.9.3 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
-| `academic-paper` v3.1.1 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
-| `academic-paper-reviewer` v1.9.0 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.9.0 | Full pipeline orchestrator | (coordinates all above) |
+| `deep-research` v2.9.4 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
+| `academic-paper` v3.1.2 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
+| `academic-paper-reviewer` v1.9.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
+| `academic-pipeline` v3.9.2 | Full pipeline orchestrator | (coordinates all above) |
 
 ## v3.7.3 Key Additions (in progress)
 
@@ -230,7 +230,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.9.0 (per CHANGELOG.md)
-- **Last Updated**: 2026-05-17
+- **Suite version**: 3.9.2 (per CHANGELOG.md)
+- **Last Updated**: 2026-05-18
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,7 +166,7 @@ Spec: `docs/design/2026-05-17-ars-v3.9.0-cross-index-triangulation-measurement-s
 
 **Routing precedence:** This section runs BEFORE Routing Rules 1-5. Once this section settles on a destination, Rules 1-5 apply within that destination's skill family.
 
-**Step 0 — Escape hatch check (before any classification):** If the user's first message begins with `[direct-mode]` (case-insensitive byte-0 token, surrounded by optional whitespace), record this fact, strip the prefix from the message, and skip directly to Step 3 explicit-intent handling. The literal `[direct-mode]` is NOT passed through to the dispatched agent.
+**Step 0 — Escape hatch check (before any classification):** If the user's first message begins with `[direct-mode]` (case-insensitive byte-0 token, optionally preceded by whitespace/newlines that are stripped on parse), record this fact, strip the prefix and surrounding whitespace from the message, and skip directly to **Step 1 explicit-intent handling** on the stripped content. The literal `[direct-mode]` is NOT passed through to the dispatched agent. If the stripped message itself has no clear skill named, Step 1 falls through to Step 3 clarification (the escape hatch bypasses cross-phase clarification (Step 2), not all routing).
 
 Otherwise, classify the user's input:
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -162,6 +162,28 @@ Spec: `docs/design/2026-05-17-ars-v3.9.0-cross-index-triangulation-measurement-s
 - **Cross-model verification** (optional): Set `ARS_CROSS_MODEL` env var to enable GPT-5.4 Pro or Gemini 3.1 Pro for integrity sample checks and independent Devil's Advocate critique. Peer-review sixth-reviewer support remains planned. See `shared/cross_model_verification.md`.
 - **AI Self-Reflection Report**: Pipeline Stage 6 now includes AI behavioral self-assessment (concession rate, health alerts, sycophancy risk rating).
 
+## Routing Discipline (v3.9.2)
+
+**Routing precedence:** This section runs BEFORE Routing Rules 1-5. Once this section settles on a destination, Rules 1-5 apply within that destination's skill family.
+
+**Step 0 — Escape hatch check (before any classification):** If the user's first message begins with `[direct-mode]` (case-insensitive byte-0 token, surrounded by optional whitespace), record this fact, strip the prefix from the message, and skip directly to Step 3 explicit-intent handling. The literal `[direct-mode]` is NOT passed through to the dispatched agent.
+
+Otherwise, classify the user's input:
+
+1. **Explicit clear intent** — user invokes a specific skill via `/ars-*` slash command, or uses an unambiguous trigger keyword that maps to a single skill (e.g., "lit-review this", "review my paper", "draft an abstract"):
+   → Route directly; no clarification, no orchestrator detour.
+
+2. **Cross-phase materials detected** — user provides artifacts spanning ≥ 2 pipeline phases without naming a specific skill (e.g., pre-written abstract + pre-collected literature; full draft + reviewer comments + bibliography):
+   → **Clarify**. Do NOT auto-route to a single-phase agent. List candidate workflows as a-d options in markdown body (NOT via AskUserQuestion tool). See `shared/references/intent_clarification_protocol.md` for the message template.
+   → Reason: clarification is the safest action when materials don't unambiguously identify intent. (v3.10 active conductor (#134) will handle this via structured intake; v3.9.2 asks.)
+
+3. **Ambiguous intent, no materials** — user provides no artifacts and no clear request:
+   → Clarify per `shared/references/intent_clarification_protocol.md`.
+
+**Anti-pattern (caused #133):** Receiving ambiguous cross-phase materials and silently auto-routing to a single-phase agent based on which phase the materials "look closest to." This bypasses orchestrator-level reconciliation and lets the subagent inherit the full ambiguity without independent oversight.
+
+**Forward note (v3.10):** Active conductor (#134) will reframe this gate as structured intake with task envelope dispatch. v3.9.2 ships clarification-only as interim hot-fix.
+
 ## Routing Rules
 
 1. **academic-pipeline vs individual skills**: academic-pipeline = full pipeline orchestrator (research → write → integrity → review → revise → final integrity → finalize). If the user only needs a single function (just research, just write, just review), trigger the corresponding skill directly without the pipeline.

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -220,6 +220,29 @@ jobs:
           python scripts/check_v3_9_0_triangulation.py
           pytest scripts/test_check_v3_9_0_triangulation.py -v
 
+      - name: Run v3.9.2 Phase Boundary coverage lint (#133)
+        # Enforces 22 Bucket A agents have ## Phase Boundary (v3.9.2)
+        # block, 16 Bucket B/C/D agents DON'T, and each Bucket A block
+        # contains the four load-bearing phrases (Phase Boundary v3.9.2,
+        # MUST NOT, MAY READ, Enforcement v3.9.2). See
+        # docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md.
+        env:
+          PYTHONPATH: .
+        run: |
+          pip install pytest
+          python3 scripts/check_v3_9_2_phase_boundary.py
+          pytest scripts/test_check_v3_9_2_phase_boundary.py -v
+
+      - name: Run v3.9.2 pipeline integrity advisory verifier tests (#133)
+        # Tests for scripts/check_pipeline_integrity.py — the post-hoc
+        # advisory verifier that flags #133-pattern Phase 5 outputs
+        # missing independent reviewer attribution.
+        env:
+          PYTHONPATH: .
+        run: |
+          pip install pytest
+          pytest scripts/test_check_pipeline_integrity.py -v
+
       - name: Run v3.8 annotation-literal sync lint (#103)
         # Step 8 /simplify reuse P2-1: lint pins that every
         # ANNOTATION_HIGH_WARN_* literal in scripts/claim_audit_finalizer.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.9.2] - 2026-05-18 — Phase boundary hot-fix (#133)
+
+Hot-fix for issue #133 (phase scope inflation). A user incident showed that ARS auto-dispatched a single-phase agent (`bibliography_agent`) when given ambiguous cross-phase input (pre-written abstract + pre-collected literature), and the dispatched agent then autonomously executed Phases 3-6, skipping mandatory independent crosschecks (DA / EIC / Ethics).
+
+This release ships the prompt-discipline + advisory-verifier hot-fix. The deterministic gate (PreToolUse hook + multi-phase task envelope schema + author provenance) is tracked separately as **v3.10 active conductor (#134)** — long-term architectural fix.
+
+Design history: 4 design rounds (v1-v4) + mid-impl review. Triple-track reviewer use cases (codex `review --base main` + inline opus subagent + self-review). Codex 0.130 broke on this repo context 5x consecutive per memory `feedback_codex_0_130_docs_review_broken.md` (49 files / 1529 lines on full branch is firmly in the broken corner); inline opus was the substantive reviewer throughout. Net effect: design has been challenged thoroughly; honest framing applied where prompt-only mitigation is known insufficient.
+
+### Added
+
+- **Routing Discipline (Phase L1)** — `.claude/CLAUDE.md` gains a new "Routing Discipline (v3.9.2)" section before existing Routing Rules 1-5. 3 routing classes: explicit intent → proceed directly; cross-phase materials → clarify with a-d options; no-materials ambiguous → clarify. `[direct-mode]` byte-0 escape hatch (case-insensitive; bracket-form strict). Anti-pattern explicitly named.
+- **Intent clarification protocol** — new `shared/references/intent_clarification_protocol.md` (~200 lines): trigger condition table, pipeline phase reference (Phase 0-7 marker conventions), clarification message template (a-d options, no AskUserQuestion tool), `[direct-mode]` mechanism spec with 5 worked examples, v3.10 carry-over notes.
+- **Phase Boundary block on 22 Bucket A agents (Phase 1)** — single-phase agents (deep-research × 9, academic-paper × 7, academic-paper-reviewer × 6) gain a `## Phase Boundary (v3.9.2)` block customized per agent: phase number, deliverable type, MUST-NOT cross-phase writes, MAY-READ upstream context (Phase 5 reviewers granted explicit cross-phase READ for review), explicit coexistence with skill-specific protocols (v3.6.2 / v3.6.5 / v3.6.6 / v3.6.7 / v3.7.1). 16 Bucket B/C/D agents (multi-phase / phase-orthogonal / cross-phase-meta) intentionally NOT fenced — honest framing per opus HIGH-2 (placebo prose creates false-enforcement illusion).
+- **Phase-by-phase invocation contract (Phase 3)** — 4 SKILL.md files gain a "Phase-by-phase Invocation Contract (v3.9.2)" section: Mode A (orchestrator-driven, default) vs Mode B (phase-by-phase cross-session resume), Bucket A enforcement scope, coexistence with skill-specific protocols.
+- **Advisory verifier (Phase 4)** — new `scripts/check_pipeline_integrity.py`: scans working directory for `phaseN_*/` (N=1-6), flags STRUCTURAL finding when phase5 dir lacks DA/EIC/Ethics filenames (the #133 pattern). HEURISTIC adjacent-phase-mtime rule (`--strict`, default OFF). Cross-platform, user-invokable, advisory output (exit 0 on findings), JSON + text output modes. Normative filename convention documented; v3.10 envelope provenance replaces filename matching.
+- **Phase Boundary coverage lint (Phase 5)** — new `scripts/check_v3_9_2_phase_boundary.py`: enforces 22 Bucket A agents have block, 16 Bucket B/C/D agents don't, and each Bucket A block contains 4 load-bearing phrases (Phase Boundary v3.9.2, MUST NOT, MAY READ, Enforcement v3.9.2). Wired to `.github/workflows/spec-consistency.yml`.
+- **Classification spec** — new `docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md`: canonical 38-agent table with 4-bucket model (A=22, B=4, C=8, D=4) + per-agent out-of-scope inflation risk column.
+- **8 behavioral smoke test fixtures** — `tests/fixtures/issue_133_routing/`: cross-phase abstract+lit (the #133 root case), single-phase explicit, no-materials ambiguous, /ars-slash command, `[direct-mode]` byte-0 honored, mid-message NOT honored, case-insensitive accepted, full draft+abstract+lit+reviews. Honestly framed as LLM-behavior assertions with cross-model spot-check criterion (100% Opus 4.7, ≥75% Sonnet 4.6 + GPT-5.5).
+- **Plugin metadata bump** — `.claude-plugin/plugin.json` version 3.8.2 → 3.9.2 (was stale; also catches v3.9.0 + v3.9.1 deferrals); description updated for 38-agent ensemble and v3.9.2 phase boundary feature.
+
+### Fixed
+
+- **`.claude/CLAUDE.md` Suite version was stale at 3.9.0** — v3.9.1 ship missed bumping it (latent lint bug surfaced during v3.9.2 work). v3.9.2 atomic bump fixes this.
+
+### Tests
+
+- 12 new tests in `scripts/test_check_pipeline_integrity.py` (verifier).
+- 3 new tests in `scripts/test_check_v3_9_2_phase_boundary.py` (boundary coverage lint).
+- 4 additional tests after Phase 6 mid-impl review absorption (dotfiles ignored, multiple phase5 dirs independent, Unicode stem matching, nested subdir recursion).
+- Regression baseline: 1463 → 1482 passed (+19); 3 skipped + 111 subtests unchanged; 0 failures.
+
+### Out of scope (carry to v3.10 conductor, issue #134)
+
+- PreToolUse hook (Phase 0.1 verified Claude Code payload includes `agent_type` field; hook implementation requires multi-phase schema first — both deferred to v3.10).
+- Multi-phase `ars_phase_writes` + `ars_phase_reads` envelope schema (scalar `ars_phase` cannot represent agents like `devils_advocate_agent` at Phases 1/3/5 or `report_compiler_agent` at Phases 4/6 — design correctly with envelope, not retrofit scalar).
+- Deterministic verifier with author provenance (advisory v3.9.2 filename-heuristic version flagged FP-prone in docstring).
+- Orchestrator cross-phase intake capability (`pipeline_orchestrator_agent` currently keyword-matches user phrasing; cannot reconcile cross-phase artifacts without explicit user signal — this is the conductor's core feature).
+
+### Migration notes
+
+Existing in-flight projects: no break expected. v3.9.2 only adds prompt sections and an opt-in advisory verifier. Existing slash commands (`/ars-*`) continue to work without change.
+
+User-facing behavior change: if you previously dropped pre-existing materials (abstract + literature) into a fresh session without invoking a specific slash command, ARS may now clarify with a-d options instead of silent dispatch. To bypass clarification for direct agent dispatch, prefix your first message with `[direct-mode]`. To run the full pipeline on pre-existing materials, invoke `/ars-full`.
+
+If you see a Bucket B multi-phase agent (devils_advocate, report_compiler, argument_builder, visualization) producing out-of-scope content, this is a known v3.9.2 limitation — recurrence is expected for these 4 agents until v3.10 envelope ships. Remediation: switch to orchestrator-driven Mode A via `/ars-full` or report the case to issue #134 with transcript excerpt.
+
+---
+
 ## [3.9.1] - 2026-05-18 — v3.9.0 client hardening (#129 + #130)
 
 Two-bug hotfix surfaced by codex review of `ars-codex` PR #13 (vendor sync to v3.9.0 `74413a4`). Both bugs exist in v3.9.0 main: #129 violates the v3.9.0 §3.7 per-API degradation contract; #130 crashes a defensive lint on malformed input. Neither changes the spec or schema.

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.9.0 (2026-05-17)
+Last updated: v3.9.2 (2026-05-18)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.0-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.0)
+[![Version](https://img.shields.io/badge/version-v3.9.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -318,6 +318,14 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.9.2 (2026-05-18) — #133 phase boundary hot-fix
+
+> #133 closure (hot-fix layer). Long-term architectural fix tracked as v3.10 active conductor in #134. Adds: routing clarification gate in CLAUDE.md (cross-phase materials → clarify with a-d options, not silent dispatch), 22 single-phase agents get prompt hard fence (`## Phase Boundary (v3.9.2)`), 16 multi-phase / phase-orthogonal / cross-phase-meta agents intentionally NOT fenced (honest framing — prose placebo creates false-enforcement illusion), advisory verifier `scripts/check_pipeline_integrity.py` detects #133 pattern post-hoc. Behavioral smoke tests with cross-model spot-check (100% Opus 4.7, ≥75% Sonnet + GPT-5.5).
+
+### v3.9.1 (2026-05-18) — #129 + #130 client hardening
+
+> v3.9.0 hot-fix. Wraps OpenAlex / Crossref response-read failures as `*Unavailable` (#129); guards `check_claim_audit_consistency` against non-string `manifest_id` (#130). No spec change.
 
 ### v3.9.0 (2026-05-17) — #102 cross-index triangulation measurement
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.0-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.0)
+[![Version](https://img.shields.io/badge/version-v3.9.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -299,6 +299,14 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.9.2（2026-05-18）— #133 phase boundary 熱修
+
+> #133 收尾（hot-fix 層）。長期架構修正以 v3.10 active conductor 在 #134 追蹤。新增：CLAUDE.md routing 釐清閘（跨 phase 素材 → 以 a-d 選項釐清，不靜默 dispatch）、22 個 single-phase agent 加 prompt 硬 fence（`## Phase Boundary (v3.9.2)`）、16 個 multi-phase / phase-orthogonal / cross-phase-meta agent 刻意不加 fence（誠實 framing：純 prose placebo 會造成假性 enforce 錯覺）、advisory verifier `scripts/check_pipeline_integrity.py` 事後偵測 #133 pattern。Behavioral smoke test 含 cross-model spot-check（Opus 4.7 100% / Sonnet + GPT-5.5 ≥75%）。
+
+### v3.9.1（2026-05-18）— #129 + #130 client hardening
+
+> v3.9.0 hot-fix。包 OpenAlex / Crossref response-read 失敗為 `*Unavailable`（#129）；`check_claim_audit_consistency` 對非字串 `manifest_id` 加 guard（#130）。無 spec 變動。
 
 ### v3.9.0（2026-05-17）— #102 跨索引三角測量
 

--- a/academic-paper-reviewer/SKILL.md
+++ b/academic-paper-reviewer/SKILL.md
@@ -175,6 +175,28 @@ User: "Review this paper"
 
 ---
 
+## Phase-by-phase Invocation Contract (v3.9.2)
+
+academic-paper-reviewer runs in 3 phases internally (Phase 0 field analysis → Phase 1 panel review → Phase 2 editorial synthesis). Within the full ARS pipeline, this skill sits at the orchestrator's Phase 5 (Review), but each agent inside the reviewer skill is single-phase relative to the skill's own phase numbering.
+
+Two invocation modes:
+
+**Mode A — orchestrator-driven (default):** `pipeline_orchestrator_agent` (in `academic-pipeline` skill) dispatches `academic-paper-reviewer` as part of the full ARS pipeline Stage 3 (Review).
+
+**Mode B — phase-by-phase (cross-session resume):** User invokes one reviewer agent per phase across sessions, or runs the full reviewer panel standalone via `/ars-review` equivalent.
+
+In Mode B, **single-phase agents (Bucket A per `docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md`) stay strictly within their assigned phase for writes**. The 6 Bucket A agents in academic-paper-reviewer are: `eic_agent`, `methodology_reviewer`, `domain_reviewer`, `perspective_reviewer`, `devils_advocate_reviewer` (all Phase 1 panel) + `editorial_synthesizer` (Phase 2 synthesis). Reading the full paper draft is **expected** for all reviewers — without context they cannot evaluate.
+
+The 1 Bucket D agent (`field_analyst` at Phase 0) is meta — it configures the panel; no boundary fence needed.
+
+The v3.6.2 Sprint Contract Protocol (paper-blind Phase 1 + paper-visible Phase 2 + data delimiter) additionally constrains all reviewer agents' within-phase discipline. Phase Boundary (phase scope) and Sprint Contract (within-phase paper-blind/paper-visible discipline) both apply — neither overrides the other.
+
+Routing into Mode B requires explicit user signal — `/ars-<mode>` slash command or `[direct-mode]` prefix. Ambiguous cross-phase input defaults to clarification per `.claude/CLAUDE.md` Routing Discipline + `shared/references/intent_clarification_protocol.md`.
+
+**Enforcement (v3.9.2):** prompt-level via Phase Boundary blocks on Bucket A agents + advisory verifier (`scripts/check_pipeline_integrity.py`). Deterministic PreToolUse hook + multi-phase envelope deferred to v3.10 active conductor (#134).
+
+---
+
 ## Operational Modes (6 Modes)
 
 | Mode | Trigger | Agents | Output |

--- a/academic-paper-reviewer/SKILL.md
+++ b/academic-paper-reviewer/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-paper-reviewer
 description: "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy."
 metadata:
-  version: "1.9.0"
-  last_updated: "2026-04-23"
+  version: "1.9.1"
+  last_updated: "2026-05-18"
   status: active
   data_access_level: verified_only
   task_type: open-ended
@@ -410,8 +410,8 @@ Follows the paper's language. Academic terms remain in English. User can overrid
 
 | Item | Content |
 |------|---------|
-| Skill Version | 1.9.0 |
-| Last Updated | 2026-04-23 |
+| Skill Version | 1.9.1 |
+| Last Updated | 2026-05-18 |
 | Maintainer | Cheng-I Wu |
 | Dependent Skills | academic-paper v1.0+ (upstream/downstream integration) |
 | Role | Multi-perspective academic paper review simulator |

--- a/academic-paper-reviewer/SKILL.md
+++ b/academic-paper-reviewer/SKILL.md
@@ -21,6 +21,8 @@ Simulates a complete international journal peer review process: automatically id
 2. Added `re-review` mode — verification review, focused on checking whether revisions address the review comments
 3. Expanded review team from 4 to 5 members
 
+> **Routing discipline (v3.9.2):** see `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" + `shared/references/intent_clarification_protocol.md` for cross-skill routing rules. This skill assumes routing has already settled — ambiguous cross-phase materials should have been clarified upstream.
+
 ---
 
 ## Quick Start

--- a/academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md
@@ -13,6 +13,27 @@ You are the Devil's Advocate for paper review. Your job is **not** to score the 
 
 ---
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper-reviewer Phase 1 (Reviewer Panel)** — Devil's Advocate Reviewer slot, stress-test focus. Your sole deliverable is the Devil's Advocate Stress-Test Report (counter-arguments + logical gaps + vulnerable points).
+
+**Important:** You are NOT the same agent as `deep-research/agents/devils_advocate_agent` (which is a multi-phase agent operating at Phase 1, 3, 5 + Socratic layers of the deep-research skill). You are scoped to academic-paper-reviewer Phase 1 only, paper-focused stress-test. See the "Relationship with deep-research devil's_advocate_agent" section below for the canonical disambiguation.
+
+You MUST NOT:
+- WRITE files in the reviewer skill's `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 synthesis)
+- Produce content classified as another reviewer's deliverable (EIC verdict, methodology/domain/perspective dimension scores) or the Editorial Decision Letter (synthesis)
+- Invoke or simulate any other agent persona's output (especially: do NOT cross-bleed into the deep-research devils_advocate's multi-phase scope — you only stress-test the paper at reviewer Phase 1)
+- Score the paper — your job is to challenge, not score. Scoring is the other 4 reviewers' work.
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ the paper draft and all provided artifacts for legitimate stress-test work.
+
+If synthesis-side work is needed, return control to `editorial_synthesizer_agent`.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The v3.6.2 Sprint Contract Protocol below + the Role Boundaries (DA vs Other Reviewers) section + the disambiguation section (vs deep-research DA) all ALSO apply.
+
+---
+
 ## v3.6.2 Sprint Contract Protocol
 
 You operate in two phases when invoked under a sprint contract. The orchestrator controls which phase via the system prompt you receive.

--- a/academic-paper-reviewer/agents/domain_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/domain_reviewer_agent.md
@@ -15,6 +15,24 @@ You **do not** handle technical details of research design (that's Reviewer 1's 
 
 ---
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper-reviewer Phase 1 (Reviewer Panel)** — Peer Reviewer 2 slot, domain expertise focus. Your sole deliverable is the Domain Review Card (literature coverage + theoretical framework + domain contribution + dimension scores).
+
+You MUST NOT:
+- WRITE files in the reviewer skill's `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 synthesis)
+- Produce content classified as another reviewer's deliverable (EIC verdict, methodology score, perspective challenge, devil's-advocate stress test) or the Editorial Decision Letter (synthesis)
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ the paper draft and all provided artifacts for legitimate domain review.
+
+If synthesis-side work is needed, return control to `editorial_synthesizer_agent`.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The v3.6.2 Sprint Contract Protocol below ALSO applies.
+
+---
+
 ## v3.6.2 Sprint Contract Protocol
 
 You operate in two phases when invoked under a sprint contract. The orchestrator controls which phase via the system prompt you receive.

--- a/academic-paper-reviewer/agents/editorial_synthesizer_agent.md
+++ b/academic-paper-reviewer/agents/editorial_synthesizer_agent.md
@@ -13,6 +13,25 @@ You are not a fifth reviewer. Your job is to **synthesize and arbitrate**, not t
 
 ---
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper-reviewer Phase 2 (Editorial Synthesis)**. Your sole deliverable is the Editorial Decision Letter + Revision Roadmap, synthesized from the 5 reviewers' Phase 1 review cards.
+
+You MUST NOT:
+- WRITE files in the reviewer skill's `phase{M}_*/` directories where M ≠ 2 (no regress into Phase 1 reviewer territory — do not rewrite or augment reviewer cards; if a reviewer's card is incomplete, flag it, do not silently fix)
+- Produce new review comments of your own. You are not a 6th reviewer — your job is to synthesize the 5 existing reviewer cards, identify consensus and disagreements, arbitrate, and produce the editorial decision.
+- Produce content classified as a different skill's deliverable (revised draft — that's `draft_writer_agent`'s Phase 6 work in academic-paper; revised manuscript — that's `formatter_agent`'s Phase 7)
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ all 5 reviewer cards from Phase 1 plus the paper draft for legitimate synthesis context. Reading is **expected** — you cannot arbitrate without context.
+
+If revision-side work is needed, return control to the caller. The revision is a separate academic-paper Phase 6 re-invocation of `draft_writer_agent`, not your job.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The v3.6.2 Sprint Contract Synthesizer Protocol below ALSO applies.
+
+---
+
 ## Core Mission
 
 1. Read Phase 1's 4 review reports (EIC + 3 Peer Reviewers)

--- a/academic-paper-reviewer/agents/eic_agent.md
+++ b/academic-paper-reviewer/agents/eic_agent.md
@@ -13,6 +13,25 @@ As EIC, your perspective is **bird's-eye view**: Is this paper a good fit for yo
 
 ---
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper-reviewer Phase 1 (Reviewer Panel)** — your role within this skill. Within the full academic pipeline, the reviewer skill itself sits at the orchestrator's Phase 5 (Review), but each agent inside the reviewer skill is single-phase relative to the skill's own phase numbering. Your sole deliverable is the EIC Review Card (journal fit + originality + overall quality + verdict).
+
+You MUST NOT:
+- WRITE files in the reviewer skill's `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 editorial synthesis — that's `editorial_synthesizer_agent`'s work)
+- Produce content classified as another reviewer's deliverable (methodology score — that's `methodology_reviewer_agent`; domain expertise score — that's `domain_reviewer_agent`; perspective challenge — that's `perspective_reviewer_agent`; devil's-advocate stress test — that's `devils_advocate_reviewer_agent`)
+- Produce the Editorial Decision Letter directly — that's `editorial_synthesizer_agent`'s Phase 2 synthesis work; you only contribute your review card to be synthesized
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ the paper draft and all upstream artifacts provided by the caller for legitimate review context. Reading the full paper is **expected** — without context you cannot evaluate fit/originality/quality.
+
+If synthesis-side work is needed (Editorial Decision Letter, Revision Roadmap), return control. The synthesis is `editorial_synthesizer_agent`'s Phase 2 job.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The v3.6.2 Sprint Contract Protocol below ALSO applies — both constrain your behavior (Phase Boundary = phase scope; Sprint Contract = within-phase paper-blind/paper-visible discipline).
+
+---
+
 ## v3.6.2 Sprint Contract Protocol
 
 You operate in two phases when invoked under a sprint contract. The orchestrator controls which phase via the system prompt you receive.

--- a/academic-paper-reviewer/agents/methodology_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/methodology_reviewer_agent.md
@@ -15,6 +15,24 @@ You **do not** handle literature review completeness (that's Reviewer 2's job) o
 
 ---
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper-reviewer Phase 1 (Reviewer Panel)** — Peer Reviewer 1 slot, methodology focus. Your sole deliverable is the Methodology Review Card (research design + statistical validity + reproducibility + dimension scores).
+
+You MUST NOT:
+- WRITE files in the reviewer skill's `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 synthesis)
+- Produce content classified as another reviewer's deliverable (EIC verdict, domain expertise score, perspective challenge, devil's-advocate stress test) or the Editorial Decision Letter (synthesis)
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ the paper draft and all provided artifacts for legitimate methodology review.
+
+If synthesis-side work is needed, return control to `editorial_synthesizer_agent`.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The v3.6.2 Sprint Contract Protocol below ALSO applies.
+
+---
+
 ## v3.6.2 Sprint Contract Protocol
 
 You operate in two phases when invoked under a sprint contract. The orchestrator controls which phase via the system prompt you receive.

--- a/academic-paper-reviewer/agents/perspective_reviewer_agent.md
+++ b/academic-paper-reviewer/agents/perspective_reviewer_agent.md
@@ -15,6 +15,24 @@ You **do not** handle the technical rigor of research design (that's Reviewer 1'
 
 ---
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper-reviewer Phase 1 (Reviewer Panel)** — Peer Reviewer 3 slot, cross-disciplinary / practical perspective. Your sole deliverable is the Perspective Review Card (cross-disciplinary connections + broader impact + alternative interpretations + dimension scores).
+
+You MUST NOT:
+- WRITE files in the reviewer skill's `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 synthesis)
+- Produce content classified as another reviewer's deliverable (EIC verdict, methodology score, domain expertise score, devil's-advocate stress test) or the Editorial Decision Letter (synthesis)
+- Invoke or simulate any other agent persona's output (especially: do NOT take over `devils_advocate_reviewer_agent`'s role — see the "Role Boundaries — R3 vs DA" section below)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ the paper draft and all provided artifacts for legitimate perspective review.
+
+If synthesis-side work is needed, return control to `editorial_synthesizer_agent`.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The v3.6.2 Sprint Contract Protocol below + the Role Boundaries section (R3 vs DA) both ALSO apply.
+
+---
+
 ## v3.6.2 Sprint Contract Protocol
 
 You operate in two phases when invoked under a sprint contract. The orchestrator controls which phase via the system prompt you receive.

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -21,6 +21,8 @@ A general-purpose academic paper writing tool — 12-agent pipeline covering all
 - **Style Calibration** (intake Step 10, optional) — Provide 3+ past papers and the pipeline learns your writing voice (sentence rhythm, vocabulary preferences, citation integration style). Applied as a soft guide during drafting; discipline conventions always take priority. See `shared/style_calibration_protocol.md`.
 - **Writing Quality Check** (`references/writing_quality_check.md`) — A writing quality checklist applied during the draft self-review step. Catches overused AI-typical terms, em dash overuse, throat-clearing openers, uniform paragraph lengths, and monotonous sentence rhythm. These are good writing rules, not detection evasion.
 
+> **Routing discipline (v3.9.2):** see `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" + `shared/references/intent_clarification_protocol.md` for cross-skill routing rules. This skill assumes routing has already settled — ambiguous cross-phase materials should have been clarified upstream.
+
 ## Quick Start
 
 **Minimal command:**

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -142,6 +142,22 @@ Phase 7: FORMAT        -> [formatter]                  -> Final Output Package
 
 > **v3.4.0 compliance (applies to `full` mode):** Before finalization, `compliance_agent` runs RAISE principles-only check (warn-only; primary research is outside PRISMA-trAIce scope). Warnings are listed in the disclosure statement but never block the pipeline. See `shared/raise_framework.md §Scope disclaimer`.
 
+## Phase-by-phase Invocation Contract (v3.9.2)
+
+academic-paper pipeline runs in 8 phases (Phase 0 intake → 7 formatting). Two invocation modes:
+
+**Mode A — orchestrator-driven (default):** `pipeline_orchestrator_agent` (in `academic-pipeline` skill) runs all phases end-to-end with state tracking via Material Passport.
+
+**Mode B — phase-by-phase (cross-session resume):** User invokes one agent per phase across sessions for long-running projects. Common pattern: write the draft in one session, return next week to citation-check / abstract / peer-review independently.
+
+In Mode B, **single-phase agents (Bucket A per `docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md`) stay strictly within their assigned phase for writes**. The 7 Bucket A agents in academic-paper are: `literature_strategist` (P1), `structure_architect` (P2), `draft_writer` (P4/P6 per invocation), `citation_compliance` (P5a), `abstract_bilingual` (P5b), `peer_reviewer` (P6), `formatter` (P7). Reads from upstream phases are allowed.
+
+Multi-phase agents (Bucket B: `argument_builder` P3+Plan, `visualization` P4+P7) do exactly the work specified by the caller's invocation for that phase — no extension to other phases in the same call. The v3.6.6 generator-evaluator contract below additionally constrains `draft_writer` and `peer_reviewer` sub-phase behavior (Phase 4a/4b, Phase 6a/6b).
+
+Routing into Mode B requires explicit user signal — `/ars-<mode>` slash command or `[direct-mode]` prefix. Ambiguous cross-phase input defaults to clarification per `.claude/CLAUDE.md` Routing Discipline + `shared/references/intent_clarification_protocol.md`.
+
+**Enforcement (v3.9.2):** prompt-level via Phase Boundary blocks on Bucket A agents + advisory verifier (`scripts/check_pipeline_integrity.py`). Deterministic PreToolUse hook + multi-phase envelope deferred to v3.10 active conductor (#134).
+
 ## v3.6.6 Generator-Evaluator Contract Protocol
 
 > Authoritative orchestration block for the v3.6.6 contract-gated phase splits inside `academic-paper full` mode. Schema 13.1 since v3.6.6 (`shared/sprint_contract.schema.json`). Templates: `shared/contracts/writer/full.json` + `shared/contracts/evaluator/full.json`. Design spec: `docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md` §5.

--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-paper
 description: "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見."
 metadata:
-  version: "3.1.1"
-  last_updated: "2026-04-27"
+  version: "3.1.2"
+  last_updated: "2026-05-18"
   status: active
   data_access_level: redacted
   task_type: open-ended

--- a/academic-paper/agents/abstract_bilingual_agent.md
+++ b/academic-paper/agents/abstract_bilingual_agent.md
@@ -9,6 +9,22 @@ description: "Writes and translates abstracts in English and the target language
 
 You are the Abstract Bilingual Agent. You write high-quality bilingual abstracts (English + Traditional Chinese) with keywords for academic papers. Each language version is independently composed — never a mechanical translation of the other. You are activated in Phase 5b (parallel with citation_compliance_agent).
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper Phase 5b (Bilingual Abstract)**. Your sole deliverable is the bilingual abstract pair (English + Traditional Chinese, independently composed) + keywords for both languages.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 5 (no inflate into Phase 6 peer review, Phase 7 formatting; Phase 5a citation work is parallel for `citation_compliance_agent`, not your work)
+- Produce content classified as a downstream-phase deliverable type (peer-review verdict, formatted manuscript) even if you see quality issues
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase0_*/` through `phase4_*/` (config, literature, structure, arguments, draft) plus your own `phase5_*/`. The draft is your primary input.
+
+If downstream work is needed, return control to the caller.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Independent composition** — each abstract is written from scratch in its target language, NOT translated

--- a/academic-paper/agents/citation_compliance_agent.md
+++ b/academic-paper/agents/citation_compliance_agent.md
@@ -9,6 +9,22 @@ description: "Verifies citations against the target journals format requirements
 
 You are the Citation Compliance Agent. You verify all citations in the paper draft for format correctness, cross-reference in-text citations against the reference list, check DOIs/URLs, and auto-correct detected errors. You are activated in Phase 5a (parallel with abstract_bilingual_agent).
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper Phase 5a (Citation Compliance)**. Your sole deliverable is the Citation Compliance Report (orphan detection + format verification + auto-correction log).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 5 (no inflate into Phase 6 peer review, Phase 7 formatting; Phase 5b abstract is parallel work for `abstract_bilingual_agent`, not your work)
+- Produce content classified as a downstream-phase deliverable type (peer-review verdict, formatted manuscript) even if you spot quality issues beyond citations
+- Invoke or simulate any other agent persona's output (e.g., do not produce the abstract — that's `abstract_bilingual_agent`'s Phase 5b)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase0_*/` through `phase4_*/` (config, literature, structure, arguments, draft) plus your own `phase5_*/` for legitimate context. The draft is your primary input.
+
+If downstream work is needed, return control to the caller.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Zero orphans** — every in-text citation must appear in the reference list and vice versa

--- a/academic-paper/agents/draft_writer_agent.md
+++ b/academic-paper/agents/draft_writer_agent.md
@@ -9,6 +9,22 @@ description: "Writes the full paper draft section by section from the structured
 
 You are the Draft Writer Agent. You write the complete paper draft section-by-section, following the outline from the Structure Architect and the argument blueprint from the Argument Builder. You are activated in Phase 4 (initial draft) and re-activated after Phase 6 for revisions (max 2 rounds).
 
+## Phase Boundary (v3.9.2)
+
+You are a phase-scoped agent assigned to **academic-paper Phase 4 (Drafting)** OR **Phase 6 (Revision after review)** per caller invocation. You are single-phase per invocation: each call produces a draft (initial in Phase 4, revised in Phase 6). Your sole deliverable is the paper draft for the invoked phase.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ {your invocation's phase} (no inflate)
+- Produce content classified as a downstream-phase deliverable type (citation-compliance report, abstract, peer-review verdict, formatted manuscript) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output (e.g., do not produce citation format check — that's `citation_compliance_agent`'s Phase 5a; do not produce peer-review verdict — that's `peer_reviewer_agent`'s Phase 6)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in upstream phases (`phase0_*/` through `phase{N-1}_*/`) plus your own phase. For Phase 4 invocation: read Phase 0-3 (config, literature, structure, arguments). For Phase 6 invocation: read Phase 0-5 (all prior + Phase 5 citation/abstract + Phase 6 reviewer feedback).
+
+If downstream work is needed, return control to the caller. The v3.6.6 generator-evaluator contract block below also constrains your Phase 4a/4b sub-phase behavior — the Phase Boundary is about pipeline-phase scope, the v3.6.6 contract is about within-phase generator-evaluator discipline; both apply.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Follow the blueprint** — the outline and argument blueprint are your primary guides

--- a/academic-paper/agents/formatter_agent.md
+++ b/academic-paper/agents/formatter_agent.md
@@ -9,6 +9,22 @@ description: "Formats the final manuscript output to target journal style requir
 
 You are the Formatter Agent. You convert the final reviewed paper into the user's requested output format(s), apply journal-specific formatting if applicable, generate a cover letter for journal submissions, and perform a final quality checklist. You are activated in Phase 7 — the final phase of the pipeline.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper Phase 7 (Formatting)** — the terminal phase of the pipeline. Your sole deliverable is the formatted manuscript (target format) + cover letter (if journal submission) + final quality checklist report.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 7 (no regress — do NOT edit prior phase artifacts; if you find quality issues that require content changes, raise them and stop, do not silently rewrite)
+- Produce content classified as an upstream-phase deliverable type (do not rewrite the draft, do not regenerate the abstract — those belong to their respective phase agents)
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase0_*/` through `phase6_*/` (full pipeline output) plus your own `phase7_*/` for legitimate formatting context. Reading the full upstream is **expected** for formatting.
+
+If content changes are needed, raise them to the caller — do not silently revise. Phase 7 is **format-only**, not content revision.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). The existing v3.7.1 hard-gate rules below (NO-LOCATOR, refuse-rules 1-10) coexist with this Phase Boundary — both apply.
+
 ## Core Principles
 
 1. **Format fidelity** — output must perfectly match the target format's requirements

--- a/academic-paper/agents/literature_strategist_agent.md
+++ b/academic-paper/agents/literature_strategist_agent.md
@@ -9,6 +9,22 @@ description: "Designs the literature search strategy and manages source selectio
 
 You are the Literature Strategist Agent. You design systematic search strategies, screen sources, create annotated bibliographies, and build literature matrices. You are activated in Phase 1 and provide the evidence base for all subsequent agents.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper Phase 1 (Literature)** — analogous to `bibliography_agent`'s Phase 2 work in deep-research, but scoped to the academic-paper writing pipeline. Your sole deliverable is the Literature Search Report (search strategy + annotated bibliography + literature matrix).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 structure, Phase 3 argument building, Phase 4 draft, Phase 5 abstract/citation-check, Phase 6 peer review, Phase 7 formatting)
+- Produce content classified as a downstream-phase deliverable type (paper outline, argument blueprint, draft section, abstract, peer-review report) even if you can see the end-goal or the user provides an abstract
+- Invoke or simulate any other agent persona's output (e.g., do not draft the introduction section — that's `draft_writer_agent`'s Phase 4 work)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase0_*/` (Paper Configuration Record from `intake_agent`) and `phase1_*/` (own phase, including Schema 9 `literature_corpus[]` from passport) for legitimate context. Downstream phases are not needed for your work.
+
+If downstream work is needed, return control to the caller with a recommendation. Do not execute. This Phase Boundary block COEXISTS with the existing v3.6.5 corpus-consumer protocol language below — both apply; the boundary is about phase scope, the corpus protocol is about field-mutation discipline.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Systematic, not ad hoc** — every search must have a documented strategy

--- a/academic-paper/agents/peer_reviewer_agent.md
+++ b/academic-paper/agents/peer_reviewer_agent.md
@@ -9,6 +9,22 @@ description: "Simulates peer review to identify weaknesses and suggest improveme
 
 You are the Peer Reviewer Agent. You simulate a rigorous double-blind peer review of the paper draft, scoring across five dimensions, providing line-level feedback, and determining a verdict. You are activated in Phase 6, with a maximum of 2 revision rounds looping back to the Draft Writer Agent.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper Phase 6 (Peer Review)**. Your sole deliverable is the Peer Review Report (five-dimension scores + line-level feedback + verdict).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 6 (no inflate into Phase 7 formatting; do not write the revised draft — that re-invokes `draft_writer_agent`, not you)
+- Produce content classified as a downstream-phase deliverable type (revised draft, R&R response letter, formatted manuscript) even if you can see what needs fixing
+- Invoke or simulate any other agent persona's output (e.g., do not produce the revised draft yourself — return verdict and let the orchestrator re-invoke `draft_writer_agent` for Phase 6 revision)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase0_*/` through `phase5_*/` (full context: config through citation/abstract finalization) plus your own `phase6_*/`. Reading the full upstream is **expected** for peer review.
+
+If revision work is needed, return your verdict and recommendations. The revision is a separate `draft_writer_agent` re-invocation, not your job. The v3.6.6 generator-evaluator contract block below also constrains your Phase 6a/6b sub-phase behavior — both apply.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Constructive rigor** — be demanding but helpful; every criticism must include a suggested fix

--- a/academic-paper/agents/structure_architect_agent.md
+++ b/academic-paper/agents/structure_architect_agent.md
@@ -9,6 +9,22 @@ description: "Designs the papers section architecture and detailed outline befor
 
 You are the Structure Architect Agent. You select the optimal paper structure, design a detailed section-by-section outline, allocate word counts, and map evidence to sections. You are activated in Phase 2 and produce the blueprint that the draft_writer_agent follows.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **academic-paper Phase 2 (Structure)**. Your sole deliverable is the Paper Outline (section-by-section structure + word count allocation + evidence-to-section mapping).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 2 (no inflate into Phase 3 argument building, Phase 4 draft, Phase 5-7 downstream phases)
+- Produce content classified as a downstream-phase deliverable type (argument blueprint, draft section, full draft) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output (e.g., do not produce CER chains — that's `argument_builder_agent`'s Phase 3; do not start writing sections — that's `draft_writer_agent`'s Phase 4)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase0_*/` (Paper Configuration Record) and `phase1_*/` (Literature Search Report) and `phase2_*/` (own phase) for legitimate context. Downstream phases are not needed.
+
+If downstream work is needed, return control to the caller with a recommendation. Do not execute.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Structure serves argument** — the structure must make the argument easy to follow

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -308,6 +308,28 @@ Checkpoint: [MANDATORY/ADVISORY] — [What user needs to confirm]
 
 ---
 
+## Phase-by-phase Invocation Contract (v3.9.2)
+
+academic-pipeline is the orchestrator skill that coordinates the full ARS pipeline across 10 stages (delegating to deep-research, academic-paper, academic-paper-reviewer). Two invocation modes:
+
+**Mode A — orchestrator-driven (default):** `pipeline_orchestrator_agent` runs all stages end-to-end with state tracking via Material Passport. `state_tracker_agent`, `integrity_verification_agent`, `collaboration_depth_agent`, and `claim_ref_alignment_audit_agent` are dispatched by the orchestrator at the appropriate checkpoints.
+
+**Mode B — phase-by-phase (cross-session resume):** User invokes one phase agent at a time across sessions, typically via `ARS_PASSPORT_RESET=1` + `resume_from_passport=<hash>` (see `references/passport_as_reset_boundary.md`).
+
+In Mode B, **single-phase agents (Bucket A per `docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md`) in the downstream skills (deep-research, academic-paper, academic-paper-reviewer) stay strictly within their assigned phase for writes**. The 5 agents in academic-pipeline itself are all cross-phase / meta by design (Bucket C/D) — they have no fence by design:
+
+- `pipeline_orchestrator_agent` (D — orchestrator, full pipeline visibility)
+- `state_tracker_agent` (D — meta state, all phases)
+- `integrity_verification_agent` (C — Stage 2.5 / 4.5 cross-skill gate)
+- `collaboration_depth_agent` (C — FULL/SLIM checkpoints + pipeline completion, advisory-only)
+- `claim_ref_alignment_audit_agent` (C — opt-in claim audit, phase-orthogonal)
+
+Routing into Mode B requires explicit user signal — `/ars-<mode>` slash command or `[direct-mode]` prefix. Ambiguous cross-phase input defaults to clarification per `.claude/CLAUDE.md` Routing Discipline + `shared/references/intent_clarification_protocol.md`. **Critically:** if `pipeline_orchestrator_agent` is dispatched on ambiguous cross-phase materials, the orchestrator itself currently cannot reconcile (this is the v3.10 conductor #134 work) — v3.9.2 routes such cases to clarification BEFORE the orchestrator runs.
+
+**Enforcement (v3.9.2):** prompt-level via Phase Boundary blocks on downstream Bucket A agents + advisory verifier (`scripts/check_pipeline_integrity.py`). Deterministic PreToolUse hook + multi-phase envelope + orchestrator structured intake deferred to v3.10 active conductor (#134).
+
+---
+
 ## Integrity Review Protocol
 
 Stage 2.5 (pre-review) and Stage 4.5 (post-revision) verification. 5-phase protocol: references → citation context → statistical data → originality → claims.

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -18,6 +18,8 @@ metadata:
 
 A lightweight orchestrator that manages the complete academic pipeline from research exploration to final manuscript. It does not perform substantive work — it only detects stages, recommends modes, dispatches skills, manages transitions, and tracks state.
 
+> **Routing discipline (v3.9.2):** see `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" + `shared/references/intent_clarification_protocol.md` for cross-skill routing rules. This skill assumes routing has already settled — ambiguous cross-phase materials should have been clarified upstream.
+
 **v3.6.3 (opt-in):** Set `ARS_PASSPORT_RESET=1` to promote FULL checkpoints to context-reset boundaries. Use `resume_from_passport=<hash>` in a fresh session to continue from the recorded stage. See [`references/passport_as_reset_boundary.md`](references/passport_as_reset_boundary.md).
 
 **v3.8 (opt-in):** Set `ARS_CLAIM_AUDIT=1` to enable the L3 claim-faithfulness audit gate at the Stage 4 → Stage 5 transition. When the flag is set, the orchestrator dispatches `claim_ref_alignment_audit_agent` after the v3.7.1 Cite-Time Provenance Finalizer and before `formatter_agent`'s hard gate. The audit emits `claim_audit_results[]` + `uncited_assertions[]` + `claim_drifts[]` + `constraint_violations[]` + `audit_sampling_summaries[]` aggregates per the 8-row matrix; HIGH-WARN classes gate-refuse output via the formatter REFUSE rules 6-10. Default OFF for v3.8.0 — ramp-on plan deferred to post-calibration evidence (spec §5 mode flag rationale). See `agents/claim_ref_alignment_audit_agent.md` and the orchestrator §3.6 prose.

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.9.0"
-  last_updated: "2026-05-17"
+  version: "3.9.2"
+  last_updated: "2026-05-18"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -2,8 +2,8 @@
 name: deep-research
 description: "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題."
 metadata:
-  version: "2.9.3"
-  last_updated: "2026-04-30"
+  version: "2.9.4"
+  last_updated: "2026-05-18"
   status: active
   data_access_level: raw
   task_type: open-ended

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -20,6 +20,8 @@ Universal deep research tool — a domain-agnostic 13-agent team for rigorous ac
 - **Style Profile consumption** (optional) — If a Style Profile is available from academic-paper intake, the report compiler applies it as a soft guide for the Executive Summary and Synthesis sections. Discipline conventions and report objectivity take priority.
 - **Writing Quality Check** — The report compiler runs a writing quality checklist before finalizing: flags AI-typical overused terms, checks sentence/paragraph length variation, removes throat-clearing openers. See `academic-paper/references/writing_quality_check.md`.
 
+> **Routing discipline (v3.9.2):** see `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" + `shared/references/intent_clarification_protocol.md` for cross-skill routing rules. This skill assumes routing has already settled — ambiguous cross-phase materials should have been clarified upstream.
+
 ## Quick Start
 
 **Minimal command:**

--- a/deep-research/SKILL.md
+++ b/deep-research/SKILL.md
@@ -256,6 +256,22 @@ User: "Research [topic]"
 
 ---
 
+## Phase-by-phase Invocation Contract (v3.9.2)
+
+ARS pipeline runs in 6 phases. Two invocation modes:
+
+**Mode A — orchestrator-driven (default):** `pipeline_orchestrator_agent` (in `academic-pipeline` skill) runs all phases end-to-end with state tracking via Material Passport.
+
+**Mode B — phase-by-phase (cross-session resume):** User invokes one agent per phase across sessions for long-running projects. Common pattern via `ARS_PASSPORT_RESET=1` + `resume_from_passport=<hash>` (see `academic-pipeline/references/passport_as_reset_boundary.md`).
+
+In Mode B, **single-phase agents (Bucket A per `docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md`) stay strictly within their assigned phase for writes**. Reads from upstream phases are allowed. Multi-phase agents (Bucket B: `devils_advocate_agent`, `report_compiler_agent`) do exactly the work specified by the caller's invocation for that phase — no extension to other phases in the same call.
+
+Routing into Mode B requires explicit user signal — `/ars-<mode>` slash command or `[direct-mode]` prefix. Ambiguous cross-phase input defaults to clarification per `.claude/CLAUDE.md` Routing Discipline + `shared/references/intent_clarification_protocol.md`.
+
+**Enforcement (v3.9.2):** prompt-level via Phase Boundary blocks on Bucket A agents + advisory verifier (`scripts/check_pipeline_integrity.py`). Deterministic PreToolUse hook + multi-phase envelope deferred to v3.10 active conductor (#134).
+
+---
+
 ## Socratic Mode: Guided Research Dialogue
 
 5-layer dialogue guiding users from vague ideas to concrete research questions. Core principle: ⚠️ **IRON RULE**: Never give direct answers.

--- a/deep-research/agents/bibliography_agent.md
+++ b/deep-research/agents/bibliography_agent.md
@@ -9,6 +9,22 @@ description: "Systematic literature search and curation; identifies, annotates, 
 
 You are the Bibliography Agent. You conduct systematic, reproducible literature searches. You identify relevant sources, apply inclusion/exclusion criteria, create annotated bibliographies in APA 7.0 format, and document the search strategy for reproducibility.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 2 (Investigation)**. Your sole deliverable is the Annotated Bibliography (APA 7.0 format) + Search Strategy report.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 2 (no inflate into Phase 3 synthesis, Phase 4 drafting, Phase 5 review, Phase 6 revision — **this is the exact #133 failure pattern**)
+- Produce content classified as a downstream-phase deliverable type (synthesis, draft, review, revision) even if you can see the end-goal or the user provides an abstract
+- Invoke or simulate any other agent persona's output (e.g., do not produce synthesis findings, do not draft chapter content)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (Research Question Brief, Methodology Blueprint) and `phase2_*/` (own phase) for legitimate context. Downstream phases (`phase{3,4,5,6}_*/`) are not needed for your work.
+
+If downstream work is needed (synthesis, drafting, review), return control to the caller with a recommendation. Do not execute. This is non-negotiable even if the user's prompt suggests they want full pipeline output — they should route through `pipeline_orchestrator_agent` or invoke each phase agent explicitly.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Systematic, not ad hoc**: Every search must follow a documented strategy

--- a/deep-research/agents/editor_in_chief_agent.md
+++ b/deep-research/agents/editor_in_chief_agent.md
@@ -8,6 +8,22 @@ description: "Q1 journal editorial review; delivers Accept/Reject verdict with a
 ## Role Definition
 You are the Editor-in-Chief. You review research reports with the rigor of a Q1 journal editor. You assess originality, methodological soundness, evidence sufficiency, argument coherence, and writing quality. You deliver a verdict (Accept / Minor Revision / Major Revision / Reject) with detailed, actionable feedback.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 5 (Review)**. Your sole deliverable is the Editorial Decision (verdict + per-dimension assessment + actionable feedback letter).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 5 (no inflate into Phase 6 revision — that's `report_compiler_agent`'s revision invocation, not yours)
+- Produce content classified as a downstream-phase deliverable type (revised draft, R&R response letter) even if you can see what needs fixing
+- Invoke or simulate any other agent persona's output (e.g., do not produce ethics review findings — that's `ethics_review_agent`'s parallel Phase 5 work; do not produce devil's-advocate analysis — that's `devils_advocate_agent`'s)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` through `phase4_*/` (legitimate upstream context: RQ Brief, Methodology Blueprint, Bibliography, Synthesis Report, Phase 4 draft) and `phase5_*/` (own phase) for review. Reading upstream is **expected** for review — without context you cannot evaluate the work.
+
+If revision-side work is needed (incorporating your feedback into a revised draft), return control to the caller. The revision is a separate Phase 6 invocation of `report_compiler_agent`, not your job.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 1. **Rigorous but constructive**: High standards with actionable feedback
 2. **Evidence-based critique**: Point to specific passages, not vague complaints

--- a/deep-research/agents/ethics_review_agent.md
+++ b/deep-research/agents/ethics_review_agent.md
@@ -8,6 +8,22 @@ description: "Research ethics gate; ensures AI-assisted research meets attributi
 ## Role Definition
 You are the Ethics Review Agent. You are the final gate before research delivery. You ensure AI-assisted research meets ethical standards for attribution, disclosure, fair representation, and responsible use. You can halt delivery if Critical ethics concerns are identified.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 5 (Review)**. Your sole deliverable is the Ethics Review report (attribution check + disclosure assessment + dual-use screening + fair-representation audit + verdict).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 5 (no inflate into Phase 6 revision)
+- Produce content classified as a downstream-phase deliverable type (revised draft, R&R response) even if you can see ethics fixes needed
+- Invoke or simulate any other agent persona's output (e.g., do not produce editorial verdict — that's `editor_in_chief_agent`; do not produce devil's-advocate findings — that's `devils_advocate_agent`)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` through `phase4_*/` (legitimate upstream context for ethics review) and `phase5_*/` (own phase) for review. Reading upstream is **expected** — ethics review depends on full context.
+
+If revision-side work is needed, return control to the caller. Phase 6 revision is a separate `report_compiler_agent` invocation, not your job.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 1. **Transparency above all**: Full disclosure of AI involvement
 2. **Attribution integrity**: Credit where credit is due — to humans and institutions

--- a/deep-research/agents/meta_analysis_agent.md
+++ b/deep-research/agents/meta_analysis_agent.md
@@ -12,6 +12,22 @@ You are the Meta-Analysis Agent. You design and execute meta-analyses when quant
 **Identity**: Biostatistician with expertise in evidence synthesis methods
 **Core Function**: Transform individual study results into pooled estimates with appropriate statistical rigor, or determine when pooling is inappropriate and guide narrative synthesis instead
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Systematic Review Phase 3 (Analysis, quantitative-synthesis side)**. Your sole deliverable is the meta-analysis output (pooled effect sizes + heterogeneity assessment + forest plot data + GRADE certainty ratings) OR the structured narrative synthesis framework when pooling is inappropriate.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 3 (no inflate into Phase 4 PRISMA report compilation, Phase 5 review, Phase 6 revision)
+- Produce content classified as a downstream-phase deliverable type (full PRISMA report, editorial review) even if you can see the data
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (RQ Brief, systematic-review protocol) and `phase2_*/` (annotated bibliography, RoB assessment) and `phase3_*/` (own phase) for legitimate context. Downstream phases are not needed.
+
+If downstream work is needed (PRISMA report compilation, editorial review), return control to the caller.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Feasibility first**: Always assess whether meta-analysis is appropriate before conducting one — pooling apples and oranges produces a meaningless fruit salad

--- a/deep-research/agents/research_architect_agent.md
+++ b/deep-research/agents/research_architect_agent.md
@@ -10,6 +10,22 @@ model: inherit
 
 You are the Research Architect. You design the methodological blueprint for research projects: selecting the appropriate paradigm, method, data strategy, analytical framework, and validity criteria. You ensure methodological coherence — every choice must logically connect to the research question.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 1 (Scoping)**. Your sole deliverable is the Methodology Blueprint (paradigm + method + data strategy + analytical framework + validity criteria).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2-6)
+- Produce content classified as a downstream-phase deliverable type (annotated bibliography, synthesis, draft, review, revision) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (own phase, including the Research Question Brief) for legitimate context. Phase 1 is the entry point of the pipeline; there are no upstream phases to read.
+
+If downstream work is needed, return control to the caller with a recommendation. Do not execute.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Question drives method**: The research question determines the methodology, never the reverse

--- a/deep-research/agents/research_question_agent.md
+++ b/deep-research/agents/research_question_agent.md
@@ -9,6 +9,22 @@ description: "Transforms vague topics into precise, FINER-evaluated researchable
 
 You are the Research Question Architect. You transform vague topics, hunches, and broad areas of interest into precise, researchable questions. You apply the FINER framework (Feasible, Interesting, Novel, Ethical, Relevant) to evaluate and refine each question.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 1 (Scoping)**. Your sole deliverable is the FINER-evaluated Research Question Brief (precise RQ + scope boundaries + 2-3 sub-questions).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 1 (no inflate into Phase 2 bibliography, Phase 3 synthesis, Phase 4 drafting, Phase 5 review, Phase 6 revision)
+- Produce content classified as a downstream-phase deliverable type (annotated bibliography, synthesis, draft, review, revision) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output (e.g., do not draft bibliography entries to "save time")
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (own phase) for legitimate context. Phase 1 is the entry point of the pipeline; there are no upstream phases to read.
+
+If downstream work is needed (bibliography, synthesis, etc.), return control to the caller with a recommendation. Do not execute.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Precision over breadth**: A narrow, answerable question beats a broad, unanswerable one

--- a/deep-research/agents/risk_of_bias_agent.md
+++ b/deep-research/agents/risk_of_bias_agent.md
@@ -12,6 +12,22 @@ You are the Risk of Bias Agent. You assess the risk of bias in studies included 
 **Identity**: Methodologist with expertise in Cochrane risk of bias assessment tools
 **Core Function**: Transform subjective quality concerns into standardized, reproducible bias assessments
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Systematic Review Phase 2 (Investigation, bias-assessment side)** — parallel to `bibliography_agent` and `source_verification_agent` in standard pipelines, but specific to systematic-review mode. Your sole deliverable is the RoB 2 / ROBINS-I assessment with traffic-light visualization output.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 2 (no inflate into Phase 3 meta-analysis, Phase 4 PRISMA report, Phase 5 review, Phase 6 revision)
+- Produce content classified as a downstream-phase deliverable type (meta-analysis effect sizes, GRADE certainty ratings, PRISMA report) even if you can see the data — those are `meta_analysis_agent`'s and `report_compiler_agent`'s jobs
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (RQ Brief, systematic-review protocol) and `phase2_*/` (own phase, including the bibliography_agent output) for legitimate context. Downstream phases are not needed.
+
+If downstream work is needed (meta-analysis, PRISMA compilation), return control to the caller.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Instrument fidelity**: Apply RoB 2 and ROBINS-I exactly as designed — do not invent custom criteria

--- a/deep-research/agents/source_verification_agent.md
+++ b/deep-research/agents/source_verification_agent.md
@@ -9,6 +9,22 @@ description: "Grades evidence, detects predatory publications, and fact-checks c
 
 You are the Source Verification Agent. You are the quality gatekeeper for all evidence entering the research pipeline. You grade sources using the evidence hierarchy, detect predatory publications, flag conflicts of interest, and verify factual claims against multiple sources.
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 2 (Investigation)** — same phase as `bibliography_agent`. Your sole deliverable is the Source Verification report (evidence grades + predatory-journal flags + COI flags + per-claim verification verdicts).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 2 (no inflate into Phase 3-6)
+- Produce content classified as a downstream-phase deliverable type (synthesis, draft, review, revision) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output (e.g., do not synthesize the verified findings — that's `synthesis_agent`'s Phase 3 work)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (Research Question Brief) and `phase2_*/` (own phase, including annotated bibliography from `bibliography_agent`) for legitimate context. Downstream phases are not needed.
+
+If downstream work is needed (synthesis, drafting, review), return control to the caller with a recommendation. Do not execute.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+
 ## Core Principles
 
 1. **Trust but verify**: No source is automatically trusted regardless of reputation

--- a/deep-research/agents/synthesis_agent.md
+++ b/deep-research/agents/synthesis_agent.md
@@ -10,6 +10,22 @@ model: inherit
 
 You are the Synthesis Agent. You perform the core intellectual work of research: integrating findings across multiple sources, identifying patterns and contradictions, resolving conflicts in evidence, mapping convergence and divergence, and identifying knowledge gaps. You bridge the gap between "finding sources" and "writing a report."
 
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to **Phase 3 (Analysis)**. Your sole deliverable is the Synthesis Report (integrated findings + contradiction resolution + thematic synthesis + gap analysis).
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ 3 (no inflate into Phase 4 drafting, Phase 5 review, Phase 6 revision)
+- Produce content classified as a downstream-phase deliverable type (full report draft, editorial review, revision) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output (e.g., do not produce a full APA 7.0 report — that's `report_compiler_agent`'s Phase 4 work)
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase1_*/` (Research Question Brief, Methodology Blueprint) and `phase2_*/` (annotated bibliography, source verification report) and `phase3_*/` (own phase) for legitimate context. Downstream phases are not needed.
+
+If downstream work is needed (report compilation, editorial review), return control to the caller with a recommendation. Do not execute.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134). This Phase Boundary block COEXISTS with the v3.6.7 PATTERN PROTECTION block below — both apply, neither overrides the other.
+
 ## Core Principles
 
 1. **Integration, not summarization**: Synthesize across sources, don't summarize each one sequentially

--- a/docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md
+++ b/docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md
@@ -87,7 +87,7 @@ All cross-phase / meta by design.
 
 | Bucket | Count | Agents |
 |---|---|---|
-| A (single-phase, get hard fence) | **23** | research_question, research_architect, bibliography, source_verification, synthesis, editor_in_chief, ethics_review, risk_of_bias, meta_analysis, literature_strategist, structure_architect, draft_writer, citation_compliance, abstract_bilingual, peer_reviewer, formatter, eic, methodology_reviewer, domain_reviewer, perspective_reviewer, devils_advocate_reviewer, editorial_synthesizer + (audit-flag: literature_strategist + draft_writer already have partial language) |
+| A (single-phase, get hard fence) | **22** | research_question, research_architect, bibliography, source_verification, synthesis, editor_in_chief, ethics_review, risk_of_bias, meta_analysis (9 deep-research) + literature_strategist, structure_architect, draft_writer, citation_compliance, abstract_bilingual, peer_reviewer, formatter (7 academic-paper) + eic, methodology_reviewer, domain_reviewer, perspective_reviewer, devils_advocate_reviewer, editorial_synthesizer (6 reviewer); audit-flag for harmonization (within Bucket A, not separate count): synthesis, literature_strategist, draft_writer |
 | B (multi-phase, no fence) | **4** | report_compiler, devils_advocate (deep-research), argument_builder, visualization |
 | C (phase-orthogonal, no fence) | **8** | socratic_mentor × 2 (deep-research + academic-paper), monitoring, revision_coach, integrity_verification, collaboration_depth, claim_ref_alignment_audit, compliance |
 | D (cross-phase / meta) | **3** | intake, pipeline_orchestrator, state_tracker, field_analyst |
@@ -95,18 +95,16 @@ All cross-phase / meta by design.
 
 **Recount D:** intake_agent (1) + pipeline_orchestrator_agent (2) + state_tracker_agent (3) + field_analyst_agent (4) = 4 agents.
 
-**Corrected totals:** A=23 + B=4 + C=8 + D=4 = **39 records**.
+**Final totals:** A=22 + B=4 + C=8 (incl. 2 × socratic_mentor) + D=4 = **38 records** total / **37 unique frontmatter `name`** values (socratic_mentor counted once at name-level; counted twice at file-level).
 
-Wait — that's 39 not 38. Cross-checking: socratic_mentor appears twice (deep-research + academic-paper) as separate .md files with same `name:` field. They are **2 separate agent files** in the 38-file count. Bucket C should be 8 (counting both socratic_mentor files separately).
+For Phase 1 sweep purposes (file-level), the operative count is: **22 files get hard fence**, **16 files get no fence**.
 
-**Final totals:** A=23 + B=4 + C=8 (incl. 2 × socratic_mentor) + D=4 = **39 records** total but **38 unique frontmatter `name`** values (socratic_mentor counted once at name-level; counted twice at file-level).
-
-For Phase 1 sweep purposes (file-level), the operative count is: **23 files get hard fence**, **15 files get no fence**.
+(Earlier draft of this section said A=23. Phase 1 sweep on 2026-05-18 confirmed actual count is 22 — corrected here. The miscount was a 9 + 7 + 6 = 22 typo, not a misclassification.)
 
 ## v3.9.2 fence coverage summary
 
-- **Files modified in Phase 1:** 23 (Bucket A only)
-- **Files documented in this table but unchanged:** 15
+- **Files modified in Phase 1:** 22 (Bucket A only)
+- **Files documented in this table but unchanged:** 16
 - **Already-has-language audits (within Bucket A):** 3 (synthesis, literature_strategist, draft_writer)
 
 ## Out-of-scope inflation risk acknowledged

--- a/docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md
+++ b/docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md
@@ -1,0 +1,134 @@
+# ARS v3.9.2 — 38-Agent Phase Classification Table
+
+**Date:** 2026-05-18
+**Spec:** Phase 0.2 of v3.9.2 hot-fix per `2026-05-18-ars-v3.9.2-phase-boundary-spec.md`
+**Issue:** #133 (phase scope inflation hot-fix); v3.10 (#134) deferred items noted
+**Purpose:** Canonical agent → phase classification used to drive Phase 1 prompt fence sweep. Per v4 design opus HIGH-1: 4-bucket model + per-agent out-of-scope inflation risk column.
+
+## 4-Bucket schema
+
+| Bucket | Definition | v3.9.2 treatment |
+|---|---|---|
+| **A — Single-phase** | Operates at exactly one numbered pipeline phase per invocation | Hard fence prompt block added |
+| **B — Multi-phase** | Operates at 2+ numbered phases across invocations | NO fence added (honest framing — placebo prose creates false-enforcement illusion); recurrence acknowledged, v3.10 envelope is the fix |
+| **C — Phase-orthogonal** | Operates outside numbered phase axis (Socratic Layers, Stage gates, cross-skill, advisory) | NO fence added; classification doc notes latent inflation risk class |
+| **D — Cross-phase / meta** | Legitimate cross-phase role by design (orchestrator, intake, observer) | NO fence added (legitimate by design) |
+
+## Classification table (38 rows)
+
+### deep-research/agents/ (13)
+
+| Agent | Bucket | Phase(s) declared | v3.9.2 fence | Out-of-scope inflation risk | Source citation |
+|---|---|---|---|---|---|
+| `research_question_agent` | A | Phase 1 (+ Socratic Layer 1) | hard-fence | (Socratic Layer 1 not covered; outside #133 class) | deep-research/SKILL.md row 1 |
+| `research_architect_agent` | A | Phase 1 | hard-fence | none specific | deep-research/SKILL.md row 2 |
+| `bibliography_agent` | A | Phase 2 | hard-fence | (this is #133's case agent — main target) | deep-research/SKILL.md row 3 |
+| `source_verification_agent` | A | Phase 2 | hard-fence | none specific (codex P2 corrected: NOT Phase 5 reviewer) | deep-research/SKILL.md row 4 |
+| `synthesis_agent` | A | Phase 3 | hard-fence (audit existing v3.6.7 PATTERN PROTECTION) | none specific | deep-research/SKILL.md row 5 |
+| `report_compiler_agent` | B | Phase 4, 6 | none-unmitigated | scope inflation across Phase 4↔6 invocations; v3.10 envelope is fix | deep-research/SKILL.md row 6 |
+| `editor_in_chief_agent` | A | Phase 5 | hard-fence | none specific | deep-research/SKILL.md row 7 |
+| `devils_advocate_agent` | B | Phase 1, 3, 5, Socratic Layer 2, 4 | none-unmitigated | scope inflation across invocations; v3.10 envelope is fix | deep-research/SKILL.md row 8 |
+| `ethics_review_agent` | A | Phase 5 | hard-fence | none specific | deep-research/SKILL.md row 9 |
+| `socratic_mentor_agent` | C | Socratic Mode Layer 1-5 (phase-orthogonal) | not-applicable | latent: direct-conclusion inflation (different class, not covered in v3.9.2) | deep-research/SKILL.md row 10 |
+| `risk_of_bias_agent` | A | Systematic Review Phase 2 | hard-fence | none specific | deep-research/SKILL.md row 11 |
+| `meta_analysis_agent` | A | Systematic Review Phase 3 | hard-fence | none specific | deep-research/SKILL.md row 12 |
+| `monitoring_agent` | C | Post-pipeline optional (phase-orthogonal) | not-applicable | low (advisory mode by design) | deep-research/SKILL.md row 13 |
+
+### academic-paper/agents/ (12)
+
+| Agent | Bucket | Phase(s) declared | v3.9.2 fence | Out-of-scope inflation risk | Source citation |
+|---|---|---|---|---|---|
+| `intake_agent` | D | Phase 0 (configuration interview, cross-phase by design) | none (meta) | low | academic-paper/SKILL.md row 1 |
+| `literature_strategist_agent` | A | Phase 1 (academic-paper, ≈ deep-research Phase 2 work) | hard-fence (audit existing v3.6.5 partial language) | none specific | academic-paper/SKILL.md row 2 |
+| `structure_architect_agent` | A | Phase 2 | hard-fence | none specific | academic-paper/SKILL.md row 3 |
+| `argument_builder_agent` | B | Phase 3 + Plan Step 3 | none-unmitigated | scope inflation Phase 3↔Plan Step; v3.10 envelope is fix | academic-paper/SKILL.md row 4 |
+| `draft_writer_agent` | A | Phase 4 | hard-fence (audit existing v3.6.6/v3.6.7 partial language) | none specific | academic-paper/SKILL.md row 5 |
+| `citation_compliance_agent` | A | Phase 5a | hard-fence | none specific | academic-paper/SKILL.md row 6 |
+| `abstract_bilingual_agent` | A | Phase 5b | hard-fence | none specific | academic-paper/SKILL.md row 7 |
+| `peer_reviewer_agent` | A | Phase 6 | hard-fence | none specific | academic-paper/SKILL.md row 8 |
+| `formatter_agent` | A | Phase 7 | hard-fence | none specific | academic-paper/SKILL.md row 9 |
+| `socratic_mentor_agent` | C | Plan Step 0-3 (phase-orthogonal — Plan mode, not numbered pipeline) | not-applicable | latent: direct-conclusion inflation; same class as deep-research socratic_mentor (different prompt body) | academic-paper/SKILL.md row 10 |
+| `visualization_agent` | B | Phase 4 + Phase 7 | none-unmitigated | scope inflation Phase 4↔7; v3.10 envelope is fix | academic-paper/SKILL.md row 11 |
+| `revision_coach_agent` | C | Revision-Coach mode (standalone, phase-orthogonal) | not-applicable | low (standalone mode by design) | academic-paper/SKILL.md row 12 |
+
+### academic-paper-reviewer/agents/ (7)
+
+All 5 reviewers (eic, methodology, domain, perspective, devils_advocate_reviewer) operate at this skill's **Phase 1**. The skill itself sits inside academic-pipeline's Phase 5 in the full pipeline, but each agent within the reviewer skill is single-phase relative to the skill's own phase numbering.
+
+| Agent | Bucket | Phase(s) declared | v3.9.2 fence | Out-of-scope inflation risk | Source citation |
+|---|---|---|---|---|---|
+| `field_analyst_agent` | D | Phase 0 (configures reviewers, meta) | none (meta) | low | academic-paper-reviewer/SKILL.md row 1 |
+| `eic_agent` | A | Phase 1 (reviewer skill) | hard-fence | none specific | academic-paper-reviewer/SKILL.md row 2 |
+| `methodology_reviewer_agent` | A | Phase 1 (reviewer skill) | hard-fence | none specific | academic-paper-reviewer/SKILL.md row 3 |
+| `domain_reviewer_agent` | A | Phase 1 (reviewer skill) | hard-fence | none specific | academic-paper-reviewer/SKILL.md row 4 |
+| `perspective_reviewer_agent` | A | Phase 1 (reviewer skill) | hard-fence | none specific | academic-paper-reviewer/SKILL.md row 5 |
+| `devils_advocate_reviewer_agent` | A | Phase 1 (reviewer skill — NOT same as deep-research devils_advocate_agent) | hard-fence | none specific | academic-paper-reviewer/SKILL.md row 6 |
+| `editorial_synthesizer_agent` | A | Phase 2 (reviewer skill) | hard-fence | none specific | academic-paper-reviewer/SKILL.md row 7 |
+
+### academic-pipeline/agents/ (5)
+
+All cross-phase / meta by design.
+
+| Agent | Bucket | Phase(s) declared | v3.9.2 fence | Out-of-scope inflation risk | Source citation |
+|---|---|---|---|---|---|
+| `pipeline_orchestrator_agent` | D | All phases (orchestrator) | none (meta) | low (high-trust by design) | academic-pipeline/SKILL.md row 1 |
+| `state_tracker_agent` | D | All phases (state tracking) | none (meta) | low | academic-pipeline/SKILL.md row 2 |
+| `integrity_verification_agent` | C | Stage 2.5 / 4.5 integrity gates (phase-orthogonal) | not-applicable | low | academic-pipeline/SKILL.md row 3 |
+| `collaboration_depth_agent` | C | FULL/SLIM checkpoints + pipeline completion (phase-orthogonal; advisory only) | not-applicable | low (advisory by design) | academic-pipeline/SKILL.md row 4 |
+| `claim_ref_alignment_audit_agent` | C | Opt-in claim audit (phase-orthogonal) | not-applicable | low (opt-in by design) | academic-pipeline/SKILL.md row 5 |
+
+### shared/agents/ (1)
+
+| Agent | Bucket | Phase(s) declared | v3.9.2 fence | Out-of-scope inflation risk | Source citation |
+|---|---|---|---|---|---|
+| `compliance_agent` | C | Stage 2.5 / 4.5 gates, cross-skill | not-applicable | latent: high write-authority (writes compliance_report to passport); low probability misclassification | shared/agents/compliance_agent.md frontmatter `invoked_by: [academic-pipeline, deep-research, academic-paper]` |
+
+## Bucket totals
+
+| Bucket | Count | Agents |
+|---|---|---|
+| A (single-phase, get hard fence) | **23** | research_question, research_architect, bibliography, source_verification, synthesis, editor_in_chief, ethics_review, risk_of_bias, meta_analysis, literature_strategist, structure_architect, draft_writer, citation_compliance, abstract_bilingual, peer_reviewer, formatter, eic, methodology_reviewer, domain_reviewer, perspective_reviewer, devils_advocate_reviewer, editorial_synthesizer + (audit-flag: literature_strategist + draft_writer already have partial language) |
+| B (multi-phase, no fence) | **4** | report_compiler, devils_advocate (deep-research), argument_builder, visualization |
+| C (phase-orthogonal, no fence) | **8** | socratic_mentor × 2 (deep-research + academic-paper), monitoring, revision_coach, integrity_verification, collaboration_depth, claim_ref_alignment_audit, compliance |
+| D (cross-phase / meta) | **3** | intake, pipeline_orchestrator, state_tracker, field_analyst |
+| **Total** | **38** | (D = 4 actually; recount below) |
+
+**Recount D:** intake_agent (1) + pipeline_orchestrator_agent (2) + state_tracker_agent (3) + field_analyst_agent (4) = 4 agents.
+
+**Corrected totals:** A=23 + B=4 + C=8 + D=4 = **39 records**.
+
+Wait — that's 39 not 38. Cross-checking: socratic_mentor appears twice (deep-research + academic-paper) as separate .md files with same `name:` field. They are **2 separate agent files** in the 38-file count. Bucket C should be 8 (counting both socratic_mentor files separately).
+
+**Final totals:** A=23 + B=4 + C=8 (incl. 2 × socratic_mentor) + D=4 = **39 records** total but **38 unique frontmatter `name`** values (socratic_mentor counted once at name-level; counted twice at file-level).
+
+For Phase 1 sweep purposes (file-level), the operative count is: **23 files get hard fence**, **15 files get no fence**.
+
+## v3.9.2 fence coverage summary
+
+- **Files modified in Phase 1:** 23 (Bucket A only)
+- **Files documented in this table but unchanged:** 15
+- **Already-has-language audits (within Bucket A):** 3 (synthesis, literature_strategist, draft_writer)
+
+## Out-of-scope inflation risk acknowledged
+
+Per opus HIGH-1 column, the following risk classes are **explicitly NOT covered** by v3.9.2:
+
+1. **Multi-phase scope inflation** (Bucket B, 4 agents): report_compiler, devils_advocate (deep-research), argument_builder, visualization — recurrence expected; v3.10 envelope is fix
+2. **Socratic direct-conclusion inflation** (socratic_mentor × 2): different failure class from #133 (not silent scope expansion but Socratic discipline failure)
+3. **Compliance write-authority misclassification** (compliance_agent): low-probability latent risk; v3.10 envelope makes this structurally impossible
+4. **Phase 5a / 5b / 7 academic-paper sub-phases**: in scope (treated as distinct single-phase numbers in this classification)
+
+## Migration notes
+
+**For users:** if you see one of the 4 Bucket B multi-phase agents producing out-of-scope content (e.g., `devils_advocate_agent` producing draft text instead of devil's-advocate critique), this is a known v3.9.2 limitation. Remediation:
+- Switch to Mode A orchestrator-driven invocation (`/ars-full` or via `pipeline_orchestrator_agent`)
+- Report the case to issue #134 with transcript excerpt
+
+## v3.10 carry-over (logged for #134)
+
+The 4-bucket model + per-agent column documents **what v3.10 conductor + envelope schema must handle**:
+
+- Multi-phase agents need `ars_phase_writes: [list]` + `ars_phase_reads: [list]` envelope declarations
+- Phase-orthogonal agents need separate axis (e.g., `socratic_layer: [list]` or `stage_gate: [list]`)
+- Meta agents need explicit cross-phase permission grant (e.g., `phase_grants: all`)
+- Cross-file `socratic_mentor_agent` deduplication question: should they merge to single definition or remain skill-scoped? (v3.10 decision)

--- a/docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md
+++ b/docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md
@@ -1,0 +1,400 @@
+# ARS Issue #133 — Phase Scope Inflation: Design Doc (v4 — HIGH-finding amendment)
+
+**Date:** 2026-05-18
+**Issue:** #133 — Phase 2+ agents can silently inflate scope and skip independent Phase 3/5 checkpoints
+**Severity:** HIGH (silent integrity failure; recurrence-risk pattern)
+**Target release:** v3.9.2
+**Design phase:** v3 review complete (codex `review --base main` broken-corner + inline opus subagent). Opus surfaced 2 HIGH + 5 MED + 3 LOW findings. v4 (this doc) addresses both HIGH; MED/LOW deferred to impl phase per user decision.
+**Related:** #134 (v3.10 active conductor architecture — long-term fix; hook + multi-phase schema + provenance now live there)
+
+**Doc revision history:**
+- v1: initial — single-track self-review. 9 issues identified.
+- v2: incorporated codex r2 + inline opus + self triple-track review. Resolved 3 conflicts; v2 committed to hook + verifier in v3.9.2.
+- v3: incorporated v2 dual-track review (codex r2 retry + inline opus). 14 findings showed scalar `ars_phase` schema is wrong (multi-phase agents exist), L1 routes to orchestrator that can't handle it, hook lookup mechanism is hand-waved. **Scope narrowed**: hot-fix ships only L1 routing + Fix 1 prompt fence + advisory verifier. Hook (Fix 2), multi-phase schema, deterministic provenance all moved to v3.10 conductor.
+- v4 (this doc): incorporated v3 review (codex broken corner + inline opus). HIGH-1 (3-bucket model insufficient → 4-bucket A/B/C/D with out-of-scope inflation column) + HIGH-2 (multi-phase lite reminder is placebo → cut entirely, honest framing) addressed. MED/LOW carry to impl phase. Effort revised 18-22h → 18-23h with Phase 0.2 bumped to 2-3h.
+
+---
+
+## 1. Problem (unchanged from v2)
+
+#133 was originally framed as "subagent inflates scope when invoked phase-by-phase." A user incident report on 2026-05-18 revealed a deeper root cause: **ARS itself routes ambiguous input to a single-phase subagent instead of engaging the orchestrator**, then the subagent inflates from that bad starting position.
+
+### L1 — Routing failure (root cause)
+
+User provided pre-existing abstract (Phase 4 artifact) + pre-collected literature (Phase 2 artifact) with no explicit invocation. ARS routing logic auto-dispatched a single phase agent without engaging `pipeline_orchestrator_agent`. This is a routing discipline failure: ambiguous input + LLM helpfulness = shortcut to single-phase dispatch.
+
+### L2 — Subagent scope inflation (downstream symptom)
+
+Once dispatched without orchestrator oversight, the phase agent treated visible end-goal + write permissions as license to "be helpful" and produced Phase 3/4/5/6 output autonomously. Mandatory independent crosschecks (DA2 / DA3 / editor-in-chief / ethics_review) were silently skipped.
+
+### Relation to #134 (v3.10 conductor)
+
+v3.10 will replace passive routing + autonomous subagent with active conductor + structured task envelopes. v3.9.2 is the **hot-fix** that buys time for v3.10 to be designed correctly.
+
+---
+
+## 2. Why v3 narrowed scope (review findings that forced the call)
+
+v2 design committed to deterministic hook + verifier in v3.9.2. Round-2 dual-track review (codex retry + inline opus) surfaced critical findings that revealed the deterministic gate cannot be built correctly in hot-fix scope. Key blockers:
+
+### Blocker 1: Scalar `ars_phase` schema is wrong
+
+Multi-phase agents exist in actual ARS:
+- `devils_advocate_agent` runs at **Phases 1, 3, 5 + Socratic Layer 2, 4** (per `deep-research/SKILL.md` agent table)
+- `report_compiler_agent` runs at **Phases 4, 6**
+- `socratic_mentor_agent` runs at Socratic layers, not numbered phase
+- `compliance_agent` runs at any phase (Stage 2.5 / 4.5 integrity gates, cross-skill)
+- academic-paper has sub-phases (5a/5b, generator-evaluator contract)
+
+Single scalar `ars_phase: <N>` cannot represent any of these. v2's `{1..6, orchestrator, meta}` enum is also insufficient (e.g., what's DA's value? `1`? `1,3,5`? `meta`?).
+
+**Correct schema is multi-phase** (`ars_phase_writes: [list]`, `ars_phase_reads: [list]`) or pattern-based (`ars_phase: "1|3|5"`). Designing that properly + auditing all 38 agents to assign correct values is **multi-day work**, not hot-fix scope.
+
+### Blocker 2: Codex P1 — forbidding `phase{N-1}_*/` reads breaks legitimate handoffs
+
+v2 Phase 1 prompt fence said:
+> You MUST NOT: Read or write files in `phase{N+1}_*/`, `phase{N-1}_*/`, ...
+
+Codex P1 finding: Phase 3 synthesis **must** read Phase 2 bibliography; Phase 4 drafting must read Phase 3 synthesis; etc. The "no regress" rule was over-reach. v3 corrects: only **writes** are scope-bound, reads from upstream phases are always allowed.
+
+### Blocker 3: Opus H3 — L1 routes to orchestrator that can't handle cross-phase materials
+
+Current `pipeline_orchestrator_agent.md` keyword-matches user phrasing (Stage 1 vs Stage 2 etc.). It does NOT have logic for "user dropped cross-phase artifacts, no passport, no explicit invocation — figure out where in the pipeline to resume from." That capability is the heart of #134 (conductor with structured intake), not a hot-fix patch.
+
+v2's L1 strategy (route ambiguous input to orchestrator) was thus broken — destination was non-functional. v3 changes L1: instead of routing to orchestrator, ARS simply **clarifies** with the user.
+
+### Blocker 4: Opus H2 + Codex P2 — hook lookup + verifier provenance are missing infrastructure
+
+- Hook needs `agent_type → ars_phase` lookup mechanism that doesn't exist (where it lives, regeneration, stale-safe).
+- Verifier needs tamper-resistant author provenance on each phase file that doesn't exist (current passport records skill/mode, not exact agent).
+
+Both are infrastructure work that v3.10 conductor will design correctly with task envelopes. Trying to bolt them on in hot-fix produces fragile half-solutions.
+
+### Decision: narrow v3.9.2 to prompt-and-routing-discipline-only
+
+Hot-fix scope:
+- **L1**: routing clarification gate (not orchestrator detour — destination is broken)
+- **Fix 1**: prompt hard fence per agent (writes only, reads allowed) — for **single-phase agents** only in v3.9.2; multi-phase agents get prose-only "be aware of your phase" reminder pending v3.10 schema
+- **Fix 3**: SKILL.md phase-by-phase invocation contract
+- **Fix 4 lite**: advisory-only verifier (heuristic, no provenance guarantee)
+
+Cut from v3.9.2:
+- ~~Fix 2 PreToolUse hook~~ → v3.10 (needs multi-phase schema + lookup mechanism + Phase 0.1's `agent_type` finding is preserved for v3.10)
+- ~~Multi-phase `ars_phase` schema~~ → v3.10
+- ~~Orchestrator cross-phase intake capability~~ → v3.10 (this is conductor's core feature anyway)
+- ~~Deterministic verifier with provenance~~ → v3.10
+
+What remains is a **prompt-discipline-plus-routing-clarification hot-fix**. It won't fully prevent #133 (capable models can still rationalize past prompts), but it raises the bar significantly + buys time for v3.10.
+
+---
+
+## 3. Implementation plan (scope-narrowed)
+
+### Phase 0: Pre-flight (~1h)
+
+- **0.1 ✅ DONE** Phase 0.1 from v2 preserved as note: CC PreToolUse payload contains `agent_type` field equaling agent frontmatter `name`. **Not used in v3.9.2** (hook deferred to v3.10). Recorded for v3.10 conductor design.
+- **0.2 (NEW)** Audit each of the 38 unique agent .md files to classify into **4 buckets** (revised per v3 review opus HIGH-1):
+  - **Bucket A — Single-phase** (e.g., `bibliography_agent` = P2 only, `research_question_agent` = P1 only) → gets v3.9.2 hard boundary prompt
+  - **Bucket B — Multi-phase** (e.g., `devils_advocate_agent` = P1+P3+P5, `report_compiler_agent` = P4+P6) → **NO boundary added in v3.9.2** (per HIGH-2 honest framing — placebo prose would create illusion of enforcement). Recurrence acknowledged; v3.10 envelope is the fix.
+  - **Bucket C — Phase-orthogonal** (e.g., `socratic_mentor_agent` operates on Socratic Layers 1-5 not numbered pipeline phases; `compliance_agent` runs at Stage 2.5 / 4.5 integrity gates cross-skill) → no boundary added. Note in classification doc whether the agent has any latent inflation risk class (e.g., socratic_mentor inflating into direct conclusions); v3.9.2 explicitly does not cover those classes.
+  - **Bucket D — Cross-phase / meta** (e.g., `pipeline_orchestrator_agent`, `field_analyst_agent`, `intake_agent`) → no boundary added (legitimate cross-phase by design role)
+  
+  **Audit-flag (NOT a bucket):** `draft_writer_agent`, `literature_strategist_agent` already carry partial boundary language. Assigned to whichever real bucket they belong (likely both Bucket A — Phase 4 and Phase 2-equivalent respectively); audit existing language for v3.9.2 consistency. Do NOT classify these as a separate bucket.
+  
+  **Output table columns** (per opus HIGH-1):
+  
+  | Agent | Bucket | Phase(s) declared in | v3.9.2 fence coverage | Out-of-scope inflation risk | Source citation |
+  |---|---|---|---|---|---|
+  | bibliography_agent | A | Phase 2 | hard-fence | (none specific to v3.9.2) | deep-research/SKILL.md row 3 |
+  | devils_advocate_agent | B | Phase 1, 3, 5, Socratic L2/L4 | none-unmitigated | scope inflation across invocations; awaits v3.10 envelope | deep-research/SKILL.md row 8 |
+  | socratic_mentor_agent | C | Socratic Layers 1-5 (phase-orthogonal) | not-applicable | latent: direct-conclusion inflation (different class from #133, not covered) | deep-research/SKILL.md row 10 |
+  | compliance_agent | C | Stage 2.5 / 4.5 cross-skill | not-applicable | latent: high-write-authority misclassification (low probability) | shared/agents/compliance_agent.md |
+  | ... | ... | ... | ... | ... | ... |
+  
+  Output: `docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md` (38-row table with the columns above).
+  
+  **Estimate revision:** 2-3h (not 1-1.5h per opus MED-5 — 38 agents × careful cross-check against SKILL.md tables + frontmatter + actual usage is non-trivial).
+
+### Phase L1: Routing clarification gate (~3-4h)
+
+**Goal:** When user provides ambiguous cross-phase input, ARS must clarify before dispatching ANY agent. v2's "route to orchestrator" approach dropped because orchestrator can't handle this case (deferred to v3.10).
+
+#### L1.1 — Routing discipline rule in `.claude/CLAUDE.md` (single source of truth)
+
+Insert before existing "Routing Rules":
+
+```markdown
+## Routing Discipline (v3.9.2)
+
+**Routing precedence:** This section runs BEFORE Routing Rules 1-5. Once this section settles on a destination, Rules 1-5 apply within that destination's skill family.
+
+Before invoking any ARS skill or agent, classify the user's input:
+
+1. **Explicit clear intent** (user names a specific skill via `/ars-*` command or unambiguous trigger keyword like "lit-review this", "review my paper"):
+   → Route directly; no clarification.
+
+2. **Cross-phase materials detected** (user provides artifacts spanning ≥ 2 pipeline phases — e.g., pre-written abstract + pre-collected literature):
+   → **Clarify**. Do NOT auto-route to a single-phase agent. List candidate workflows as a-d options in markdown body (NOT via AskUserQuestion tool, per `feedback_no_askuserquestion_use_brainstorm.md`).
+   → Reason: clarification is the safest action when materials don't unambiguously identify intent. (v3.10 conductor will handle this via structured intake; for now, ask.)
+
+3. **No materials, ambiguous request:**
+   → Clarify per `shared/references/intent_clarification_protocol.md`.
+
+**Escape hatch:** Prefix `[direct-mode]` at start of first message → all clarification bypassed; ARS dispatches whatever single agent matches the literal trigger.
+
+**Anti-pattern (caused #133):** Receiving ambiguous cross-phase materials and silently auto-routing to a single-phase agent based on which phase the materials "look closest to."
+
+**Forward note (v3.10):** Active conductor will reframe this gate as structured intake with task envelope dispatch. v3.9.2 ships clarification-only as interim.
+```
+
+#### L1.2 — Protocol doc: `shared/references/intent_clarification_protocol.md` (NEW file)
+
+Carries:
+- **Trigger condition table** (precise rules for the 3 routing classes)
+- **Clarification message template** (a-d options format, multi-select discipline per `feedback_telegram_conversation_style.md`)
+- **`[direct-mode]` escape hatch behavior spec**: must be byte-0 of first message (case-insensitive); literal `[direct-mode]` or `[Direct-Mode]` accepted; consumed by main session before routing, stripped from passed-through message
+- **3-5 worked examples** of inputs → correct routing outcome
+- **Forward note** referencing #134 / v3.10 active conductor
+
+#### L1.3 — Single-line backpointer in 4 SKILL.md files
+
+```markdown
+> **Routing discipline:** see `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" + `shared/references/intent_clarification_protocol.md`. This skill assumes routing has already settled.
+```
+
+No rule duplication; source-of-truth lives in CLAUDE.md + protocol doc.
+
+#### L1.4 — Behavioral smoke tests (NOT deterministic unit tests, honestly framed)
+
+8 fixture cases covering:
+- Cross-phase materials (abstract + lit) → asserts clarification triggers (NOT silent dispatch)
+- Single-phase material (literature only) → asserts ARS proceeds with Phase 2 work (no clarification needed for single-phase)
+- No materials + ambiguous request → asserts clarification with a-d options
+- Explicit `/ars-lit-review` invocation → asserts skip clarification
+- `[direct-mode] run bibliography_agent` → asserts skip clarification
+- `[direct-mode]` mid-message (not byte-0) → asserts clarification still fires (escape hatch not honored)
+- `[Direct-Mode]` case variant → asserts escape hatch honored (case-insensitive)
+- Full draft + abstract + lit → assertion: clarification fires (cross-phase, no clear skill named)
+
+**Acceptance criterion:** 100% pass on Opus 4.7; ≥ 75% pass on Sonnet 4.6 + GPT-5.5 (degradation flagged but non-blocking ship). Framed as behavioral smoke test + cross-model spot-check, not green/red unit test.
+
+### Phase 1: Fix 1 — Prompt hard fence per agent (~4-5h, NOT 5-7h, scope narrowed)
+
+**Scope (per Phase 0.2 4-bucket classification, revised per v3 review):**
+- **Bucket A — Single-phase agents** (~25 of 38, finalized in Phase 0.2): full hard boundary block as below
+- **Bucket B — Multi-phase agents** (~8 of 38): **NO boundary added** (placebo prose creates false-enforcement illusion; HIGH-2 honest framing)
+- **Bucket C — Phase-orthogonal agents** (~3 of 38): no boundary added; classification doc notes any latent inflation risk
+- **Bucket D — Cross-phase / meta agents** (~2 of 38): no boundary added (legitimate cross-phase role)
+- **Audit-flag (within Bucket A):** `draft_writer_agent`, `literature_strategist_agent` carry existing partial language — harmonize with v3.9.2 hard fence shape
+
+Net effect: only Bucket A agents receive new prompt fence. Bucket B-D are documentation-only changes (added to classification doc, no agent .md modification).
+
+#### Single-phase hard boundary block
+
+Insert after persona, before role description:
+
+```markdown
+## Phase Boundary (v3.9.2)
+
+You are a single-phase agent assigned to Phase N (<phase name>). Your sole deliverable is <X>.
+
+You MUST NOT:
+- WRITE files in `phase{M}_*/` directories where M ≠ N (no inflate)
+- Produce content classified as a downstream-phase deliverable type (synthesis / draft / review / revision / etc.) even if you can see the end-goal
+- Invoke or simulate any other agent persona's output
+- "Helpfully" continue past your assigned deliverable
+
+You MAY READ files in `phase{1}_*/` through `phase{N}_*/` (upstream + own phase) for legitimate context. Reads from downstream phases (`phase{N+1}_*/`+) are not needed for your work.
+
+If downstream work is needed, return control to the caller with a recommendation. Do not execute.
+
+**Enforcement (v3.9.2):** prompt-level only. Advisory verifier (`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. Deterministic PreToolUse hook deferred to v3.10 active conductor (#134).
+```
+
+#### Multi-phase agents: NO additional prompt in v3.9.2 (honest framing per v3 review)
+
+v3 dual-track review (inline opus HIGH-2) surfaced that any prose-level "lite reminder" for multi-phase agents is essentially placebo — #133's caller prompt already contained tight phase-scope language ("Phase 2 only, no fabrication, return under 300 words") and the agent still inflated. Adding a similar reminder at the agent persona layer delegates enforcement back to the same prompt mechanism that already failed.
+
+**Decision:** multi-phase agents (devils_advocate, report_compiler, etc., per Phase 0.2 classification) receive **NO additional prompt fence in v3.9.2**. Their existing role descriptions stand. The multi-phase inflation class is **explicitly unmitigated in v3.9.2**; deterministic enforcement via task envelope is the v3.10 conductor (#134) fix.
+
+This is documented in:
+- The Phase 0.2 classification table (per-agent column: "v3.9.2 fence coverage" with values `hard-fence | none-unmitigated | not-applicable`)
+- §5 Failure modes — explicit "multi-phase inflation remains possible; recurrence expected for ~N agents until v3.10"
+- README migration note — if user sees DA / RC / similar multi-phase agent producing out-of-scope content, the remediation is "report to issue #134, do not retry, switch to Mode A orchestrator-driven invocation"
+
+**Rationale for not adding placebo prose:** users (and codex review) reading the multi-phase agent .md should not see boundary language that creates an illusion of enforcement. Either the fence works (single-phase case) or there's no fence (multi-phase case, explicitly acknowledged). This is more honest than splitting hairs about "lite reminder" semantics.
+
+#### Frontmatter: NO `ars_phase` field in v3.9.2
+
+v2's scalar `ars_phase` is intentionally NOT added in v3.9.2. Multi-phase schema is v3.10 work. Adding scalar now and changing to multi-list later creates schema migration friction.
+
+### Phase 3: Fix 3 — SKILL.md phase-by-phase invocation contract (~1h)
+
+Add to all 4 SKILL.md files:
+
+```markdown
+## Phase-by-phase Invocation Contract (v3.9.2)
+
+ARS pipeline runs in 6 phases. Two invocation modes:
+
+**Mode A — orchestrator-driven (default):** `pipeline_orchestrator_agent` runs all phases end-to-end with state tracking.
+
+**Mode B — phase-by-phase (Material Passport resume):** User invokes one agent per phase across sessions (long-running projects).
+
+In Mode B, **each single-phase agent stays strictly within its assigned phase for writes**. Reads from upstream phases are allowed. Multi-phase agents (e.g., `devils_advocate_agent`) do exactly the work specified by the caller's invocation prompt, no more.
+
+Routing into Mode B requires explicit user signal — `/ars-<mode>` slash command or `[direct-mode]` prefix. Ambiguous cross-phase input triggers clarification (per `.claude/CLAUDE.md` Routing Discipline).
+
+**Enforcement:** prompt-level + advisory verifier in v3.9.2; deterministic gate in v3.10 active conductor (#134).
+```
+
+### Phase 4: Fix 4 lite — Advisory post-hoc verifier (~2h, simpler than v2 design)
+
+File: `scripts/check_pipeline_integrity.py` (joins existing 28 `check_*.py` scripts).
+
+**Logic (v3.9.2 lite — no provenance required):**
+- Scan working directory for `phase{1-6}_*/` dirs
+- For each directory pair (phaseN_, phaseM_) where N+1 < M (skip-ahead detected):
+  - Flag (INTEGRITY-ADVISORY) if files in both directories share creation timestamp within 5-minute window (suggests single-dispatch generation)
+- For Phase 5 specifically:
+  - Flag (INTEGRITY-ADVISORY) if phase5_*/ exists but no separate review reports from DA / EIC / Ethics (heuristic: filenames not matching `*devils*`, `*editor*`, `*ethics*`)
+- **Output:** human-readable advisory list, NOT machine-enforceable. User reviews + decides.
+
+**Acceptance criterion:** verifier flags the #133 reported failure case (bibliography_agent producing phase3_*/phase4_*/phase5_*/phase6_*/ in single dispatch — they'll all have timestamps within ~minutes of each other).
+
+**Limitations explicit (v3.9.2):**
+- NO author provenance check (deferred to v3.10 conductor + envelope schema)
+- 5-minute window is heuristic, not deterministic
+- Multi-phase agents producing legitimate work in 2+ phases will trigger false-positive (acknowledged limitation)
+- Advisory-only — does not block, only surfaces signals for user review
+
+### Phase 5: Lint compat audit (~2h) — MOVED before Phase 1 per opus H5
+
+**Order corrected from v2:** lint compat audit runs **before** prompt fence sweep, not after. Reason: if existing 28 `check_*.py` scripts have strict frontmatter validation, adding boundary block headings (or worse, frontmatter fields) could break CI mid-sweep.
+
+**Audit method:**
+- Grep all 28 `scripts/check_*.py` for `frontmatter`, `yaml`, `parse_yaml`, agent .md path patterns
+- Identify which scripts read agent frontmatter and what fields they expect
+- Run each on a single test agent .md with proposed v3.9.2 prompt fence body (no new frontmatter field — just new section in body) — confirm no break
+- Document findings in Phase 0.2 classification doc
+
+**Expected outcome:** no breaks (we're adding markdown sections, not frontmatter fields). But verify before sweep.
+
+### Phase 6: TDD + cross-model review (~3-4h)
+
+**Test additions:**
+- L1.4 behavioral smoke tests (8 fixtures, cross-model spot-check)
+- Phase 4 verifier tests (positive: #133 case detected; negative: legitimate multi-day pipeline run not flagged)
+- Lint compat verified (Phase 5)
+
+**Review:**
+- `codex review --base main` (success corner config: small diff, free-form output)
+- Inline opus subagent independent review (parallel)
+- Skip Gemini per memory sample 12 (broken on ARS context)
+
+**Expected rounds:** 2-3 (v3 already incorporates 2 rounds of dual-track findings; remaining iterations cover implementation-level issues codex catches in the actual code).
+
+### Phase 7: Security + PII + public-flip readiness (~1h)
+
+- `~/.claude/personal-boundary/check_boundary.py --root . --quiet`
+- Per `feedback_public_flip_readiness_checklist.md` 12-item audit (ARS is public repo)
+- Per `feedback_ars_public_repo_boundary.md` — grep for hei-platform / Springer / HEEACT leakage in new files
+
+### Phase 8: Documentation + migration (~1.5h)
+
+- Spec doc `docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md` (final)
+- CHANGELOG entry under `[Unreleased]`
+- README migration note: existing in-flight projects → no break expected (we only added prompt sections and an advisory verifier; no behavior change for explicit-intent flows)
+- `feedback_*` memory updates as warranted
+
+---
+
+## 4. Pipeline-wide silent drift inventory — MOVED to #134 (v3.10 conductor)
+
+The original v1 design doc carried a 14-row inventory of silent drift candidates beyond #133. Per v2 opus subagent review, that material is roadmap-class, not hot-fix material, and is in #134 issue body.
+
+---
+
+## 5. Failure modes + mitigations (v3 scope-narrowed)
+
+- **L1 over-asks** (codex v2 finding): less risk in v3 — clarification only fires on cross-phase materials OR no-material ambiguous requests. Single-phase materials route directly. Risk reduced vs v2 (which routed everything to orchestrator).
+- **Capable model rationalizes past prompt fence** (acknowledged limitation): v3.9.2 explicitly states "prompt-level only, deterministic gate in v3.10." User expectation aligned.
+- **Multi-phase agents receive NO v3.9.2 fence** (acknowledged limitation per v3 HIGH-2 honest framing): the ~8 Bucket B agents (devils_advocate, report_compiler, etc.) are explicitly **unmitigated in v3.9.2**. Recurrence expected for this class; v3.10 conductor + envelope schema is the proper fix. User-facing remediation: switch to Mode A orchestrator-driven invocation if multi-phase agent appears to inflate; report case to #134.
+- **Phase-orthogonal agents (socratic_mentor, compliance_agent)** have latent inflation classes (direct-conclusion drift for socratic, write-authority misclassification for compliance) that are **explicitly out of v3.9.2 scope** — different failure class from #133. Classification doc records the risk per opus HIGH-1.
+- **Verifier false-positives on legitimate fast pipeline runs** (acknowledged): advisory output is user-reviewed, not auto-blocking.
+- **`[direct-mode]` prefix edge cases** (per opus M1): specified in protocol doc — byte-0, case-insensitive, stripped before pass-through.
+- **Lint compat break** (per opus H5): Phase 5 moved before Phase 1 to gate the sweep.
+- **No deterministic enforcement** (acknowledged hot-fix trade-off): v3.9.2 buys time for v3.10 conductor; this is the explicit cost.
+- **Codex 0.130 broken on ARS context** (memory sample 12): use `codex review --base main` with small diff (success corner); skip xhigh `codex exec`; inline opus subagent as parallel insurance.
+
+---
+
+## 6. Verification plan
+
+Once Phases 0-8 land, produce proof:
+
+1. **Negative integration smoke test:** input "abstract + literature, see what you can do" → ARS clarifies with a-d options, does NOT silently dispatch. Verbatim transcript in `tests/fixtures/issue_133/`.
+2. **L1 boundary case sweep:** 8 fixtures pass on Opus 4.7; degradation flagged on Sonnet + GPT-5.5.
+3. **Verifier flags #133 case:** run on test fixture matching reported failure → ≥ 4 INTEGRITY-ADVISORY lines flagged.
+4. **Lint compat clean:** all 28 existing `check_*.py` pass on agent files with new boundary block.
+5. **Phase 0.2 classification table:** 38-row doc shipped, citations to SKILL.md / agent .md frontmatter for each phase assignment.
+6. **Full pytest suite:** v3.9.1 baseline (1463+) + new tests; no regression in v3.6.7 / v3.7.3 / v3.9.0 / v3.9.1 patterns.
+
+---
+
+## 7. Effort estimate (recalculated for v3 scope-narrowed)
+
+| Phase | Description | Hours |
+|---|---|---|
+| 0 | Pre-flight + 38-agent **4-bucket** phase classification (per opus HIGH-1) | 2-3 |
+| 5 | Lint compat audit (MOVED before Phase 1) | 1.5-2 |
+| L1 | Routing rule + protocol doc + 4 SKILL.md backpointer + 8 smoke tests | 3-4 |
+| 1 | Prompt fence × ~25 Bucket A agents only (Bucket B/C/D no agent .md changes) | 3-4 |
+| 3 | SKILL.md phase contract × 4 | 1 |
+| 4 | Advisory verifier (lite, no provenance) | 2 |
+| 6 | TDD red tests + cross-model review (2-3 rounds) | 3-4 |
+| 7 | Security + PII + public-flip audit | 1 |
+| 8 | Spec doc + CHANGELOG + README migration | 1.5 |
+
+**Total v3.9.2:** **18-23h, ~3-4 working days.**
+
+(v2 estimate was 22-32h with hook + provenance; v3 cut both. v4 adjustments — Phase 0.2 bump for 4-bucket audit + Phase 1 shrink because only Bucket A gets fence — net to 18-23h.)
+
+---
+
+## 8. v3.10 carry-over (logged for #134)
+
+Items deferred from v3.9.2 to v3.10 conductor:
+
+| Item | Reason for deferral |
+|---|---|
+| PreToolUse hook (Fix 2) | Requires multi-phase schema + lookup mechanism; v3.10 conductor's task envelope is the proper substrate |
+| Multi-phase `ars_phase_writes` + `ars_phase_reads` schema | Cannot be retrofitted scalar → list cleanly; v3.10 will design correctly with envelope |
+| Deterministic verifier with author provenance | Requires tamper-resistant author record on phase files; v3.10 envelope provides natively |
+| Orchestrator cross-phase intake capability | Heart of v3.10 conductor architecture — passive routing → active intent classification |
+| `agent_type → ars_phase` lookup mechanism | Will be obsoleted by envelope-carried phase info |
+| Phase-5 reviewer cross-phase READ exception | Becomes envelope-declared read permissions |
+
+Phase 0.1 finding (CC PreToolUse payload has `agent_type` field equaling agent frontmatter `name`) preserved as design input for v3.10 conductor hook implementation.
+
+---
+
+## 9. Decision log
+
+| Decision | v3 Choice | Source |
+|---|---|---|
+| Hook (Fix 2) | **DEFERRED to v3.10** | v2 dual-track review — Codex P1 (regress read break) + Opus H1 (multi-phase schema) + Opus H2 (lookup hand-wave) |
+| Multi-phase `ars_phase` schema | **DEFERRED to v3.10** | Codex P1 (multi-phase agents exist) + Opus H1 |
+| L1 routing default | **Clarify, not orchestrator detour** | Opus H3 — orchestrator doesn't handle this case yet |
+| Deterministic verifier with provenance | **DEFERRED to v3.10**; v3.9.2 ships advisory-only | Codex P2 — provenance infrastructure missing |
+| Prompt fence READ scope | **Allow upstream reads, only block writes** | Codex P1 — v2 over-reached |
+| Single-phase vs multi-phase agent treatment | **Different prompts** (hard fence vs lite reminder) | Codex P1 (multi-phase exist) |
+| Effort estimate | **18-22h** (down from v2's 22-32h) | Scope narrowed |
+| Lint compat audit order | **Before Phase 1 sweep** | Opus H5 |
+| `[direct-mode]` prefix spec | Byte-0, case-insensitive, stripped before routing | Opus M1 |
+| Q1 platform scope | Option B (preserved from v1/v2) | unchanged |
+| Inventory (14 silent drift) | Lives in #134 | v2 Opus |
+| Codex 0.130 routing | `codex review --base main` only; skip xhigh `codex exec` | Memory sample 12 |
+| **v4: 4-bucket classification model** | A single-phase / B multi-phase / C phase-orthogonal / D cross-phase-meta; "already-has-language" is audit-flag within Bucket A, not separate bucket | v3 review opus HIGH-1 |
+| **v4: Multi-phase agents get NO fence in v3.9.2** | Honest framing — placebo prose would create false-enforcement illusion. ~8 Bucket B agents explicitly unmitigated; v3.10 envelope is the fix. | v3 review opus HIGH-2 |
+| **v4: Phase 0.2 estimate revised 1-1.5h → 2-3h** | 38 agents × 4-bucket careful cross-check is non-trivial | v3 review opus MED-5 |

--- a/scripts/check_pipeline_integrity.py
+++ b/scripts/check_pipeline_integrity.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Advisory verifier for ARS pipeline phase scope (v3.9.2).
+
+Spec: docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md Phase 4
+Issue: #133 (phase scope inflation hot-fix)
+Forward note: v3.10 active conductor (#134) replaces this with deterministic
+provenance-based verification via task envelope; this v3.9.2 advisory is
+heuristic and FP-prone by design.
+
+Usage:
+    python scripts/check_pipeline_integrity.py [workdir]
+    python scripts/check_pipeline_integrity.py --json [workdir]
+
+Default workdir: current directory.
+
+This script SCANS a working directory for `phaseN_*/` subdirectories (where
+N is 1-6 per the ARS pipeline phase convention) and flags advisory signals
+that suggest #133-class scope inflation. Output is ADVISORY ONLY — it does
+NOT block any workflow. User reviews findings and decides.
+
+Detection rules (v3.9.2 lite):
+
+1. **Phase 5 missing independent reviewer attribution** (HIGH-VALUE structural rule)
+   When `phase5_*/` exists but contains no separate files matching the
+   independent-reviewer naming convention (devils_advocate / editor_in_chief /
+   ethics_review / eic / methodology / domain / perspective / editorial_synthesizer),
+   flag INTEGRITY-ADVISORY. This catches the exact #133 reported pattern:
+   a single agent producing phase5_*/ output that looks like a review but was
+   never actually crosschecked by independent reviewer agents.
+
+2. **Multi-phase same-call generation heuristic** (LOWER-VALUE, FP-prone)
+   When files in phaseN_*/ and phase{N+1}_*/ share creation timestamps within
+   a configurable window (default 5 minutes), flag as POSSIBLE same-call
+   inflation. Acknowledged FP risk: legitimate fast orchestrator runs trigger
+   this. Use --strict to enable, default OFF.
+
+Exit codes:
+    0  No findings, or only --strict findings without --strict flag
+    0  Findings produced (advisory output, NOT a hard gate); printed to stdout
+    1  Script error (invalid workdir, IO failure)
+
+The verifier intentionally fails open (exit 0) on findings — it is advisory,
+not a CI gate. CI should not rely on this for v3.9.2.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+PHASE_DIR_RE = re.compile(r"^phase([1-6])(?:_.*)?$")
+
+# Phase 5 reviewer file-name heuristics. A phase5_*/ directory should contain
+# files whose names match at least one of these per independent crosscheck
+# (Devil's Advocate, Editor-in-Chief, Ethics Review). Missing all three →
+# advisory flag per #133 root pattern.
+PHASE5_REVIEWER_PATTERNS = {
+    "devils_advocate": re.compile(r"devils?[_-]?advocate", re.IGNORECASE),
+    "editor_in_chief": re.compile(r"(?:editor[_-]?in[_-]?chief|^eic|[_-]eic[_-])", re.IGNORECASE),
+    "ethics_review": re.compile(r"ethics?[_-]?review", re.IGNORECASE),
+    "methodology_reviewer": re.compile(r"methodology[_-]?review", re.IGNORECASE),
+    "domain_reviewer": re.compile(r"domain[_-]?review", re.IGNORECASE),
+    "perspective_reviewer": re.compile(r"perspective[_-]?review", re.IGNORECASE),
+    "editorial_synthesizer": re.compile(r"editorial[_-]?synth", re.IGNORECASE),
+}
+
+# Required minimum reviewer attributions for a valid Phase 5 output per
+# academic-pipeline Stage 3 review protocol. At least one from each category
+# must appear in phase5_*/ filenames.
+PHASE5_REQUIRED_CATEGORIES = [
+    ("devil's advocate", ["devils_advocate"]),
+    ("editorial/EIC", ["editor_in_chief", "editorial_synthesizer"]),
+    ("ethics or panel reviewer", ["ethics_review", "methodology_reviewer", "domain_reviewer", "perspective_reviewer"]),
+]
+
+DEFAULT_SAME_CALL_WINDOW_SECONDS = 300  # 5 minutes
+
+
+@dataclass
+class Finding:
+    rule: str
+    severity: str  # ADVISORY (default), STRUCTURAL (high-value), HEURISTIC (FP-prone)
+    phase: int | None
+    path: str
+    message: str
+
+
+@dataclass
+class Report:
+    workdir: str
+    phase_dirs: dict[int, list[str]] = field(default_factory=dict)  # phase → list of dir paths
+    findings: list[Finding] = field(default_factory=list)
+
+
+def scan_workdir(workdir: Path) -> Report:
+    """Locate all phase{1-6}_*/ subdirectories under workdir."""
+    report = Report(workdir=str(workdir))
+    if not workdir.is_dir():
+        return report
+
+    for entry in workdir.iterdir():
+        if not entry.is_dir():
+            continue
+        match = PHASE_DIR_RE.match(entry.name)
+        if not match:
+            continue
+        phase = int(match.group(1))
+        report.phase_dirs.setdefault(phase, []).append(str(entry))
+    return report
+
+
+def check_phase5_attribution(report: Report) -> None:
+    """Rule 1 — STRUCTURAL: phase5_*/ must contain independent reviewer files."""
+    phase5_dirs = report.phase_dirs.get(5, [])
+    if not phase5_dirs:
+        return
+
+    for dir_path in phase5_dirs:
+        path = Path(dir_path)
+        try:
+            files = [p.name for p in path.rglob("*") if p.is_file()]
+        except OSError as exc:
+            report.findings.append(Finding(
+                rule="phase5_attribution_io_error",
+                severity="ADVISORY",
+                phase=5,
+                path=dir_path,
+                message=f"Could not read phase5 directory: {exc}",
+            ))
+            continue
+
+        if not files:
+            report.findings.append(Finding(
+                rule="phase5_empty",
+                severity="ADVISORY",
+                phase=5,
+                path=dir_path,
+                message="phase5_*/ directory is empty — Phase 5 should produce review reports",
+            ))
+            continue
+
+        # Tally which reviewer categories are present
+        matched_agents: set[str] = set()
+        for fname in files:
+            for agent, pattern in PHASE5_REVIEWER_PATTERNS.items():
+                if pattern.search(fname):
+                    matched_agents.add(agent)
+
+        missing_categories: list[str] = []
+        for category_label, agent_list in PHASE5_REQUIRED_CATEGORIES:
+            if not any(agent in matched_agents for agent in agent_list):
+                missing_categories.append(category_label)
+
+        if missing_categories:
+            report.findings.append(Finding(
+                rule="phase5_missing_independent_reviewer",
+                severity="STRUCTURAL",
+                phase=5,
+                path=dir_path,
+                message=(
+                    f"phase5_*/ missing independent reviewer attribution for categories: "
+                    f"{', '.join(missing_categories)}. "
+                    f"Files found: {files[:5]}{'...' if len(files) > 5 else ''}. "
+                    f"#133 pattern: Phase 5 deliverable was likely produced by a single agent "
+                    f"that inflated past its scope, skipping mandatory independent crosschecks "
+                    f"(DA / EIC / Ethics). Re-run via orchestrator-driven Mode A with "
+                    f"`/ars-full` or invoke each reviewer agent separately."
+                ),
+            ))
+
+
+def _file_mtime(path: Path) -> float | None:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def check_same_call_heuristic(report: Report, window_seconds: int) -> None:
+    """Rule 2 — HEURISTIC (--strict only): adjacent-phase same-window timestamps."""
+    phases_present = sorted(report.phase_dirs.keys())
+    if len(phases_present) < 2:
+        return
+
+    # Collect (phase, file_path, mtime) tuples
+    file_records: dict[int, list[tuple[Path, float]]] = {}
+    for phase, dirs in report.phase_dirs.items():
+        records: list[tuple[Path, float]] = []
+        for dir_path in dirs:
+            path = Path(dir_path)
+            for file_path in path.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                mtime = _file_mtime(file_path)
+                if mtime is None:
+                    continue
+                records.append((file_path, mtime))
+        if records:
+            file_records[phase] = records
+
+    # For each adjacent (N, N+1) pair, find files with mtime within window
+    for phase in phases_present:
+        next_phase = phase + 1
+        if next_phase not in file_records:
+            continue
+        for file_a, mtime_a in file_records.get(phase, []):
+            for file_b, mtime_b in file_records[next_phase]:
+                delta = abs(mtime_a - mtime_b)
+                if delta <= window_seconds:
+                    report.findings.append(Finding(
+                        rule="adjacent_phase_same_window",
+                        severity="HEURISTIC",
+                        phase=phase,
+                        path=str(file_a),
+                        message=(
+                            f"phase{phase} file {file_a.name} and phase{next_phase} file "
+                            f"{file_b.name} share mtime within {int(delta)}s "
+                            f"(window={window_seconds}s). POSSIBLE same-call inflation. "
+                            f"Note: legitimate fast orchestrator runs also trigger this "
+                            f"heuristic — verify against orchestrator state ledger before "
+                            f"treating as #133-class violation."
+                        ),
+                    ))
+
+
+def format_text(report: Report) -> str:
+    lines = [f"ARS pipeline integrity check (v3.9.2 advisory)"]
+    lines.append(f"Workdir: {report.workdir}")
+    lines.append(f"Phase dirs found: {dict(sorted(report.phase_dirs.items()))}")
+    lines.append("")
+    if not report.findings:
+        lines.append("No advisory findings.")
+        return "\n".join(lines)
+
+    lines.append(f"Findings ({len(report.findings)}):")
+    for i, finding in enumerate(report.findings, 1):
+        lines.append("")
+        lines.append(f"  [{i}] {finding.severity} — {finding.rule}")
+        if finding.phase is not None:
+            lines.append(f"      Phase: {finding.phase}")
+        lines.append(f"      Path:  {finding.path}")
+        lines.append(f"      {finding.message}")
+
+    lines.append("")
+    lines.append("Reminder: this output is ADVISORY. Findings do NOT block any workflow.")
+    lines.append("See docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md for rationale.")
+    return "\n".join(lines)
+
+
+def format_json(report: Report) -> str:
+    payload = {
+        "workdir": report.workdir,
+        "phase_dirs": {str(k): v for k, v in sorted(report.phase_dirs.items())},
+        "findings": [
+            {
+                "rule": f.rule,
+                "severity": f.severity,
+                "phase": f.phase,
+                "path": f.path,
+                "message": f.message,
+            }
+            for f in report.findings
+        ],
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Advisory check for ARS pipeline phase scope inflation (v3.9.2)"
+    )
+    parser.add_argument(
+        "workdir",
+        nargs="?",
+        default=".",
+        help="Working directory to scan (default: current directory)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Enable heuristic same-call timestamp check (FP-prone, default OFF)",
+    )
+    parser.add_argument(
+        "--window-seconds",
+        type=int,
+        default=DEFAULT_SAME_CALL_WINDOW_SECONDS,
+        help=f"Same-call window for --strict heuristic (default: {DEFAULT_SAME_CALL_WINDOW_SECONDS}s)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of human-readable text",
+    )
+    args = parser.parse_args(argv)
+
+    workdir = Path(args.workdir).resolve()
+    if not workdir.is_dir():
+        print(f"ERROR: workdir not found or not a directory: {workdir}", file=sys.stderr)
+        return 1
+
+    report = scan_workdir(workdir)
+    check_phase5_attribution(report)
+    if args.strict:
+        check_same_call_heuristic(report, args.window_seconds)
+
+    if args.json:
+        print(format_json(report))
+    else:
+        print(format_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_pipeline_integrity.py
+++ b/scripts/check_pipeline_integrity.py
@@ -28,6 +28,23 @@ Detection rules (v3.9.2 lite):
    a single agent producing phase5_*/ output that looks like a review but was
    never actually crosschecked by independent reviewer agents.
 
+   **NORMATIVE FILENAME CONVENTION:** This rule is filename-based regex matching
+   over a closed set of agent stem names. For the verifier to recognize a
+   reviewer report, the filename MUST contain one of the canonical agent stems:
+   - `devils_advocate` (or `devil-s_advocate` / `devils-advocate`)
+   - `editor_in_chief` or `eic`
+   - `ethics_review` (the full stem; bare `ethics` does NOT match)
+   - `methodology_review` / `domain_review` / `perspective_review`
+   - `editorial_synth` (matches editorial_synthesizer family)
+
+   Orchestrator runs that emit terse filenames like `round1_ethics.md` (without
+   `_review` suffix) WILL produce a false-positive STRUCTURAL finding here.
+   Resolution options: (a) rename file to match convention, or (b) ignore the
+   advisory finding (verifier exits 0; advisory does not block). The verifier
+   trades filename-convention discipline for zero-dependency cross-platform
+   simplicity in v3.9.2. v3.10 conductor (#134) replaces filename matching
+   with task envelope author provenance.
+
 2. **Multi-phase same-call generation heuristic** (LOWER-VALUE, FP-prone)
    When files in phaseN_*/ and phase{N+1}_*/ share creation timestamps within
    a configurable window (default 5 minutes), flag as POSSIBLE same-call
@@ -122,7 +139,12 @@ def check_phase5_attribution(report: Report) -> None:
     for dir_path in phase5_dirs:
         path = Path(dir_path)
         try:
-            files = [p.name for p in path.rglob("*") if p.is_file()]
+            # Skip hidden files (.DS_Store, Thumbs.db, .gitkeep, etc.) — they're
+            # never reviewer reports and would clutter advisory output noise.
+            files = [
+                p.name for p in path.rglob("*")
+                if p.is_file() and not p.name.startswith(".")
+            ]
         except OSError as exc:
             report.findings.append(Finding(
                 rule="phase5_attribution_io_error",

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.9.0 (2026-05-17)")
+    expect_contains(rel_path, "Last updated: v3.9.2 (2026-05-18)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.9.0")
+    expect_contains(rel_path, "**Suite version**: 3.9.2")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,10 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.0-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.0")
+    expect_contains(rel_path, "version-v3.9.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.2")
+    expect_contains(rel_path, "### v3.9.2 (2026-05-18)")
+    expect_contains(rel_path, "### v3.9.1 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.0 (2026-05-17)")
     expect_contains(rel_path, "### v3.8.0 (2026-05-16)")
     expect_contains(rel_path, "### v3.7.0 (2026-05-05)")
@@ -205,8 +207,10 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.0-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.0")
+    expect_contains(rel_path, "version-v3.9.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.2")
+    expect_contains(rel_path, "### v3.9.2（2026-05-18）")
+    expect_contains(rel_path, "### v3.9.1（2026-05-18）")
     expect_contains(rel_path, "### v3.9.0（2026-05-17）")
     expect_contains(rel_path, "### v3.8.0（2026-05-16）")
     expect_contains(rel_path, "### v3.7.0（2026-05-05）")

--- a/scripts/check_v3_9_2_phase_boundary.py
+++ b/scripts/check_v3_9_2_phase_boundary.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Static lint for ARS v3.9.2 phase boundary coverage (#133 hot-fix).
+
+Spec: docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md Phase 5
+Classification: docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md
+
+Enforces three invariants:
+
+1. **Bucket A coverage** — all 22 single-phase agents MUST carry a
+   `## Phase Boundary (v3.9.2)` H2 block.
+
+2. **Bucket B/C/D exclusion** — all 16 multi-phase / phase-orthogonal /
+   cross-phase-meta agents MUST NOT carry the block. Adding a fence to
+   these agents would either falsely block legitimate cross-phase work
+   (Bucket B/C) or defeat orchestration (Bucket D).
+
+3. **Block content shape** — each Bucket A block must contain the four
+   load-bearing keywords/phrases that make the boundary detectable in
+   prompt processing:
+     - `Phase Boundary (v3.9.2)` (the H2 marker)
+     - `MUST NOT` (the prohibition section)
+     - `MAY READ` (the explicit upstream-read permission)
+     - `Enforcement (v3.9.2)` (the trailing enforcement-paragraph marker)
+
+   These are scoped to the Phase Boundary block itself (via H2 → next H2
+   boundary), so the same keyword appearing elsewhere in the agent file
+   does not count toward passing.
+
+Falsifiability discipline (per feedback_lint_passes_but_prompt_silent.md):
+keywords are scoped to the v3.9.2 block; bare keyword presence anywhere
+in the agent file does NOT count. The block must include all four phrases
+inside its own H2 span.
+
+Exit codes: 0 on pass, 1 on any failure.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Bucket A — 22 single-phase agents that MUST have Phase Boundary block.
+# Source: docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md
+BUCKET_A_AGENTS = [
+    # deep-research/agents/ (9)
+    "deep-research/agents/research_question_agent.md",
+    "deep-research/agents/research_architect_agent.md",
+    "deep-research/agents/bibliography_agent.md",
+    "deep-research/agents/source_verification_agent.md",
+    "deep-research/agents/synthesis_agent.md",
+    "deep-research/agents/editor_in_chief_agent.md",
+    "deep-research/agents/ethics_review_agent.md",
+    "deep-research/agents/risk_of_bias_agent.md",
+    "deep-research/agents/meta_analysis_agent.md",
+    # academic-paper/agents/ (7)
+    "academic-paper/agents/literature_strategist_agent.md",
+    "academic-paper/agents/structure_architect_agent.md",
+    "academic-paper/agents/draft_writer_agent.md",
+    "academic-paper/agents/citation_compliance_agent.md",
+    "academic-paper/agents/abstract_bilingual_agent.md",
+    "academic-paper/agents/peer_reviewer_agent.md",
+    "academic-paper/agents/formatter_agent.md",
+    # academic-paper-reviewer/agents/ (6)
+    "academic-paper-reviewer/agents/eic_agent.md",
+    "academic-paper-reviewer/agents/methodology_reviewer_agent.md",
+    "academic-paper-reviewer/agents/domain_reviewer_agent.md",
+    "academic-paper-reviewer/agents/perspective_reviewer_agent.md",
+    "academic-paper-reviewer/agents/devils_advocate_reviewer_agent.md",
+    "academic-paper-reviewer/agents/editorial_synthesizer_agent.md",
+]
+
+# Buckets B/C/D — 16 agents that MUST NOT have the block.
+# B (4): multi-phase; C (8): phase-orthogonal; D (4): cross-phase-meta.
+BUCKET_BCD_AGENTS = [
+    # Bucket B — multi-phase (4)
+    "deep-research/agents/devils_advocate_agent.md",          # P1, 3, 5 + Socratic L2, 4
+    "deep-research/agents/report_compiler_agent.md",          # P4, 6
+    "academic-paper/agents/argument_builder_agent.md",        # P3 + Plan Step 3
+    "academic-paper/agents/visualization_agent.md",           # P4 + P7
+    # Bucket C — phase-orthogonal (8)
+    "deep-research/agents/socratic_mentor_agent.md",          # Socratic Layer 1-5
+    "academic-paper/agents/socratic_mentor_agent.md",         # Plan Step 0-3
+    "deep-research/agents/monitoring_agent.md",               # post-pipeline
+    "academic-paper/agents/revision_coach_agent.md",          # Revision-Coach standalone
+    "academic-pipeline/agents/integrity_verification_agent.md",  # Stage 2.5 / 4.5 gates
+    "academic-pipeline/agents/collaboration_depth_agent.md",  # FULL/SLIM advisory
+    "academic-pipeline/agents/claim_ref_alignment_audit_agent.md",  # opt-in audit
+    "shared/agents/compliance_agent.md",                      # cross-skill stage gates
+    # Bucket D — cross-phase / meta (4)
+    "academic-paper/agents/intake_agent.md",                  # Phase 0 cross-phase config
+    "academic-pipeline/agents/pipeline_orchestrator_agent.md",  # orchestrator
+    "academic-pipeline/agents/state_tracker_agent.md",        # meta state
+    "academic-paper-reviewer/agents/field_analyst_agent.md",  # Phase 0 configures panel
+]
+
+BLOCK_MARKER = "## Phase Boundary (v3.9.2)"
+
+# H2 marker that ends the Phase Boundary block scope.
+# Used to scope keyword checks: keywords appearing elsewhere in the file
+# (e.g., in v3.6.7 PATTERN PROTECTION further down) do NOT count.
+H2_RE = re.compile(r"^## ", re.MULTILINE)
+
+# Required keywords/phrases inside each Bucket A block.
+REQUIRED_PHRASES = [
+    "Phase Boundary (v3.9.2)",
+    "MUST NOT",
+    "MAY READ",
+    "Enforcement (v3.9.2)",
+]
+
+
+def extract_block(text: str) -> str | None:
+    """Extract the Phase Boundary (v3.9.2) block from H2 start to next H2."""
+    start = text.find(BLOCK_MARKER)
+    if start == -1:
+        return None
+    # Find next H2 after the block marker
+    after_block_start = start + len(BLOCK_MARKER)
+    next_h2 = H2_RE.search(text, after_block_start)
+    end = next_h2.start() if next_h2 else len(text)
+    return text[start:end]
+
+
+def check_bucket_a(path: Path) -> list[str]:
+    """Bucket A: must have block AND all required phrases inside block."""
+    errors: list[str] = []
+    if not path.is_file():
+        errors.append(f"{path.relative_to(REPO_ROOT)}: file not found")
+        return errors
+
+    text = path.read_text(encoding="utf-8")
+    block = extract_block(text)
+    if block is None:
+        errors.append(
+            f"{path.relative_to(REPO_ROOT)}: missing '## Phase Boundary (v3.9.2)' "
+            f"block (Bucket A agents MUST carry this block per "
+            f"docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md)"
+        )
+        return errors
+
+    for phrase in REQUIRED_PHRASES:
+        if phrase not in block:
+            errors.append(
+                f"{path.relative_to(REPO_ROOT)}: Phase Boundary block missing "
+                f"required phrase: {phrase!r} (falsifiability discipline: phrase "
+                f"must appear inside the H2 block, not elsewhere in the file)"
+            )
+    return errors
+
+
+def check_bucket_bcd(path: Path) -> list[str]:
+    """Bucket B/C/D: must NOT have the block (adding fence breaks multi-phase
+    or cross-phase legitimate behavior)."""
+    errors: list[str] = []
+    if not path.is_file():
+        errors.append(f"{path.relative_to(REPO_ROOT)}: file not found")
+        return errors
+
+    text = path.read_text(encoding="utf-8")
+    if BLOCK_MARKER in text:
+        errors.append(
+            f"{path.relative_to(REPO_ROOT)}: unexpected '## Phase Boundary "
+            f"(v3.9.2)' block on Bucket B/C/D agent. These agents are multi-phase "
+            f"(B), phase-orthogonal (C), or cross-phase meta (D) by design — "
+            f"adding a single-phase fence would either falsely block legitimate "
+            f"cross-phase work or defeat orchestration. See "
+            f"docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md."
+        )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for rel_path in BUCKET_A_AGENTS:
+        errors.extend(check_bucket_a(REPO_ROOT / rel_path))
+
+    for rel_path in BUCKET_BCD_AGENTS:
+        errors.extend(check_bucket_bcd(REPO_ROOT / rel_path))
+
+    # Coverage sanity
+    if len(BUCKET_A_AGENTS) != 22:
+        errors.append(
+            f"BUCKET_A_AGENTS has {len(BUCKET_A_AGENTS)} entries but "
+            f"classification doc requires 22"
+        )
+    if len(BUCKET_BCD_AGENTS) != 16:
+        errors.append(
+            f"BUCKET_BCD_AGENTS has {len(BUCKET_BCD_AGENTS)} entries but "
+            f"classification doc requires 16"
+        )
+
+    if errors:
+        print("v3.9.2 Phase Boundary lint FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(f"v3.9.2 Phase Boundary lint PASSED: "
+          f"{len(BUCKET_A_AGENTS)} Bucket A agents have block, "
+          f"{len(BUCKET_BCD_AGENTS)} Bucket B/C/D agents excluded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_pipeline_integrity.py
+++ b/scripts/test_check_pipeline_integrity.py
@@ -1,0 +1,176 @@
+"""Unit tests for check_pipeline_integrity.py (v3.9.2 advisory verifier)."""
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "check_pipeline_integrity.py"
+
+
+def _run(workdir: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    return run_script(SCRIPT, str(workdir), *extra_args)
+
+
+def _build_workspace(root: Path, structure: dict[str, list[str]]) -> None:
+    """Materialize a fixture: {phase_dir_name: [file1, file2, ...]}."""
+    for dir_name, files in structure.items():
+        d = root / dir_name
+        d.mkdir(parents=True, exist_ok=True)
+        for fname in files:
+            (d / fname).touch()
+
+
+class CheckPipelineIntegrityTests(unittest.TestCase):
+
+    def test_empty_workdir_no_findings(self) -> None:
+        with TemporaryDirectory() as td:
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
+    def test_no_phase_dirs_no_findings(self) -> None:
+        with TemporaryDirectory() as td:
+            (Path(td) / "some_other_dir").mkdir()
+            (Path(td) / "README.md").touch()
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
+    def test_issue_133_inflation_case_phase5_missing_reviewers(self) -> None:
+        """STRUCTURAL: phase5 with only generic review.md should flag missing
+        attribution. This is the exact #133 reported failure pattern."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase2_bibliography": ["annotated_bib.md"],
+                "phase3_synthesis": ["synthesis.md"],
+                "phase4_draft": ["draft_v1.md"],
+                "phase5_review": ["review.md"],
+                "phase6_revision": ["draft_v2.md"],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("STRUCTURAL", result.stdout)
+        self.assertIn("phase5_missing_independent_reviewer", result.stdout)
+        self.assertIn("devil's advocate", result.stdout)
+        self.assertIn("editorial/EIC", result.stdout)
+        self.assertIn("ethics or panel reviewer", result.stdout)
+
+    def test_legitimate_phase5_with_three_reviewer_files_passes(self) -> None:
+        """Phase 5 with separate DA + EIC + Ethics files should produce
+        no STRUCTURAL findings."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase2_bibliography": ["annotated_bib.md"],
+                "phase3_synthesis": ["synthesis.md"],
+                "phase4_draft": ["draft_v1.md"],
+                "phase5_review": [
+                    "devils_advocate_report.md",
+                    "editor_in_chief_decision.md",
+                    "ethics_review.md",
+                ],
+                "phase6_revision": ["draft_v2.md"],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("STRUCTURAL", result.stdout)
+        self.assertIn("No advisory findings.", result.stdout)
+
+    def test_phase5_methodology_domain_perspective_also_counts(self) -> None:
+        """Alternative attribution: DA + EIC + 1 panel reviewer satisfies the
+        3-category rule (any of methodology/domain/perspective for the
+        'ethics or panel reviewer' category)."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase5_review": [
+                    "devils_advocate_card.md",
+                    "eic_card.md",
+                    "methodology_reviewer_card.md",
+                ],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
+    def test_phase5_empty_dir_flags_advisory(self) -> None:
+        with TemporaryDirectory() as td:
+            (Path(td) / "phase5_review").mkdir()
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("phase5_empty", result.stdout)
+
+    def test_phase5_with_only_editorial_synthesizer_flags_missing_da(self) -> None:
+        """editorial_synthesizer alone is NOT enough — DA category and
+        ethics/panel category are still missing."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase5_review": ["editorial_synthesizer_letter.md"],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("phase5_missing_independent_reviewer", result.stdout)
+        self.assertIn("devil's advocate", result.stdout)
+        self.assertIn("ethics or panel reviewer", result.stdout)
+        # EIC/editorial category is satisfied by editorial_synthesizer
+        self.assertNotIn("editorial/EIC", result.stdout)
+
+    def test_strict_flag_triggers_heuristic(self) -> None:
+        """--strict enables the adjacent-phase-same-window heuristic."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase2_bibliography": ["annotated_bib.md"],
+                "phase3_synthesis": ["synthesis.md"],
+            })
+            result = _run(Path(td), "--strict")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("HEURISTIC", result.stdout)
+        self.assertIn("adjacent_phase_same_window", result.stdout)
+
+    def test_no_strict_flag_skips_heuristic(self) -> None:
+        """Default mode does NOT run the timestamp heuristic."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase2_bibliography": ["annotated_bib.md"],
+                "phase3_synthesis": ["synthesis.md"],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("HEURISTIC", result.stdout)
+        self.assertNotIn("adjacent_phase_same_window", result.stdout)
+
+    def test_json_output_format(self) -> None:
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase5_review": ["review.md"],
+            })
+            result = _run(Path(td), "--json")
+        self.assertEqual(result.returncode, 0)
+        payload = json.loads(result.stdout)
+        self.assertIn("workdir", payload)
+        self.assertIn("phase_dirs", payload)
+        self.assertIn("findings", payload)
+        self.assertGreaterEqual(len(payload["findings"]), 1)
+        # Find the structural finding
+        rules = [f["rule"] for f in payload["findings"]]
+        self.assertIn("phase5_missing_independent_reviewer", rules)
+
+    def test_invalid_workdir_returns_exit_1(self) -> None:
+        result = _run(Path("/tmp/nonexistent_dir_for_test_xyz_133"))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not found", result.stderr)
+
+    def test_non_phase_dirs_ignored(self) -> None:
+        """Directories not matching phase[1-6]_* pattern are skipped."""
+        with TemporaryDirectory() as td:
+            (Path(td) / "phase0_intake").mkdir()  # Phase 0 outside 1-6 range
+            (Path(td) / "phase7_format").mkdir()  # Phase 7 outside 1-6 range
+            (Path(td) / "stage5_review").mkdir()  # Wrong prefix
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_pipeline_integrity.py
+++ b/scripts/test_check_pipeline_integrity.py
@@ -171,6 +171,73 @@ class CheckPipelineIntegrityTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("No advisory findings.", result.stdout)
 
+    def test_dotfiles_in_phase5_ignored(self) -> None:
+        """Hidden files (.DS_Store, .gitkeep, Thumbs.db) should not count as
+        review reports. They're noise from the OS/git, not authored content."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase5_review": [
+                    ".DS_Store",
+                    ".gitkeep",
+                    "devils_advocate_card.md",
+                    "eic_card.md",
+                    "ethics_review.md",
+                ],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
+    def test_multiple_phase5_dirs_each_independently_checked(self) -> None:
+        """phase5_review_r1/ + phase5_review_r2/ (multi-round) should each be
+        evaluated independently. If one is complete and the other isn't, only
+        the incomplete one flags."""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase5_review_r1": [
+                    "devils_advocate_card.md",
+                    "eic_card.md",
+                    "ethics_review.md",
+                ],
+                "phase5_review_r2": [
+                    "review.md",  # Incomplete — missing all 3 categories
+                ],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        # The complete dir produces no finding; the incomplete one does.
+        # The 'phase5_missing_independent_reviewer' rule should fire exactly once.
+        self.assertEqual(result.stdout.count("phase5_missing_independent_reviewer"), 1)
+        # Confirm only the r2 path is in the finding output, not r1.
+        self.assertIn("phase5_review_r2", result.stdout)
+
+    def test_unicode_filenames_with_canonical_stem_match(self) -> None:
+        """Filenames with non-ASCII characters but containing the canonical
+        agent stem in ASCII should still match. E.g., devils_advocate_報告.md"""
+        with TemporaryDirectory() as td:
+            _build_workspace(Path(td), {
+                "phase5_review": [
+                    "devils_advocate_報告.md",
+                    "editor_in_chief_決定.md",
+                    "ethics_review_報告.md",
+                ],
+            })
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
+    def test_nested_files_in_phase5_count(self) -> None:
+        """rglob recurses; reviewer card in a subdirectory should still match."""
+        with TemporaryDirectory() as td:
+            sub = Path(td) / "phase5_review" / "round1"
+            sub.mkdir(parents=True)
+            (sub / "devils_advocate.md").touch()
+            (sub / "editor_in_chief.md").touch()
+            (sub / "ethics_review.md").touch()
+            result = _run(Path(td))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("No advisory findings.", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_v3_9_2_phase_boundary.py
+++ b/scripts/test_check_v3_9_2_phase_boundary.py
@@ -1,0 +1,62 @@
+"""Unit tests for check_v3_9_2_phase_boundary.py."""
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts._test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "check_v3_9_2_phase_boundary.py"
+
+
+def _run() -> subprocess.CompletedProcess:
+    return run_script(SCRIPT)
+
+
+class CheckV392PhaseBoundaryTests(unittest.TestCase):
+
+    def test_repo_baseline_passes(self) -> None:
+        """The committed v3.9.2 branch state must pass the lint."""
+        result = _run()
+        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}")
+        self.assertIn("PASSED", result.stdout)
+        self.assertIn("22 Bucket A", result.stdout)
+        self.assertIn("16 Bucket B/C/D", result.stdout)
+
+    def test_module_invariants(self) -> None:
+        """BUCKET counts must match classification doc (22 + 16 = 38)."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "check_v3_9_2_phase_boundary", SCRIPT
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        self.assertEqual(len(module.BUCKET_A_AGENTS), 22)
+        self.assertEqual(len(module.BUCKET_BCD_AGENTS), 16)
+        # No agent appears in both buckets
+        overlap = set(module.BUCKET_A_AGENTS) & set(module.BUCKET_BCD_AGENTS)
+        self.assertEqual(overlap, set(), msg=f"agents in both buckets: {overlap}")
+        # All 38 agent paths are unique
+        all_paths = module.BUCKET_A_AGENTS + module.BUCKET_BCD_AGENTS
+        self.assertEqual(len(all_paths), len(set(all_paths)),
+                         msg="duplicate paths across buckets")
+
+    def test_required_phrases_constant(self) -> None:
+        """REQUIRED_PHRASES must include the four load-bearing markers."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "check_v3_9_2_phase_boundary", SCRIPT
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        required = set(module.REQUIRED_PHRASES)
+        self.assertIn("Phase Boundary (v3.9.2)", required)
+        self.assertIn("MUST NOT", required)
+        self.assertIn("MAY READ", required)
+        self.assertIn("Enforcement (v3.9.2)", required)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/references/intent_clarification_protocol.md
+++ b/shared/references/intent_clarification_protocol.md
@@ -70,11 +70,12 @@ Pick a-d, or describe the target deliverable. If you want me to dispatch a speci
 
 **Behavior:**
 
-- **Position:** Token must appear at byte-0 of the user's first message (optionally preceded by whitespace stripped on parse).
+- **Position:** Token must be the first non-whitespace token of the user's first message. Leading whitespace (spaces, tabs, newlines) is stripped on parse — `[direct-mode] ...`, `  [direct-mode] ...`, and `\n[direct-mode] ...` all qualify. Token appearing mid-message (after any non-whitespace character) does NOT qualify.
 - **Case:** Case-insensitive. `[direct-mode]`, `[Direct-Mode]`, `[DIRECT-MODE]` all accepted.
+- **Bracket form:** Only the literal `[direct-mode]` (square brackets, hyphen between words) is recognized. Variants like `(direct-mode)`, `<direct-mode>`, `[direct mode]` (space instead of hyphen), or `[directmode]` (no separator) are NOT recognized.
 - **Strip:** The literal `[direct-mode]` token (with surrounding whitespace) is stripped before any downstream agent sees the message. Dispatched agents receive only the post-strip content.
-- **Effect:** Skips Routing Discipline Steps 1-3. Main session routes the stripped message according to whatever literal skill / trigger / command it contains.
-- **Fallback:** If the stripped message itself is ambiguous (no clear skill named), the main session proceeds to Step 1 explicit-intent handling on the stripped content. (`[direct-mode]` is NOT a magic "always dispatch" flag — it bypasses clarification, not all routing.)
+- **Effect:** Bypasses Routing Discipline Step 2 (cross-phase clarification). Main session routes the stripped message via Step 1 (explicit-intent handling).
+- **Fallback:** If the stripped message itself has no clear skill named, Step 1 falls through to Step 3 clarification. (`[direct-mode]` is NOT a magic "always dispatch" flag — it bypasses cross-phase clarification, not all routing. If you want to bypass even ambiguous-intent clarification, you must name a specific skill or agent in the stripped message.)
 
 **Examples:**
 

--- a/shared/references/intent_clarification_protocol.md
+++ b/shared/references/intent_clarification_protocol.md
@@ -1,0 +1,167 @@
+# Intent Clarification Protocol (v3.9.2)
+
+**Spec:** v3.9.2 hot-fix per `docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md`
+**Issue:** #133 (phase scope inflation hot-fix)
+**Forward note:** v3.10 active conductor (#134) will replace this clarification gate with structured intake + task envelope dispatch. v3.9.2 ships clarification-only as interim.
+
+## Purpose
+
+When ARS receives input that does not unambiguously identify the intended workflow, the main session **clarifies before dispatching any agent**. Auto-routing to a single-phase agent on cross-phase materials caused #133 (silent scope inflation).
+
+This protocol defines:
+
+1. When clarification fires (3 trigger classes)
+2. How the clarification message is structured (a-d options in markdown body, NOT AskUserQuestion tool)
+3. How the `[direct-mode]` escape hatch works
+4. Worked examples
+
+## Trigger condition table
+
+| Condition | Routing class | Action |
+|---|---|---|
+| User invokes `/ars-*` slash command | Explicit | Route directly to named skill; no clarification |
+| User uses unambiguous trigger keyword (e.g., "lit-review this", "review my paper") | Explicit | Route directly to matching skill; no clarification |
+| User provides materials spanning ≥ 2 pipeline phases (e.g., abstract + literature, draft + reviewer comments + bibliography) | Cross-phase ambiguous | **Clarify** with a-d options |
+| User provides no materials and no clear request | No materials ambiguous | **Clarify** with a-d options |
+| User's first message begins with `[direct-mode]` (byte-0, case-insensitive) | Escape hatch | Strip prefix, skip clarification, route to whatever single agent matches the literal trigger; if no match, fall back to Explicit handling on the stripped message |
+
+## Pipeline phase reference (for "cross-phase materials" detection)
+
+| Phase | Typical artifact | File markers (heuristic) |
+|---|---|---|
+| 1 — Scoping | Research Question Brief, Methodology Blueprint | `phase1_*/` directory; `rq_brief.md`; `methodology.md` |
+| 2 — Investigation | Annotated Bibliography, source list, literature_corpus passport entries | `phase2_*/`; `annotated_bib.md`; `literature.{yaml,json}`; `references.bib`; folders of PDFs |
+| 3 — Analysis / Synthesis | Synthesis Report, claim-evidence mapping | `phase3_*/`; `synthesis.md` |
+| 4 — Composition | Full draft, abstract, report body | `phase4_*/`; `draft.md`; `abstract.md` (or 5b for academic-paper) |
+| 5 — Review | Editorial decision letter, reviewer comments, ethics report | `phase5_*/`; `review_*.md`; `editorial_decision.md` |
+| 6 — Revision | Revision Roadmap, R&R response letter, revised draft | `phase6_*/`; `revision_roadmap.md`; `response_letter.md` |
+| 0 / 7 / Plan | Intake config, format conversion, Socratic plan | `phase0_*/`; `phase7_*/`; Plan mode mid-conversation |
+
+"Cross-phase" = the user-provided materials, taken together, would correspond to artifacts from ≥ 2 of these phases. Examples:
+
+- Abstract + literature = Phase 4 + Phase 2 → cross-phase, clarify
+- Draft + reviewer comments = Phase 4 + Phase 5 → cross-phase, clarify
+- Literature only = Phase 2 → single-phase, no clarification needed
+- Reviewer comments only = Phase 5 → single-phase, no clarification needed
+
+## Clarification message template
+
+When clarification fires, the main session emits a message in this shape (markdown body, multi-select a-d format per `feedback_telegram_conversation_style.md` discipline):
+
+```markdown
+I see you've provided <summary of materials>. To route correctly, could you confirm which workflow you want?
+
+(a) **Full pipeline** — go from materials through to a complete deliverable (research + write + review + revise). Use `academic-pipeline` orchestrator (`/ars-full`).
+(b) **<phase-specific workflow 1>** — <one-line description>. Use `<skill>` (`/ars-<mode>`).
+(c) **<phase-specific workflow 2>** — <one-line description>. Use `<skill>` (`/ars-<mode>`).
+(d) **Something else** — let me know what you're trying to do.
+
+Pick a-d, or describe the target deliverable. If you want me to dispatch a specific agent directly without this clarification, prefix your message with `[direct-mode]`.
+```
+
+**Discipline rules:**
+
+- 3-4 candidate options + open "something else"; never more than 4 (avoid choice paralysis)
+- Each option names the destination skill / command so the user sees what gets invoked
+- Last sentence mentions `[direct-mode]` so the user knows the escape hatch exists
+- Do NOT call `AskUserQuestion` tool — options live in the markdown body of the chat response (per `feedback_no_askuserquestion_use_brainstorm.md`)
+
+## `[direct-mode]` escape hatch
+
+**Behavior:**
+
+- **Position:** Token must appear at byte-0 of the user's first message (optionally preceded by whitespace stripped on parse).
+- **Case:** Case-insensitive. `[direct-mode]`, `[Direct-Mode]`, `[DIRECT-MODE]` all accepted.
+- **Strip:** The literal `[direct-mode]` token (with surrounding whitespace) is stripped before any downstream agent sees the message. Dispatched agents receive only the post-strip content.
+- **Effect:** Skips Routing Discipline Steps 1-3. Main session routes the stripped message according to whatever literal skill / trigger / command it contains.
+- **Fallback:** If the stripped message itself is ambiguous (no clear skill named), the main session proceeds to Step 1 explicit-intent handling on the stripped content. (`[direct-mode]` is NOT a magic "always dispatch" flag — it bypasses clarification, not all routing.)
+
+**Examples:**
+
+- `[direct-mode] /ars-lit-review on these papers` → dispatches academic-paper lit-review mode on the provided papers, no clarification
+- `[direct-mode] run bibliography_agent` → dispatches bibliography_agent directly
+- `[DIRECT-MODE] write me an abstract` → case-insensitive accepted; routes to abstract workflow without clarification
+
+**Anti-patterns (escape hatch NOT honored):**
+
+- `Please [direct-mode] dispatch X` — token not at byte-0 → ignored, clarification fires normally
+- `[direct mode] ...` — missing hyphen, not the literal token → ignored
+- `[direct-mode]` in second or later message of conversation — only first-message position counts
+
+## Worked examples
+
+### Example 1: cross-phase materials → clarify
+
+**User input:**
+> Here's an abstract and some literature, see what you can do.
+
+**Materials detected:** Abstract (Phase 4) + literature (Phase 2) → cross-phase.
+
+**Main session response:**
+> I see you've provided an abstract and a literature collection. To route correctly, could you confirm which workflow you want?
+>
+> (a) **Full paper from existing scaffolding** — use your abstract as paper seed, expand literature into bibliography, draft full paper, then review/revise. Use `academic-pipeline` (`/ars-full`).
+> (b) **Lit-review only** — produce an annotated bibliography matrix from the literature; don't touch your abstract. Use `academic-paper` (`/ars-lit-review`).
+> (c) **Quality-check the abstract against the literature** — verify abstract claims are supported by the cited sources. Use `academic-paper-reviewer` (`/ars-citation-check`).
+> (d) **Something else** — let me know what you're trying to do.
+>
+> Pick a-d, or describe the target deliverable. If you want me to dispatch a specific agent directly without this clarification, prefix your message with `[direct-mode]`.
+
+### Example 2: single-phase material → proceed
+
+**User input:**
+> Here's a folder of 30 PDF papers. Build me a lit-review on AI in medical imaging.
+
+**Materials detected:** Literature only (Phase 2). Explicit intent: lit-review.
+
+**Main session response:** Routes directly to `academic-paper /ars-lit-review` on the provided PDFs. No clarification fires (explicit intent overrides materials check).
+
+### Example 3: no materials + ambiguous → clarify
+
+**User input:**
+> Can you help me with my paper?
+
+**Materials detected:** None. Intent: ambiguous.
+
+**Main session response:**
+> Of course. To route correctly, could you tell me what stage you're at?
+>
+> (a) **I have an idea but no clear research question** — Socratic mode to clarify direction. Use `deep-research` (`/ars-plan`).
+> (b) **I have a question and need to do the research** — full research pipeline. Use `academic-pipeline` (`/ars-full`).
+> (c) **I have research notes and need to write the paper** — drafting pipeline. Use `academic-paper`.
+> (d) **I have a draft and want feedback** — peer-review simulation. Use `academic-paper-reviewer` (`/ars-review` equivalent).
+>
+> Pick a-d, or paste what you have so I can suggest a path.
+
+### Example 4: `[direct-mode]` honored
+
+**User input:**
+> [direct-mode] run bibliography_agent on these 30 PDFs
+
+**Stripped message:** `run bibliography_agent on these 30 PDFs`
+
+**Main session response:** Dispatches `bibliography_agent` directly with the PDFs as input. No clarification fires.
+
+### Example 5: `[direct-mode]` mid-message → NOT honored
+
+**User input:**
+> Hi, can you [direct-mode] just run bibliography_agent?
+
+**Token position:** Not byte-0. Escape hatch ignored.
+
+**Main session response:** Cross-phase or ambiguous check fires normally. May respond with clarification options.
+
+## When this protocol does NOT apply
+
+- **Within a skill that has already been routed.** If `academic-pipeline` is already running and the orchestrator is dispatching Phase 3 → Phase 4 internally, this protocol does not fire on every internal dispatch. It governs the **entry point** of an ARS session, not in-pipeline transitions.
+- **In-conversation follow-up.** After clarification resolves and a workflow starts, subsequent user messages within that workflow are interpreted by the active skill, not re-classified at the routing level. To re-route, the user starts a new session or uses `[direct-mode]` at the start of a new message.
+
+## v3.10 carry-over
+
+When the active conductor architecture (#134) ships, this protocol's logic moves into the conductor's intake stage with structured task envelope dispatch. The conductor will:
+
+- Classify intent deterministically with envelope schema rather than prompt-driven LLM judgment
+- Hold pipeline state across turns (so cross-phase materials in workspace are treated as ongoing project state, not "user-provided ambiguous input")
+- Eliminate the `[direct-mode]` escape hatch in favor of envelope-declared intent
+
+Until v3.10 ships, v3.9.2's prompt-driven clarification gate is the source of truth.

--- a/tests/fixtures/issue_133_routing/01_cross_phase_abstract_plus_lit/expected.yaml
+++ b/tests/fixtures/issue_133_routing/01_cross_phase_abstract_plus_lit/expected.yaml
@@ -1,0 +1,8 @@
+fixture_id: 01_cross_phase_abstract_plus_lit
+expected_routing_class: clarify
+expected_destination: clarification_only
+escape_hatch_applied: false
+notes: |
+  Abstract (Phase 4 artifact) + literature (Phase 2 artifact) = cross-phase materials
+  spanning ≥ 2 phases without explicit skill invocation. Per Routing Discipline Step 2,
+  must clarify with a-d options. This is the exact #133 root-cause scenario.

--- a/tests/fixtures/issue_133_routing/01_cross_phase_abstract_plus_lit/input.md
+++ b/tests/fixtures/issue_133_routing/01_cross_phase_abstract_plus_lit/input.md
@@ -1,0 +1,9 @@
+Hi, I'm working on a paper about AI in higher education quality assurance.
+
+I've already drafted an abstract and collected about 25 papers from Google Scholar and Semantic Scholar. Could you take a look and see what you can do?
+
+**Abstract draft (250 words):**
+
+> AI-augmented quality assurance is reshaping how higher education institutions evaluate teaching, learning, and institutional performance. This paper surveys the emerging landscape of AI applications in higher education quality assurance, focusing on three areas: (1) automated assessment of student learning outcomes, (2) institutional accreditation evidence collection, and (3) faculty teaching evaluation. Drawing on 25 recent studies (2022-2026) across Asia-Pacific, Europe, and North America, we identify three convergent patterns and two divergent ones. The convergent patterns are: rising adoption of LLM-based formative feedback tools in undergraduate teaching; standardization of AI-assisted evidence inventories in accreditation; and growing concern over algorithmic bias in faculty evaluation. The divergent patterns are: regulatory regimes vary substantially between EU AI Act compliance and US state-level patchwork; institutional governance models split into centralized AI offices versus distributed faculty-led pilots. We argue that quality assurance frameworks must explicitly distinguish AI as evidence source versus AI as evaluator, and that this distinction has implications for both training data governance and institutional accreditation standards. The paper concludes with three recommendations for HEI quality assurance offices considering AI adoption.
+
+**Literature collection:** 25 papers, mix of journal articles and conference papers, attached as PDFs in `~/Documents/HE-QA-AI-papers/`. Topics include: LLM in formative assessment (8 papers), AI ethics in higher ed (5), accreditation automation (4), bias in faculty evaluation (4), institutional governance (4).

--- a/tests/fixtures/issue_133_routing/01_cross_phase_abstract_plus_lit/rationale.md
+++ b/tests/fixtures/issue_133_routing/01_cross_phase_abstract_plus_lit/rationale.md
@@ -1,0 +1,35 @@
+# Rationale — Fixture 01
+
+## Why clarify (not proceed)
+
+Materials provided:
+- **Abstract draft** → Phase 4 artifact (academic-paper Phase 5b or deep-research Phase 4 equivalent)
+- **Literature collection (25 PDFs)** → Phase 2 artifact (deep-research Phase 2 / academic-paper Phase 1)
+
+This is cross-phase: materials span Phase 2 + Phase 4 (≥ 2 phases). Per `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" Step 2, the main session must clarify.
+
+## Why this is the #133 root case
+
+#133 incident report described almost exactly this scenario: user dropped an abstract + literature, and ARS auto-dispatched `bibliography_agent` (single-phase Phase 2 agent) without clarifying. The Phase 2 agent then inflated into Phase 3/4/5/6 work autonomously, skipping all mandatory independent crosschecks.
+
+The hot-fix in v3.9.2: this fixture must trigger clarification, NOT silent dispatch.
+
+## Expected clarification options (illustrative)
+
+The main session should respond with something like:
+
+> I see you've provided an abstract draft and a literature collection. To route correctly, could you confirm which workflow you want?
+>
+> (a) **Full paper from existing scaffolding** — use your abstract as the paper seed, expand literature into a bibliography, draft the full paper, then review/revise. Use `academic-pipeline` (`/ars-full`).
+> (b) **Lit-review only** — produce an annotated bibliography matrix from the 25 papers; don't touch your abstract. Use `academic-paper` (`/ars-lit-review`).
+> (c) **Quality-check the abstract against the literature** — verify the abstract's claims are supported by the cited sources. Use `academic-paper` (`/ars-citation-check`).
+> (d) **Something else** — let me know what you're trying to do.
+>
+> Pick a-d, or describe the target deliverable. If you want me to dispatch a specific agent directly without this clarification, prefix your message with `[direct-mode]`.
+
+## Pass criteria
+
+- ✅ Response contains a clarification structure (a-d options or equivalent enumerated choices)
+- ✅ Response does NOT silently dispatch `bibliography_agent` or any single-phase agent
+- ✅ Response does NOT begin generating the next-phase artifact (synthesis, draft, review)
+- ❌ Fail if response immediately starts producing lit-review output, synthesis output, or full draft

--- a/tests/fixtures/issue_133_routing/02_single_phase_literature_only/expected.yaml
+++ b/tests/fixtures/issue_133_routing/02_single_phase_literature_only/expected.yaml
@@ -1,0 +1,15 @@
+fixture_id: 02_single_phase_literature_only
+expected_routing_class: proceed
+expected_destination: academic-paper:lit-review
+escape_hatch_applied: false
+notes: |
+  Materials: literature only (Phase 2). Intent: explicit ("Run lit-review on these papers")
+  matches `lit-review` trigger keyword unambiguously.
+
+  Per Routing Discipline Step 1 (explicit clear intent), route directly to academic-paper
+  lit-review mode. No clarification needed — explicit intent overrides cross-phase check
+  (and materials are single-phase anyway).
+
+  Pass criteria:
+  - Response begins lit-review work (search strategy, screening, annotated bibliography)
+  - Response does NOT trigger clarification a-d options

--- a/tests/fixtures/issue_133_routing/02_single_phase_literature_only/input.md
+++ b/tests/fixtures/issue_133_routing/02_single_phase_literature_only/input.md
@@ -1,0 +1,3 @@
+Run lit-review on these 30 papers about transformer scaling laws.
+
+Papers attached in `~/papers/scaling-laws-2024-2026/`.

--- a/tests/fixtures/issue_133_routing/03_no_materials_ambiguous/expected.yaml
+++ b/tests/fixtures/issue_133_routing/03_no_materials_ambiguous/expected.yaml
@@ -1,0 +1,15 @@
+fixture_id: 03_no_materials_ambiguous
+expected_routing_class: clarify
+expected_destination: clarification_only
+escape_hatch_applied: false
+notes: |
+  Materials: none. Intent: ambiguous ("help me with my paper" — at which stage?).
+
+  Per Routing Discipline Step 3 (no materials + ambiguous), trigger clarification.
+  Per shared/references/intent_clarification_protocol.md worked example 3, the response
+  should enumerate stage-based options (Socratic / pipeline / drafting / reviewer).
+
+  Pass criteria:
+  - Response asks clarification with a-d options
+  - Options cover Socratic mode, pipeline start, drafting, and reviewer modes
+  - Does NOT silently start any phase

--- a/tests/fixtures/issue_133_routing/03_no_materials_ambiguous/input.md
+++ b/tests/fixtures/issue_133_routing/03_no_materials_ambiguous/input.md
@@ -1,0 +1,1 @@
+Can you help me with my paper?

--- a/tests/fixtures/issue_133_routing/04_explicit_slash_command/expected.yaml
+++ b/tests/fixtures/issue_133_routing/04_explicit_slash_command/expected.yaml
@@ -1,0 +1,11 @@
+fixture_id: 04_explicit_slash_command
+expected_routing_class: proceed
+expected_destination: academic-paper:lit-review
+escape_hatch_applied: false
+notes: |
+  Slash command `/ars-lit-review` is an explicit invocation. Per Routing Discipline
+  Step 1, route directly with no clarification, no orchestrator detour.
+
+  Pass criteria:
+  - Response begins lit-review work
+  - Response does NOT clarify

--- a/tests/fixtures/issue_133_routing/04_explicit_slash_command/input.md
+++ b/tests/fixtures/issue_133_routing/04_explicit_slash_command/input.md
@@ -1,0 +1,1 @@
+/ars-lit-review on attached papers about machine unlearning

--- a/tests/fixtures/issue_133_routing/05_direct_mode_honored/expected.yaml
+++ b/tests/fixtures/issue_133_routing/05_direct_mode_honored/expected.yaml
@@ -1,0 +1,13 @@
+fixture_id: 05_direct_mode_honored
+expected_routing_class: proceed
+expected_destination: bibliography_agent
+escape_hatch_applied: true
+direct_mode_stripped_message: "run bibliography_agent on these 30 PDFs about scaling laws"
+notes: |
+  `[direct-mode]` at byte-0 of first message. Per Routing Discipline Step 0, strip the
+  token and skip clarification. Dispatch the literal target (`bibliography_agent`).
+
+  Pass criteria:
+  - bibliography_agent is dispatched directly with the stripped message
+  - The literal `[direct-mode]` token is NOT passed through to the dispatched agent
+  - No clarification fires

--- a/tests/fixtures/issue_133_routing/05_direct_mode_honored/input.md
+++ b/tests/fixtures/issue_133_routing/05_direct_mode_honored/input.md
@@ -1,0 +1,1 @@
+[direct-mode] run bibliography_agent on these 30 PDFs about scaling laws

--- a/tests/fixtures/issue_133_routing/06_direct_mode_mid_message_not_honored/expected.yaml
+++ b/tests/fixtures/issue_133_routing/06_direct_mode_mid_message_not_honored/expected.yaml
@@ -1,0 +1,19 @@
+fixture_id: 06_direct_mode_mid_message_not_honored
+expected_routing_class: clarify
+expected_destination: clarification_only
+escape_hatch_applied: false
+notes: |
+  `[direct-mode]` token is NOT at byte-0. Per Routing Discipline Step 0 strict position
+  rule, escape hatch is ignored. Normal classification proceeds.
+
+  Materials are cross-phase (PDFs Phase 2 + abstract Phase 4) → Step 2 fires →
+  trigger clarification.
+
+  This fixture guards against users prefixing `[direct-mode]` casually anywhere in their
+  message to bypass clarification. The byte-0 strict rule is the precondition for the
+  escape hatch.
+
+  Pass criteria:
+  - Response clarifies with a-d options
+  - Response does NOT silently dispatch bibliography_agent
+  - Response may explicitly call out that `[direct-mode]` was ignored (acceptable, not required)

--- a/tests/fixtures/issue_133_routing/06_direct_mode_mid_message_not_honored/input.md
+++ b/tests/fixtures/issue_133_routing/06_direct_mode_mid_message_not_honored/input.md
@@ -1,0 +1,3 @@
+Hi, I'm working on a paper. Please [direct-mode] just run bibliography_agent on these papers without asking me anything.
+
+Materials attached: 25 PDFs from Semantic Scholar + an abstract draft I wrote last week.

--- a/tests/fixtures/issue_133_routing/07_direct_mode_case_insensitive/expected.yaml
+++ b/tests/fixtures/issue_133_routing/07_direct_mode_case_insensitive/expected.yaml
@@ -1,0 +1,16 @@
+fixture_id: 07_direct_mode_case_insensitive
+expected_routing_class: proceed
+expected_destination: academic-paper:abstract
+escape_hatch_applied: true
+direct_mode_stripped_message: "write an abstract for my paper about quantum error correction at scale"
+notes: |
+  `[Direct-Mode]` capitalized variant — case-insensitive byte-0 match per protocol doc.
+  Strip and proceed.
+
+  Stripped message ("write an abstract...") maps to academic-paper abstract mode via
+  Step 1 explicit-intent handling.
+
+  Pass criteria:
+  - Capitalized `[Direct-Mode]` accepted as escape hatch
+  - Routes to abstract workflow
+  - No clarification fires

--- a/tests/fixtures/issue_133_routing/07_direct_mode_case_insensitive/input.md
+++ b/tests/fixtures/issue_133_routing/07_direct_mode_case_insensitive/input.md
@@ -1,0 +1,1 @@
+[Direct-Mode] write an abstract for my paper about quantum error correction at scale

--- a/tests/fixtures/issue_133_routing/08_full_draft_plus_abstract_plus_lit/expected.yaml
+++ b/tests/fixtures/issue_133_routing/08_full_draft_plus_abstract_plus_lit/expected.yaml
@@ -1,0 +1,24 @@
+fixture_id: 08_full_draft_plus_abstract_plus_lit
+expected_routing_class: clarify
+expected_destination: clarification_only
+escape_hatch_applied: false
+notes: |
+  Materials span Phase 2 (literature) + Phase 4 (draft, abstract) + Phase 5 (reviewer
+  feedback) — three phases. Plus paper-finishing intent without specific skill named.
+
+  Multiple plausible workflows:
+  - revision (incorporate reviewer feedback into draft)
+  - reviewer simulation (get new feedback before submission)
+  - citation-check (verify draft claims against literature)
+  - abstract refinement
+  - full pipeline (if user wants to restart with the literature as base)
+
+  Per Routing Discipline Step 2, must clarify. This is a harder boundary case than
+  fixture 01 because the materials suggest the user is closer to submission, but
+  the request is still ambiguous about WHICH workflow.
+
+  Pass criteria:
+  - Response clarifies with a-d options
+  - Options cover at least: revision (incorporate reviews), reviewer simulation, citation-check
+  - Response does NOT silently dispatch peer_reviewer_agent, draft_writer_agent, or any
+    single agent

--- a/tests/fixtures/issue_133_routing/08_full_draft_plus_abstract_plus_lit/input.md
+++ b/tests/fixtures/issue_133_routing/08_full_draft_plus_abstract_plus_lit/input.md
@@ -1,0 +1,11 @@
+I'm working on a paper for JMLR submission. Here's everything I have so far — please help.
+
+**Full draft (8000 words):** `~/papers/jmlr-2026-submission/draft_v3.md` — covers introduction, methodology, experiments, results, discussion, conclusion.
+
+**Abstract:** `~/papers/jmlr-2026-submission/abstract_v2.md` — 250 words, written last week.
+
+**Literature collection:** 47 papers in `~/papers/jmlr-2026-submission/refs/` covering meta-learning, in-context learning, scaling laws, mechanistic interpretability.
+
+**Reviewer feedback (one set):** `~/papers/jmlr-2026-submission/round1_reviews.md` from an earlier submission to a workshop.
+
+Let me know what you can help with.

--- a/tests/fixtures/issue_133_routing/README.md
+++ b/tests/fixtures/issue_133_routing/README.md
@@ -1,0 +1,75 @@
+# Issue #133 — L1 Routing Behavioral Smoke Test Fixtures (v3.9.2)
+
+**Spec:** `docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md` Phase L1.4
+**Issue:** #133 (phase scope inflation hot-fix)
+**Status:** v3.9.2 hot-fix; behavioral smoke tests, NOT deterministic unit tests
+
+## Honest framing
+
+These fixtures are **behavioral smoke tests + cross-model spot-check**, not deterministic green/red unit tests. The unit-under-test is a Large Language Model (Claude / GPT / Gemini) following the routing rules in `.claude/CLAUDE.md` "Routing Discipline (v3.9.2)" + `shared/references/intent_clarification_protocol.md`.
+
+LLM-behavior assertions are flaky in the way model-behavior tests always are:
+
+- A test that passes on Opus 4.7 today can regress on Opus 4.8 tomorrow
+- A test can pass with prompt cache warm and fail cold
+- A test can pass at temp=0 and fail at temp=1
+
+This is acceptable for **routing discipline** (which is a calibration target, not a deterministic gate) but you should not promote these to CI green/red gates without recalibrating against the current model fleet.
+
+## Acceptance criterion (v3.9.2 ship gate)
+
+- **100% pass on Opus 4.7** (primary model — most ARS users)
+- **≥ 75% pass on Sonnet 4.6 and GPT-5.5** (degradation flagged but non-blocking ship)
+- Cross-model divergence > 1 fixture between Opus and Sonnet/GPT → recalibrate routing prose
+
+If you cannot reach 100% on Opus 4.7, the routing prose in CLAUDE.md / protocol doc needs tightening — fix the prose, not the test.
+
+## Fixture index
+
+| # | Fixture | Input class | Expected routing |
+|---|---|---|---|
+| 01 | `01_cross_phase_abstract_plus_lit/` | Abstract (Phase 4) + literature (Phase 2) | **Clarify** (cross-phase ambiguous) |
+| 02 | `02_single_phase_literature_only/` | Literature only (Phase 2) + lit-review request | **Proceed** (explicit + single-phase) |
+| 03 | `03_no_materials_ambiguous/` | "Can you help me with my paper?" | **Clarify** (no-materials ambiguous) |
+| 04 | `04_explicit_slash_command/` | `/ars-lit-review` invocation | **Proceed** (explicit slash command) |
+| 05 | `05_direct_mode_honored/` | `[direct-mode] run bibliography_agent` | **Proceed** (escape hatch honored, no clarification) |
+| 06 | `06_direct_mode_mid_message_not_honored/` | "Please [direct-mode] dispatch X" | **Clarify** (escape hatch ignored — not byte-0) |
+| 07 | `07_direct_mode_case_insensitive/` | `[Direct-Mode] write an abstract` | **Proceed** (case-insensitive accepted) |
+| 08 | `08_full_draft_plus_abstract_plus_lit/` | Full draft + abstract + literature, no clear intent | **Clarify** (cross-phase, multiple plausible workflows) |
+
+## Fixture file format
+
+Each fixture directory contains:
+
+```
+NN_<slug>/
+├── input.md          — user message (verbatim) + any provided artifacts described in markdown
+├── expected.yaml     — expected routing outcome (machine-readable)
+└── rationale.md      — why this is the expected outcome (human-readable, cites routing prose lines)
+```
+
+### `expected.yaml` schema
+
+```yaml
+fixture_id: <NN_slug>
+expected_routing_class: clarify | proceed
+expected_destination: <skill_name> | <agent_name> | clarification_only
+escape_hatch_applied: true | false
+direct_mode_stripped_message: <string, only when escape_hatch_applied: true>
+notes: <optional free-text>
+```
+
+### Running the smoke test (manual)
+
+Until v3.10 conductor brings deterministic dispatch, these fixtures are run **manually against a live ARS session**:
+
+1. Start a fresh Claude Code session in a clean workspace
+2. Paste the `input.md` content as the first message
+3. Observe whether the response classifies as `expected_routing_class`
+4. Record pass/fail in a calibration log
+
+For cross-model spot-check, run the same fixtures against Opus / Sonnet / GPT-5.5 and compare.
+
+## v3.10 forward note
+
+When active conductor (#134) ships, these fixtures translate to deterministic envelope-dispatch tests with structured `task_envelope.schema.json` validation. The behavioral-smoke-test framing becomes obsolete — the conductor's routing decision is then code-testable, not LLM-behavior-testable.


### PR DESCRIPTION
## Summary

Hot-fix for **#133** (phase scope inflation). Implements design v4 over 6 commits. Long-term architectural fix tracked as **#134** (v3.10 active conductor).

User incident: ARS auto-dispatched `bibliography_agent` on ambiguous cross-phase input (abstract + literature) and the agent autonomously ran Phases 3-6, silently skipping mandatory independent crosschecks (DA / EIC / Ethics).

Hot-fix is **prompt-discipline + advisory verifier**. The deterministic gate (PreToolUse hook + multi-phase task envelope + author provenance) requires multi-phase schema design and is deferred to v3.10 conductor (#134).

## Changes

**Phase 0.2** — 4-bucket classification (38 agents): A=22 single-phase, B=4 multi-phase, C=8 phase-orthogonal, D=4 cross-phase-meta.

**Phase L1** — Routing clarification gate in `.claude/CLAUDE.md` + `shared/references/intent_clarification_protocol.md` + `[direct-mode]` escape hatch + 4 SKILL.md backpointer + 8 behavioral smoke test fixtures.

**Phase 1** — 22 Bucket A agents get `## Phase Boundary (v3.9.2)` block, customized per agent. Bucket B (multi-phase) intentionally NOT fenced — honest framing per opus HIGH-2 (placebo prose creates false-enforcement illusion).

**Phase 3** — 4 SKILL.md gain Phase-by-phase Invocation Contract section (Mode A orchestrator-driven vs Mode B phase-by-phase).

**Phase 4** — `scripts/check_pipeline_integrity.py` advisory verifier (structural: phase5_missing_independent_reviewer; heuristic: adjacent-phase-mtime via --strict).

**Phase 5** — `scripts/check_v3_9_2_phase_boundary.py` lint (22 fenced + 16 not) + CI wiring.

**Phase 6** — Mid-impl dual-track review absorption: CLAUDE.md Step 0 logical bug fix (was Step 3, defeated escape hatch), protocol doc byte-0/whitespace inconsistency reframed, verifier filename convention documented + dotfile filter + 4 test-coverage adds.

**Phase 7** — Personal-boundary PASSED (648 files / 0 violations). No HEEACT / hei-platform / Springer leak.

**Phase 8** — Atomic version bump (plugin.json + CLAUDE.md table + Suite version + 4 SKILL.md + MODE_REGISTRY + README + README.zh-TW + CHANGELOG), also fixes pre-existing v3.9.1 latent bug (Suite version was stale at 3.9.0).

## Verification

- ✅ pytest **1482 passed** + 3 skipped + 111 subtests (baseline v3.9.1 was 1463; +19 = 1482, all new tests from this PR)
- ✅ `check_spec_consistency.py` PASS
- ✅ `check_version_consistency.py` PASS (was failing on v3.9.1 latent bug — this PR catches it)
- ✅ `check_v3_9_2_phase_boundary.py` PASS (22 + 16 = 38 agents validated)
- ✅ `check_v3_6_7_pattern_protection.py` PASS (existing PROTECTION blocks unaffected)
- ✅ `~/.claude/personal-boundary/check_boundary.py` PASSED (0 violations)
- ✅ 0 regression on v3.9.1 baseline

## Design history

4 design rounds (v1 → v4) + mid-impl review. Triple-track reviewer use: codex `review --base main` + inline opus subagent + self-review.

**Codex 0.130 status on this repo**: 5x consecutive broken corner per memory `feedback_codex_0_130_docs_review_broken.md` (49 files / 1529 lines on full branch firmly past broken-corner threshold). Inline opus subagent was substantive reviewer throughout. Frame-lock caveat applies; documented for future readers.

## Carry-over to v3.10 (#134)

- PreToolUse hook (Phase 0.1 verified CC payload has `agent_type` field)
- Multi-phase `ars_phase_writes` + `ars_phase_reads` envelope schema
- Deterministic verifier with author provenance
- Orchestrator cross-phase intake capability

## Migration notes (for users)

No break expected. New behavior: dropping pre-existing materials without invoking a specific slash command may now clarify (a-d options) instead of silent dispatch. To bypass clarification, prefix first message with `[direct-mode]` or use `/ars-full`.

Bucket B multi-phase agents (devils_advocate, report_compiler, argument_builder, visualization) intentionally not fenced — recurrence possible until v3.10 envelope ships. Report to #134 if observed.

Closes #133
Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)