### PR TITLE
v3.9.3: housekeeping — extract shared client utilities + dedup resolvers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research-skills",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 38-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.9.2 phase boundary fence (#133).",
   "author": {
     "name": "Cheng-I Wu",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 | `deep-research` v2.9.4 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
 | `academic-paper` v3.1.2 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.9.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.9.2 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.9.3 | Full pipeline orchestrator | (coordinates all above) |
 
 ## v3.7.3 Key Additions (in progress)
 
@@ -230,7 +230,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.9.2 (per CHANGELOG.md)
+- **Suite version**: 3.9.3 (per CHANGELOG.md)
 - **Last Updated**: 2026-05-18
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.9.3] - 2026-05-18 — Housekeeping (#128 §1-3, §5-6)
+
+Pure refactor + one latent-bug fix carrying over from the v3.9.0 `/simplify` review backlog. The v3.9.0 cross-index triangulation client family (Semantic Scholar + OpenAlex + Crossref) shipped intentionally byte-equivalent across 3 client modules for code locality; now that the family is stable, the dedup prevents sibling drift when threshold tuning, normalization rules, or throttle measurement need adjustment.
+
+### Refactor — extracted helpers (no behavior change)
+
+- **`scripts/_text_similarity.py`** — extracts 4 helpers + 4 constants previously triple-implemented byte-equivalent in `semantic_scholar_client.py` / `openalex_client.py` / `crossref_client.py`: `_PUNCT_TRANSLATION`, `_normalize_title`, `_similarity`, `_TITLE_SIMILARITY_THRESHOLD = 0.70`, `_BACKOFF_SECONDS = 2.0`, `_MAX_RETRIES = 3`. 14 new tests on the shared module.
+- **`scripts/_passport_yaml.py`** — extracts ruamel.yaml round-trip config (`preserve_quotes = True`, `indent(mapping=2, sequence=4, offset=2)`) + `load_passport` / `dump_passport` functions previously duplicated byte-equivalent in `migrate_literature_corpus_to_v3_7_3.py` + `migrate_literature_corpus_to_v3_9_0.py`. 7 new tests on the shared module.
+- **`contamination_signals._resolve_by_doi_then_title`** — private helper for the identical DOI-then-title control flow shared by `resolve_openalex_unmatched` (§3.4) + `resolve_crossref_unmatched` (§3.5). Both public wrappers preserve the v3.9.0 spec API surface; exception-type differentiation stays at the wrapper. 10 existing resolver tests verify byte-equivalent behavior.
+
+### Latent-bug fix — throttle measurement standardized on `time.monotonic`
+
+- OpenAlex + Crossref clients now use `time.monotonic()` for `_throttle()` elapsed measurement + `_last_request_at` anchor refresh, matching Semantic Scholar (which had standardized on monotonic per #115 R5-2). NTP / manual clock adjustments could push `time.time()` backward, producing negative elapsed and either inflated sleep (negative compared less than min_interval) or zero sleep — latent throttle-bypass / API-spam bug. Documented as a "maintenance smell" in #128 §6.
+- New tests (`test_openalex_client::test_throttle_uses_monotonic_clock` + `test_crossref_client::test_throttle_uses_monotonic_clock`) lock NTP-safe semantics: throttle reads `time.monotonic` and never reads `time.time`.
+
+### Dual-path import infrastructure
+
+- All 5 module-level cross-imports in `openalex_client.py` / `crossref_client.py` / `semantic_scholar_client.py` / `migrate_literature_corpus_to_v3_7_3.py` / `migrate_literature_corpus_to_v3_9_0.py` use the dual-path try/except pattern (sibling-first, namespace-package fallback). Follows `scripts/slr_lineage.py` precedent but inverted for class-identity preservation (pytest uses sibling-path imports; `SemanticScholarUnavailable` from `scripts.contamination_signals` is a different class instance than `contamination_signals.SemanticScholarUnavailable`).
+- Latent fix: `scripts.semantic_scholar_client` + `scripts.migrate_literature_corpus_to_v3_7_3` are now `import scripts.X`-clean from repo root (were silently broken on main due to pre-existing absolute cross-imports). Caught by codex round-1 reasoning trace.
+
+### Deferred from #128
+
+- **§4 — parallelize OA + CR per-entry calls in v3.9.0 migration tool** carried to #138 (target v3.9.4 or v3.10). Introduces new behavior + ThreadPoolExecutor + test-rebuild scope; incompatible with v3.9.3 patch boundary.
+
+### Regression status
+
+- 1482 → **1505 passed** + 3 skipped + 111 subtests (+23 new tests, 0 regression).
+- `scripts/check_spec_consistency.py` + `scripts/check_version_consistency.py` green.
+- 6/6 `import scripts.X` paths verified clean from repo root (3 from-OK-to-OK, 2 latent-broken-now-OK, 1 OK throughout).
+- Cross-model review: codex round 1 + 2 both 0 explicit findings (one P1 self-caught from R1 trace, closed pre-R2). Gemini 3.1-pro-preview round 1: 0 findings.
+
+---
+
 ## [3.9.2] - 2026-05-18 — Phase boundary hot-fix (#133)
 
 Hot-fix for issue #133 (phase scope inflation). A user incident showed that ARS auto-dispatched a single-phase agent (`bibliography_agent`) when given ambiguous cross-phase input (pre-written abstract + pre-collected literature), and the dispatched agent then autonomously executed Phases 3-6, skipping mandatory independent crosschecks (DA / EIC / Ethics).

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.9.2 (2026-05-18)
+Last updated: v3.9.3 (2026-05-18)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.2)
+[![Version](https://img.shields.io/badge/version-v3.9.3-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.3)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -318,6 +318,10 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.9.3 (2026-05-18) — #128 housekeeping (shared client utilities + dedup resolvers)
+
+> Pure refactor + one latent-bug fix from the v3.9.0 `/simplify` review backlog. Extracts `scripts/_text_similarity.py` (3-way client dedup: normalize / similarity / threshold / retry constants) + `scripts/_passport_yaml.py` (2-way migration tool dedup: ruamel.yaml round-trip config) + private `_resolve_by_doi_then_title` helper (2-way resolver body dedup, §3.4 / §3.5 API surface preserved). Standardizes throttle measurement on `time.monotonic` across OpenAlex + Crossref (was `time.time`, NTP-unsafe), aligning with Semantic Scholar. Dual-path import infrastructure on all 5 module-level cross-imports (sibling-first, namespace-package fallback) preserves class identity for `SemanticScholarUnavailable` and bonus-fixes 2 latent-broken `import scripts.X` paths. 1505 passed (+23 new, 0 regression). #128 §4 (parallelize OA + CR per-entry) carried to #138.
 
 ### v3.9.2 (2026-05-18) — #133 phase boundary hot-fix
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.2)
+[![Version](https://img.shields.io/badge/version-v3.9.3-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.3)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -299,6 +299,10 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.9.3（2026-05-18）— #128 housekeeping（client utility 抽出 + resolver dedup）
+
+> 純 refactor + 一個 latent bug fix，從 v3.9.0 `/simplify` review backlog 結清。抽出 `scripts/_text_similarity.py`（3-way client dedup：normalize / similarity / threshold / retry 常數）+ `scripts/_passport_yaml.py`（2-way migration tool dedup：ruamel.yaml round-trip config）+ 私有 `_resolve_by_doi_then_title` helper（2-way resolver body dedup、§3.4 / §3.5 API surface 不變）。OpenAlex + Crossref 的 throttle 量測從 `time.time`（NTP 不安全）統一改用 `time.monotonic`，與 Semantic Scholar 對齊。5 個 module-level cross-import 都加 dual-path try/except（sibling-first、namespace-package fallback）保持 class identity；額外順手修了 2 個 latent-broken 的 `import scripts.X` 路徑。1505 passed（+23 新測試、0 regression）。#128 §4（OA + CR 平行化）carry-over 到 #138。
 
 ### v3.9.2（2026-05-18）— #133 phase boundary 熱修
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,7 +2,7 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.9.2"
+  version: "3.9.3"
   last_updated: "2026-05-18"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active

--- a/scripts/_passport_yaml.py
+++ b/scripts/_passport_yaml.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Shared ruamel.yaml round-trip configuration for passport migration tools.
 
+For tools that **mutate and re-emit** passport YAML (preserving comments,
+key order, quoting). Read-only validators should keep using `yaml.safe_load`.
+
 Previously duplicated byte-equivalently in
 `migrate_literature_corpus_to_v3_7_3.py` and
 `migrate_literature_corpus_to_v3_9_0.py`. Extracted in #128 (v3.9.1
@@ -16,6 +19,10 @@ Configuration:
 - indent(mapping=2, sequence=4, offset=2) → sequence items align with `- `
   two spaces past the parent key, matching the passport convention used
   by `shared/contracts/passport/literature_corpus_entry.schema.json` examples.
+
+Thread-safety: single-threaded use only. The module-level `_yaml` is a shared
+mutable singleton; instantiate per-thread (or per-call) if future tools
+parallelize passport migration.
 """
 from __future__ import annotations
 

--- a/scripts/_passport_yaml.py
+++ b/scripts/_passport_yaml.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Shared ruamel.yaml round-trip configuration for passport migration tools.
+
+Previously duplicated byte-equivalently in
+`migrate_literature_corpus_to_v3_7_3.py` and
+`migrate_literature_corpus_to_v3_9_0.py`. Extracted in #128 (v3.9.1
+housekeeping) so future migration tools inherit the spec-aligned round-trip
+shape without re-deriving it.
+
+Behavior must remain byte-equivalent with the per-tool configuration that
+was verified across multiple v3.7.3 / v3.9.0 review rounds. See
+`test_passport_yaml.py` for the configuration + round-trip contract.
+
+Configuration:
+- preserve_quotes = True → keeps single vs double quoting choice.
+- indent(mapping=2, sequence=4, offset=2) → sequence items align with `- `
+  two spaces past the parent key, matching the passport convention used
+  by `shared/contracts/passport/literature_corpus_entry.schema.json` examples.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+# Single shared YAML round-tripper. ruamel.yaml preserves comments,
+# key order, and quoting style across read → mutate → write.
+_yaml = YAML()
+_yaml.preserve_quotes = True
+_yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+def load_passport(path: Path) -> Any:
+    """Round-trip load a passport YAML file. Returns the ruamel-yaml
+    representation (a CommentedMap), not a plain dict."""
+    with path.open("r", encoding="utf-8") as f:
+        return _yaml.load(f)
+
+
+def dump_passport(path: Path, doc: Any) -> None:
+    """Round-trip dump a passport YAML document back to disk, preserving
+    comments / key order / quoting style from the matching load."""
+    with path.open("w", encoding="utf-8") as f:
+        _yaml.dump(doc, f)

--- a/scripts/_text_similarity.py
+++ b/scripts/_text_similarity.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Shared title-similarity + retry-budget helpers for the v3.9.0 cross-index
+triangulation clients.
+
+Previously triple-implemented byte-equivalently in
+`semantic_scholar_client.py`, `openalex_client.py`, and `crossref_client.py`.
+Extracted in #128 (v3.9.1 housekeeping) to prevent sibling drift — any
+threshold tuning or normalization rule change now happens in one place.
+
+Behavior must remain byte-equivalent with the v3.7.3 / v3.9.0 client
+implementations. See `test_text_similarity.py` for the contract tests.
+"""
+from __future__ import annotations
+
+import string
+from difflib import SequenceMatcher
+
+
+_PUNCT_TRANSLATION = str.maketrans({c: " " for c in string.punctuation})
+
+
+# Per protocol: 429 → 2s backoff × 3 retries. Shared budget across S2 /
+# OpenAlex / Crossref clients.
+_BACKOFF_SECONDS = 2.0
+_MAX_RETRIES = 3
+
+
+# Per PaperOrchestra (Song et al. 2026 Appx D.3) + protocol §"Query Patterns"
+# Pattern 1: title-similarity threshold for "matched" verdict.
+_TITLE_SIMILARITY_THRESHOLD = 0.70
+
+
+def _normalize_title(s: str) -> str:
+    """Per protocol §"Query Patterns" Pattern 1: 'case-insensitive, stripped
+    of punctuation' before computing similarity. Punctuation becomes
+    whitespace so token boundaries are preserved, then collapse runs of
+    whitespace. Codex R4-1 closure: raw lowercased comparison falsely scored
+    'R.A.G.' vs 'RAG' below the 0.70 threshold."""
+    cleaned = s.lower().translate(_PUNCT_TRANSLATION)
+    return " ".join(cleaned.split())
+
+
+def _similarity(a: str, b: str) -> float:
+    return SequenceMatcher(None, _normalize_title(a), _normalize_title(b)).ratio()

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.9.2 (2026-05-18)")
+    expect_contains(rel_path, "Last updated: v3.9.3 (2026-05-18)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.9.2")
+    expect_contains(rel_path, "**Suite version**: 3.9.3")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,9 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.2-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.2")
-    expect_contains(rel_path, "### v3.9.2 (2026-05-18)")
+    expect_contains(rel_path, "version-v3.9.3-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.3")
+    expect_contains(rel_path, "### v3.9.3 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.1 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.0 (2026-05-17)")
     expect_contains(rel_path, "### v3.8.0 (2026-05-16)")
@@ -207,9 +207,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.2-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.2")
-    expect_contains(rel_path, "### v3.9.2（2026-05-18）")
+    expect_contains(rel_path, "version-v3.9.3-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.3")
+    expect_contains(rel_path, "### v3.9.3（2026-05-18）")
     expect_contains(rel_path, "### v3.9.1（2026-05-18）")
     expect_contains(rel_path, "### v3.9.0（2026-05-17）")
     expect_contains(rel_path, "### v3.8.0（2026-05-16）")

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -146,6 +146,33 @@ def compute_ss_unmatched_signal(
     return not result.get("matched", False)
 
 
+def _resolve_by_doi_then_title(entry: Mapping[str, Any], client) -> bool | None:
+    """Shared resolver body for OpenAlex + Crossref clients (#128 §3 dedup).
+
+    Both clients expose the same `doi_lookup_with_title_check(doi, title)` +
+    `title_search(title)` Protocol shape, so the unmatched-resolution control
+    flow is identical between them. This helper carries that flow; the two
+    named public wrappers (`resolve_openalex_unmatched`,
+    `resolve_crossref_unmatched`) preserve the v3.9.0 §3.4 / §3.5 spec API
+    surface. Exception-type differentiation stays at the wrapper — this
+    helper never catches; caller catches the client-specific *Unavailable*.
+
+    Returns:
+        True / False / None per the contract documented on each public wrapper.
+    """
+    if entry.get("obtained_via") == "manual":
+        return None
+    title = entry.get("title", "")
+    doi = entry.get("doi")
+    if doi:
+        hit = client.doi_lookup_with_title_check(doi, title)
+        if hit is not None:
+            return False
+        # DOI miss or MISMATCH — fall through to title search.
+    hit = client.title_search(title)
+    return hit is None
+
+
 def resolve_openalex_unmatched(entry: Mapping[str, Any], client) -> bool | None:
     """Compute openalex_unmatched per spec v3.9.0 §3.4.
 
@@ -165,17 +192,7 @@ def resolve_openalex_unmatched(entry: Mapping[str, Any], client) -> bool | None:
     Raises:
         OpenAlexUnavailable: API degraded, caller must omit field per R-L3-2-C.
     """
-    if entry.get("obtained_via") == "manual":
-        return None
-    title = entry.get("title", "")
-    doi = entry.get("doi")
-    if doi:
-        hit = client.doi_lookup_with_title_check(doi, title)
-        if hit is not None:
-            return False
-        # DOI miss or MISMATCH — fall through to title search.
-    hit = client.title_search(title)
-    return hit is None
+    return _resolve_by_doi_then_title(entry, client)
 
 
 def resolve_crossref_unmatched(entry: Mapping[str, Any], client) -> bool | None:
@@ -190,17 +207,7 @@ def resolve_crossref_unmatched(entry: Mapping[str, Any], client) -> bool | None:
     Raises:
         CrossrefUnavailable: API degraded, caller must omit field per R-L3-2-C.
     """
-    if entry.get("obtained_via") == "manual":
-        return None
-    title = entry.get("title", "")
-    doi = entry.get("doi")
-    if doi:
-        hit = client.doi_lookup_with_title_check(doi, title)
-        if hit is not None:
-            return False
-        # DOI miss or MISMATCH — fall through to title search.
-    hit = client.title_search(title)
-    return hit is None
+    return _resolve_by_doi_then_title(entry, client)
 
 
 def build_signals_object(

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -147,19 +147,9 @@ def compute_ss_unmatched_signal(
 
 
 def _resolve_by_doi_then_title(entry: Mapping[str, Any], client) -> bool | None:
-    """Shared resolver body for OpenAlex + Crossref clients (#128 §3 dedup).
-
-    Both clients expose the same `doi_lookup_with_title_check(doi, title)` +
-    `title_search(title)` Protocol shape, so the unmatched-resolution control
-    flow is identical between them. This helper carries that flow; the two
-    named public wrappers (`resolve_openalex_unmatched`,
-    `resolve_crossref_unmatched`) preserve the v3.9.0 §3.4 / §3.5 spec API
-    surface. Exception-type differentiation stays at the wrapper — this
-    helper never catches; caller catches the client-specific *Unavailable*.
-
-    Returns:
-        True / False / None per the contract documented on each public wrapper.
-    """
+    """Shared body for resolve_openalex_unmatched / resolve_crossref_unmatched.
+    See those wrappers for the spec contract. Exception-type differentiation
+    stays at the wrapper — this helper never catches."""
     if entry.get("obtained_via") == "manual":
         return None
     title = entry.get("title", "")

--- a/scripts/crossref_client.py
+++ b/scripts/crossref_client.py
@@ -86,7 +86,11 @@ class CrossrefClient:
     def _throttle(self) -> None:
         if self._last_request_at is None:
             return
-        elapsed = time.time() - self._last_request_at
+        # time.monotonic for elapsed measurement: NTP / manual clock
+        # adjustments can make time.time go backward, producing negative
+        # elapsed and either huge sleep or zero sleep (#128 §6). Aligns
+        # with semantic_scholar_client.py.
+        elapsed = time.monotonic() - self._last_request_at
         if elapsed < self._min_interval:
             time.sleep(self._min_interval - elapsed)
 
@@ -97,7 +101,7 @@ class CrossrefClient:
         req = urllib.request.Request(url, headers={"User-Agent": self._user_agent})
 
         self._throttle()
-        self._last_request_at = time.time()
+        self._last_request_at = time.monotonic()
 
         for attempt in range(_MAX_RETRIES + 1):
             try:
@@ -133,7 +137,7 @@ class CrossrefClient:
                     # Refresh throttle anchor after backoff so the next outer
                     # _get call's _throttle() paces against actual wake time,
                     # not the original entry time (mirrors openalex_client.py).
-                    self._last_request_at = time.time()
+                    self._last_request_at = time.monotonic()
                     continue
                 raise CrossrefUnavailable(f"Crossref HTTP {e.code}: {e.reason}") from e
             except (urllib.error.URLError, TimeoutError) as e:

--- a/scripts/crossref_client.py
+++ b/scripts/crossref_client.py
@@ -26,7 +26,6 @@ from typing import Any, Mapping
 from _text_similarity import (
     _BACKOFF_SECONDS,
     _MAX_RETRIES,
-    _PUNCT_TRANSLATION,
     _TITLE_SIMILARITY_THRESHOLD,
     _normalize_title,
     _similarity,

--- a/scripts/crossref_client.py
+++ b/scripts/crossref_client.py
@@ -23,13 +23,23 @@ import urllib.parse
 import urllib.request
 from typing import Any, Mapping
 
-from _text_similarity import (
-    _BACKOFF_SECONDS,
-    _MAX_RETRIES,
-    _TITLE_SIMILARITY_THRESHOLD,
-    _normalize_title,
-    _similarity,
-)
+# Dual-path import: see openalex_client.py comment.
+try:
+    from _text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _normalize_title,
+        _similarity,
+    )
+except ImportError:
+    from scripts._text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _normalize_title,
+        _similarity,
+    )
 
 
 _API_BASE = "https://api.crossref.org"

--- a/scripts/crossref_client.py
+++ b/scripts/crossref_client.py
@@ -17,40 +17,29 @@ from __future__ import annotations
 import http.client
 import json
 import os
-import string
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from difflib import SequenceMatcher
 from typing import Any, Mapping
 
+from _text_similarity import (
+    _BACKOFF_SECONDS,
+    _MAX_RETRIES,
+    _PUNCT_TRANSLATION,
+    _TITLE_SIMILARITY_THRESHOLD,
+    _normalize_title,
+    _similarity,
+)
 
-_PUNCT_TRANSLATION = str.maketrans({c: " " for c in string.punctuation})
 
 _API_BASE = "https://api.crossref.org"
 _POLITE_EMAIL_ENV = "CROSSREF_POLITE_EMAIL"
-
-_BACKOFF_SECONDS = 2.0
-_MAX_RETRIES = 3
 
 # Crossref polite pool: 10 req/s with mailto, ~5 req/s anonymous (per
 # Crossref live response headers: x-rate-limit-limit=10, interval=1s).
 _POLITE_MIN_INTERVAL = 0.1
 _ANONYMOUS_MIN_INTERVAL = 0.2
-
-_TITLE_SIMILARITY_THRESHOLD = 0.70
-
-
-def _normalize_title(s: str) -> str:
-    """Case-insensitive, punctuation-to-whitespace normalization. Matches
-    S2 / OpenAlex client to keep the threshold semantically aligned."""
-    cleaned = s.lower().translate(_PUNCT_TRANSLATION)
-    return " ".join(cleaned.split())
-
-
-def _similarity(a: str, b: str) -> float:
-    return SequenceMatcher(None, _normalize_title(a), _normalize_title(b)).ratio()
 
 
 def _extract_title(message_or_item: Mapping[str, Any]) -> str:

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 import contamination_signals as cs
-from _passport_yaml import dump_passport as _dump_passport, load_passport
+from _passport_yaml import dump_passport, load_passport
 from adapters._common import now_iso
 
 
@@ -159,7 +159,7 @@ def migrate_passport(
         mutated = True
 
     if mutated and not dry_run:
-        _dump_passport(path, doc)
+        dump_passport(path, doc)
     return report
 
 

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -21,17 +21,9 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-from ruamel.yaml import YAML
-
 import contamination_signals as cs
+from _passport_yaml import dump_passport as _dump_passport, load_passport
 from adapters._common import now_iso
-
-
-# Single shared YAML round-tripper. ruamel.yaml preserves comments,
-# key order, and quoting style across read → mutate → write.
-_yaml = YAML()
-_yaml.preserve_quotes = True
-_yaml.indent(mapping=2, sequence=4, offset=2)
 
 
 # Skip-reason categories surface in the migration report so users can
@@ -42,18 +34,6 @@ _SKIP_INSUFFICIENT_DATA = "skipped_insufficient_data"
 # patched, but `semantic_scholar_unmatched` was omitted per spec §3.2).
 # Distinct from skip categories above — these entries DO get patched.
 _MANUAL_UNMATCHED_OMITTED = "manual_unmatched_omitted"
-
-
-def load_passport(path: Path) -> Any:
-    """Round-trip load a passport YAML file. Returns the ruamel-yaml
-    representation (a CommentedMap), not a plain dict."""
-    with path.open("r", encoding="utf-8") as f:
-        return _yaml.load(f)
-
-
-def _dump_passport(path: Path, doc: Any) -> None:
-    with path.open("w", encoding="utf-8") as f:
-        _yaml.dump(doc, f)
 
 
 def discover_passports(directory: Path) -> Iterable[Path]:

--- a/scripts/migrate_literature_corpus_to_v3_7_3.py
+++ b/scripts/migrate_literature_corpus_to_v3_7_3.py
@@ -21,9 +21,15 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-import contamination_signals as cs
-from _passport_yaml import dump_passport, load_passport
-from adapters._common import now_iso
+# Dual-path import: see openalex_client.py comment.
+try:
+    import contamination_signals as cs
+    from _passport_yaml import dump_passport, load_passport
+    from adapters._common import now_iso
+except ImportError:
+    from scripts import contamination_signals as cs
+    from scripts._passport_yaml import dump_passport, load_passport
+    from scripts.adapters._common import now_iso
 
 
 # Skip-reason categories surface in the migration report so users can

--- a/scripts/migrate_literature_corpus_to_v3_9_0.py
+++ b/scripts/migrate_literature_corpus_to_v3_9_0.py
@@ -22,32 +22,13 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
-from ruamel.yaml import YAML
-
-
-# Single shared YAML round-tripper. ruamel.yaml preserves comments,
-# key order, and quoting style across read → mutate → write.
-_yaml = YAML()
-_yaml.preserve_quotes = True
-_yaml.indent(mapping=2, sequence=4, offset=2)
+from _passport_yaml import dump_passport as _dump_passport, load_passport
 
 
 # Skip-reason keys surface in the migration report.
 _SKIP_MANUAL = "skipped_manual"
 _SKIP_PRE_V3_7_3 = "skipped_pre_v3_7_3"
 _SKIP_COMPLETE = "skipped_complete"
-
-
-def load_passport(path: Path) -> Any:
-    """Round-trip load a passport YAML file. Returns the ruamel-yaml
-    representation (a CommentedMap), not a plain dict."""
-    with path.open("r", encoding="utf-8") as f:
-        return _yaml.load(f)
-
-
-def _dump_passport(path: Path, doc: Any) -> None:
-    with path.open("w", encoding="utf-8") as f:
-        _yaml.dump(doc, f)
 
 
 def _entry_in_v3_7_3_scope(entry: Mapping[str, Any]) -> bool:

--- a/scripts/migrate_literature_corpus_to_v3_9_0.py
+++ b/scripts/migrate_literature_corpus_to_v3_9_0.py
@@ -22,7 +22,7 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
-from _passport_yaml import dump_passport as _dump_passport, load_passport
+from _passport_yaml import dump_passport, load_passport
 
 
 # Skip-reason keys surface in the migration report.
@@ -177,7 +177,7 @@ def migrate_passport(
             mutated = True
 
     if mutated and not dry_run:
-        _dump_passport(path, doc)
+        dump_passport(path, doc)
 
     # Summary to stdout (mirrors v3.7.3 tool print-on-main pattern but
     # here we always emit; caller may also call _print_report() below).

--- a/scripts/migrate_literature_corpus_to_v3_9_0.py
+++ b/scripts/migrate_literature_corpus_to_v3_9_0.py
@@ -22,7 +22,11 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
-from _passport_yaml import dump_passport, load_passport
+# Dual-path import: see openalex_client.py comment.
+try:
+    from _passport_yaml import dump_passport, load_passport
+except ImportError:
+    from scripts._passport_yaml import dump_passport, load_passport
 
 
 # Skip-reason keys surface in the migration report.

--- a/scripts/openalex_client.py
+++ b/scripts/openalex_client.py
@@ -18,13 +18,26 @@ import urllib.parse
 import urllib.request
 from typing import Any, Mapping
 
-from _text_similarity import (
-    _BACKOFF_SECONDS,
-    _MAX_RETRIES,
-    _TITLE_SIMILARITY_THRESHOLD,
-    _normalize_title,
-    _similarity,
-)
+# Dual-path import: sibling-first (so module identity matches when callers
+# import via the sibling path, e.g. tests), namespace-package fallback (for
+# repo-root `import scripts.openalex_client`). See semantic_scholar_client.py
+# for the identity-matching rationale.
+try:
+    from _text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _normalize_title,
+        _similarity,
+    )
+except ImportError:
+    from scripts._text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _normalize_title,
+        _similarity,
+    )
 
 
 _API_BASE = "https://api.openalex.org"

--- a/scripts/openalex_client.py
+++ b/scripts/openalex_client.py
@@ -21,7 +21,6 @@ from typing import Any, Mapping
 from _text_similarity import (
     _BACKOFF_SECONDS,
     _MAX_RETRIES,
-    _PUNCT_TRANSLATION,
     _TITLE_SIMILARITY_THRESHOLD,
     _normalize_title,
     _similarity,
@@ -59,8 +58,8 @@ class OpenAlexClient:
             return
         # time.monotonic for elapsed measurement: NTP / manual clock
         # adjustments can make time.time go backward, producing negative
-        # elapsed and either huge sleep (negative compared less than) or
-        # zero sleep (#128 §6). Aligns with semantic_scholar_client.py.
+        # elapsed and either huge sleep or zero sleep (#128 §6). Aligns
+        # with semantic_scholar_client.py.
         elapsed = time.monotonic() - self._last_request_at
         if elapsed < self._min_interval:
             time.sleep(self._min_interval - elapsed)

--- a/scripts/openalex_client.py
+++ b/scripts/openalex_client.py
@@ -12,37 +12,28 @@ from __future__ import annotations
 import http.client
 import json
 import os
-import string
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from difflib import SequenceMatcher
 from typing import Any, Mapping
 
+from _text_similarity import (
+    _BACKOFF_SECONDS,
+    _MAX_RETRIES,
+    _PUNCT_TRANSLATION,
+    _TITLE_SIMILARITY_THRESHOLD,
+    _normalize_title,
+    _similarity,
+)
 
-_PUNCT_TRANSLATION = str.maketrans({c: " " for c in string.punctuation})
 
 _API_BASE = "https://api.openalex.org"
 _POLITE_EMAIL_ENV = "OPENALEX_POLITE_EMAIL"
 _FIELDS = "id,title,authorships,publication_year,doi,primary_location"
 
-_BACKOFF_SECONDS = 2.0
-_MAX_RETRIES = 3
-
 _POLITE_MIN_INTERVAL = 0.1
 _ANONYMOUS_MIN_INTERVAL = 1.0
-
-_TITLE_SIMILARITY_THRESHOLD = 0.70
-
-
-def _normalize_title(s: str) -> str:
-    cleaned = s.lower().translate(_PUNCT_TRANSLATION)
-    return " ".join(cleaned.split())
-
-
-def _similarity(a: str, b: str) -> float:
-    return SequenceMatcher(None, _normalize_title(a), _normalize_title(b)).ratio()
 
 
 class OpenAlexUnavailable(Exception):

--- a/scripts/openalex_client.py
+++ b/scripts/openalex_client.py
@@ -57,7 +57,11 @@ class OpenAlexClient:
     def _throttle(self) -> None:
         if self._last_request_at is None:
             return
-        elapsed = time.time() - self._last_request_at
+        # time.monotonic for elapsed measurement: NTP / manual clock
+        # adjustments can make time.time go backward, producing negative
+        # elapsed and either huge sleep (negative compared less than) or
+        # zero sleep (#128 §6). Aligns with semantic_scholar_client.py.
+        elapsed = time.monotonic() - self._last_request_at
         if elapsed < self._min_interval:
             time.sleep(self._min_interval - elapsed)
 
@@ -69,7 +73,7 @@ class OpenAlexClient:
         req = urllib.request.Request(url, headers={"User-Agent": "ARS-v3.9.0"})
 
         self._throttle()
-        self._last_request_at = time.time()
+        self._last_request_at = time.monotonic()
 
         for attempt in range(_MAX_RETRIES + 1):
             try:
@@ -106,7 +110,7 @@ class OpenAlexClient:
                     # paces against actual wake time, not entry time.
                     # Without this the next call may under-sleep (elapsed
                     # already counts the 2s × N backoff) and re-trigger 429.
-                    self._last_request_at = time.time()
+                    self._last_request_at = time.monotonic()
                     continue
                 raise OpenAlexUnavailable(f"OpenAlex HTTP {e.code}: {e.reason}") from e
             except (urllib.error.URLError, TimeoutError) as e:

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -21,14 +21,28 @@ import urllib.parse
 import urllib.request
 from typing import Any, Mapping
 
-from _text_similarity import (
-    _BACKOFF_SECONDS,
-    _MAX_RETRIES,
-    _TITLE_SIMILARITY_THRESHOLD,
-    _normalize_title,
-    _similarity,
-)
-from contamination_signals import SemanticScholarUnavailable
+# Dual-path import: try sibling-style first (scripts/-on-sys.path, used by
+# tests and direct CLI invocation) so module identity matches when callers
+# import via the sibling path. Fall back to `scripts.<module>` (namespace
+# package style, repo-root PYTHONPATH). Same pattern as scripts/slr_lineage.py.
+try:
+    from _text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _normalize_title,
+        _similarity,
+    )
+    from contamination_signals import SemanticScholarUnavailable
+except ImportError:
+    from scripts._text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _normalize_title,
+        _similarity,
+    )
+    from scripts.contamination_signals import SemanticScholarUnavailable
 
 
 # Per protocol: api.semanticscholar.org/graph/v1, 1 req/s unauthenticated.

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -24,7 +24,6 @@ from typing import Any, Mapping
 from _text_similarity import (
     _BACKOFF_SECONDS,
     _MAX_RETRIES,
-    _PUNCT_TRANSLATION,
     _TITLE_SIMILARITY_THRESHOLD,
     _normalize_title,
     _similarity,

--- a/scripts/semantic_scholar_client.py
+++ b/scripts/semantic_scholar_client.py
@@ -15,18 +15,21 @@ tool can switch over without code changes.
 from __future__ import annotations
 
 import os
-import string
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from difflib import SequenceMatcher
 from typing import Any, Mapping
 
+from _text_similarity import (
+    _BACKOFF_SECONDS,
+    _MAX_RETRIES,
+    _PUNCT_TRANSLATION,
+    _TITLE_SIMILARITY_THRESHOLD,
+    _normalize_title,
+    _similarity,
+)
 from contamination_signals import SemanticScholarUnavailable
-
-
-_PUNCT_TRANSLATION = str.maketrans({c: " " for c in string.punctuation})
 
 
 # Per protocol: api.semanticscholar.org/graph/v1, 1 req/s unauthenticated.
@@ -34,33 +37,11 @@ _API_BASE = "https://api.semanticscholar.org/graph/v1"
 _API_KEY_ENV = "S2_API_KEY"
 _FIELDS = "title,authors,year,externalIds,venue,publicationDate"
 
-# Per protocol: 429 → 2s backoff × 3 retries.
-_BACKOFF_SECONDS = 2.0
-_MAX_RETRIES = 3
-
 # Per protocol line 6: unauthenticated tier is ~1 req/s, authenticated
 # (S2_API_KEY) tier is 10 req/s. Default throttle interval defends
 # against proactive rate limiting before a 429 fires (#115 R5-2).
 _UNAUTHENTICATED_MIN_INTERVAL = 1.0
 _AUTHENTICATED_MIN_INTERVAL = 0.1
-
-# Per PaperOrchestra (Song et al. 2026 Appx D.3) + protocol §"Query
-# Patterns" Pattern 1: title-similarity threshold for "matched" verdict.
-_TITLE_SIMILARITY_THRESHOLD = 0.70
-
-
-def _normalize_title(s: str) -> str:
-    """Per protocol §"Query Patterns" Pattern 1: 'case-insensitive,
-    stripped of punctuation' before computing similarity. Punctuation
-    becomes whitespace so token boundaries are preserved, then collapse
-    runs of whitespace. Codex R4-1 closure: raw lowercased comparison
-    falsely scored 'R.A.G.' vs 'RAG' below the 0.70 threshold."""
-    cleaned = s.lower().translate(_PUNCT_TRANSLATION)
-    return " ".join(cleaned.split())
-
-
-def _similarity(a: str, b: str) -> float:
-    return SequenceMatcher(None, _normalize_title(a), _normalize_title(b)).ratio()
 
 
 class SemanticScholarClient:

--- a/scripts/test_crossref_client.py
+++ b/scripts/test_crossref_client.py
@@ -298,3 +298,34 @@ def test_truncated_read_raises_unavailable(monkeypatch):
         client = CrossrefClient()
         with pytest.raises(CrossrefUnavailable):
             client.title_search("any title")
+
+
+def test_throttle_uses_monotonic_clock(monkeypatch):
+    """time.monotonic for elapsed measurement (NTP-safe). time.time can
+    go backward on NTP adjustments, breaking elapsed calculation.
+    Aligns OA/CR with semantic_scholar_client.py (#128 §6)."""
+    from crossref_client import CrossrefClient
+
+    monotonic_calls = []
+    time_calls = []
+
+    def fake_monotonic():
+        monotonic_calls.append(1)
+        return 100.0
+
+    def fake_time():
+        time_calls.append(1)
+        return 100.0
+
+    monkeypatch.setattr("crossref_client.time.monotonic", fake_monotonic)
+    monkeypatch.setattr("crossref_client.time.time", fake_time)
+
+    client = CrossrefClient()
+    # Initial state: no prior request — _throttle short-circuits.
+    client._throttle()
+    # Set anchor, then check throttle uses monotonic, not time.time.
+    client._last_request_at = 90.0
+    client._throttle()
+
+    assert len(monotonic_calls) >= 1, "throttle must read time.monotonic"
+    assert len(time_calls) == 0, "throttle must NOT read time.time (NTP-unsafe)"

--- a/scripts/test_openalex_client.py
+++ b/scripts/test_openalex_client.py
@@ -296,3 +296,34 @@ def test_truncated_read_raises_unavailable(monkeypatch):
         client = OpenAlexClient()
         with pytest.raises(OpenAlexUnavailable):
             client.title_search("any title")
+
+
+def test_throttle_uses_monotonic_clock(monkeypatch):
+    """time.monotonic for elapsed measurement (NTP-safe). time.time can
+    go backward on NTP adjustments, breaking elapsed calculation.
+    Aligns OA/CR with semantic_scholar_client.py (#128 §6)."""
+    from openalex_client import OpenAlexClient
+
+    monotonic_calls = []
+    time_calls = []
+
+    def fake_monotonic():
+        monotonic_calls.append(1)
+        return 100.0
+
+    def fake_time():
+        time_calls.append(1)
+        return 100.0
+
+    monkeypatch.setattr("openalex_client.time.monotonic", fake_monotonic)
+    monkeypatch.setattr("openalex_client.time.time", fake_time)
+
+    client = OpenAlexClient()
+    # Initial state: no prior request — _throttle short-circuits.
+    client._throttle()
+    # Set anchor, then check throttle uses monotonic, not time.time.
+    client._last_request_at = 90.0
+    client._throttle()
+
+    assert len(monotonic_calls) >= 1, "throttle must read time.monotonic"
+    assert len(time_calls) == 0, "throttle must NOT read time.time (NTP-unsafe)"

--- a/scripts/test_passport_yaml.py
+++ b/scripts/test_passport_yaml.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/_passport_yaml.py` — shared ruamel.yaml round-trip
+configuration extracted from `migrate_literature_corpus_to_v3_7_3.py` and
+`migrate_literature_corpus_to_v3_9_0.py` (#128 v3.9.1 housekeeping §5).
+
+ruamel configuration order matters for round-trip equivalence:
+- preserve_quotes = True must be set BEFORE indent() (verified by ruamel
+  internals; settings are evaluated lazily at dump time but assignment
+  order is reflected in the YAML instance state).
+- indent(mapping=2, sequence=4, offset=2) is the spec-aligned shape used
+  by every passport produced by the bibliography_agent.
+
+If either migration tool's tests regress after this extraction, the
+shared module has drifted from the per-tool configuration that was
+verified across multiple v3.7.3 / v3.9.0 review rounds.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import _passport_yaml as py  # noqa: E402
+
+
+class ConfigurationTest(unittest.TestCase):
+    """Lock the ruamel.yaml configuration that every passport round-trip
+    has assumed since v3.6.4."""
+
+    def test_preserve_quotes_enabled(self) -> None:
+        self.assertTrue(py._yaml.preserve_quotes)
+
+    def test_indent_settings(self) -> None:
+        """ruamel exposes the configured indent via private attributes.
+        We check the visible round-trip behavior (test_round_trip_*),
+        but also pin the constructor inputs for fast failure on drift."""
+        # ruamel's YAML.indent(mapping=..., sequence=..., offset=...) stores
+        # the values on private attributes; the round-trip tests below
+        # are the load-bearing assertion. Here we just verify mapping/seq
+        # indent shape is reflected in actual output (next test class).
+        self.assertIsNotNone(py._yaml)
+
+
+class RoundTripTest(unittest.TestCase):
+    """Verify load → dump preserves the spec-aligned indentation shape."""
+
+    def _round_trip(self, content: str) -> str:
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "passport.yaml"
+            path.write_text(content, encoding="utf-8")
+            doc = py.load_passport(path)
+            out_path = Path(d) / "out.yaml"
+            py.dump_passport(out_path, doc)
+            return out_path.read_text(encoding="utf-8")
+
+    def test_round_trip_preserves_comments(self) -> None:
+        """ruamel's CommentedMap should preserve inline + standalone comments."""
+        content = (
+            "# Header comment\n"
+            "version: 3.9.0\n"
+            "entries:\n"
+            "  - name: foo  # trailing\n"
+            "    year: 2024\n"
+        )
+        out = self._round_trip(content)
+        self.assertIn("# Header comment", out)
+        self.assertIn("# trailing", out)
+
+    def test_round_trip_sequence_indent_is_4(self) -> None:
+        """Per spec convention: sequence indent = 4, offset = 2 → list
+        items align with `- ` two spaces past parent key."""
+        content = "entries:\n  - foo\n  - bar\n"
+        out = self._round_trip(content)
+        # The mapping=2 sequence=4 offset=2 shape preserves the 2-space
+        # offset before the dash.
+        self.assertIn("  - foo", out)
+        self.assertIn("  - bar", out)
+
+    def test_round_trip_preserves_quoted_strings(self) -> None:
+        """preserve_quotes=True keeps single vs double quote choice."""
+        content = "title: 'single'\nname: \"double\"\n"
+        out = self._round_trip(content)
+        self.assertIn("'single'", out)
+        self.assertIn('"double"', out)
+
+
+class APIShapeTest(unittest.TestCase):
+    """The shared module exposes load_passport + dump_passport as the
+    public API. Both migration tools import from this module."""
+
+    def test_load_passport_exists(self) -> None:
+        self.assertTrue(callable(py.load_passport))
+
+    def test_dump_passport_exists(self) -> None:
+        self.assertTrue(callable(py.dump_passport))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_text_similarity.py
+++ b/scripts/test_text_similarity.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/_text_similarity.py` — shared title-similarity helpers
+extracted from `semantic_scholar_client.py` / `openalex_client.py` /
+`crossref_client.py` to prevent sibling drift (#128 v3.9.1 housekeeping).
+
+These tests rebuild the byte-equivalent behavior previously triple-implemented
+in each client. The 3 client modules will import these helpers after the
+extraction lands; their existing tests continue to verify the *integration*
+(client uses similarity correctly) while these tests verify the *behavior*
+(normalization + threshold semantics) of the shared module itself.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import _text_similarity as ts  # noqa: E402
+
+
+class NormalizeTitleTest(unittest.TestCase):
+    """Per protocol §"Query Patterns" Pattern 1: case-insensitive, punctuation
+    stripped (becomes whitespace), whitespace collapsed."""
+
+    def test_lowercases(self) -> None:
+        self.assertEqual(ts._normalize_title("Foo Bar Baz"), "foo bar baz")
+
+    def test_punctuation_becomes_whitespace_then_collapsed(self) -> None:
+        self.assertEqual(ts._normalize_title("Foo,  Bar... Baz!"), "foo bar baz")
+
+    def test_acronym_dots_collapse(self) -> None:
+        self.assertEqual(ts._normalize_title("R.A.G."), "r a g")
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(ts._normalize_title(""), "")
+
+    def test_whitespace_only(self) -> None:
+        self.assertEqual(ts._normalize_title("   \t\n  "), "")
+
+    def test_already_normalized_unchanged(self) -> None:
+        self.assertEqual(ts._normalize_title("attention is all you need"), "attention is all you need")
+
+
+class SimilarityTest(unittest.TestCase):
+    """SequenceMatcher.ratio over normalized titles."""
+
+    def test_acronym_punctuation_clears_threshold(self) -> None:
+        """Codex R4-1 closure (preserved from S2 client tests): 'R.A.G.' vs
+        'RAG' clears 0.70 after normalize."""
+        self.assertGreaterEqual(ts._similarity("R.A.G.", "RAG"), 0.70)
+
+    def test_punctuation_stripped_before_similarity(self) -> None:
+        self.assertGreater(
+            ts._similarity(
+                "Attention Is All You Need: A Transformers Story",
+                "attention is all you need a transformers story",
+            ),
+            0.95,
+        )
+
+    def test_identical_strings_score_one(self) -> None:
+        self.assertEqual(ts._similarity("foo bar", "foo bar"), 1.0)
+
+    def test_completely_different_strings_score_low(self) -> None:
+        self.assertLess(ts._similarity("alpha beta gamma", "xyz qrs uvw"), 0.3)
+
+
+class ConstantsTest(unittest.TestCase):
+    """Lock the magic numbers — these are protocol-level invariants, not
+    arbitrary tuning."""
+
+    def test_title_similarity_threshold_is_protocol_value(self) -> None:
+        """Per PaperOrchestra (Song et al. 2026 Appx D.3) + protocol §Query
+        Patterns Pattern 1."""
+        self.assertEqual(ts._TITLE_SIMILARITY_THRESHOLD, 0.70)
+
+    def test_backoff_seconds(self) -> None:
+        """Per protocol: 429 → 2s backoff × 3 retries."""
+        self.assertEqual(ts._BACKOFF_SECONDS, 2.0)
+
+    def test_max_retries(self) -> None:
+        self.assertEqual(ts._MAX_RETRIES, 3)
+
+    def test_punct_translation_has_all_punctuation(self) -> None:
+        """`_PUNCT_TRANSLATION` should map every string.punctuation char to ' '."""
+        import string
+
+        for c in string.punctuation:
+            self.assertEqual(ts._PUNCT_TRANSLATION[ord(c)], " ", f"char {c!r} not mapped to space")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements 5 of 6 #128 housekeeping items as pure refactors (no behavior change under normal operation, except one latent-bug fix). Item §4 (parallelize OA + CR migration calls) carried to #138 because it introduces a new-behavior + test-rebuild surface incompatible with v3.9.3 patch scope.

**Commits (5):**

1. `4c61bd0` — Extract `scripts/_text_similarity.py` (#128 §1+2): 4 helpers + 4 constants previously triple-byte-equivalent in `semantic_scholar_client.py` / `openalex_client.py` / `crossref_client.py`. 14 new tests on the shared module.
2. `437a251` — Dedup `resolve_openalex_unmatched` / `resolve_crossref_unmatched` bodies (#128 §3): identical control flow extracted to private `_resolve_by_doi_then_title`; both public wrappers preserve spec §3.4 / §3.5 API surface.
3. `9874c7c` — Extract `scripts/_passport_yaml.py` (#128 §5): ruamel.yaml round-trip config + `load_passport` / `dump_passport` previously duplicated in two migration tools (v3.7.3 + v3.9.0). 7 new tests on shared module.
4. `f01f9b1` — Standardize throttle measurement on `time.monotonic` (#128 §6): OA + CR were using `time.time` for elapsed measurement, S2 already used `time.monotonic`. NTP / manual clock adjustments could push `time.time` backward, producing latent throttle-bypass bug. 2 new tests lock monotonic semantics.
5. `36e2089` — Polish per 3-agent /simplify review: drop dead `_PUNCT_TRANSLATION` imports, drop asymmetric `as _dump_passport` alias, tighten `_resolve_by_doi_then_title` docstring, fix half-formed comment fragment in OA `_throttle`, document `_passport_yaml._yaml` single-threaded constraint.

## Test results

- Baseline: 1482 passed + 3 skipped + 111 subtests on `main` (v3.9.2)
- This branch: **1505 passed + 3 skipped + 111 subtests** (+23 new, 0 regression)
- `scripts/check_spec_consistency.py`: passed
- `scripts/check_version_consistency.py`: passed

## Why this matters

The 3 API clients + 2 migration tools were intentionally byte-equivalent at write time (per spec note: \"Mirrors `semantic_scholar_client.py` structure for code locality\"). Now that the family is stable, the dedup prevents sibling drift when a future change to threshold / normalize / throttle would otherwise need to be applied 3-5 times by hand.

## Carry-over

- **#138** opened for #128 §4 (parallelize OA + CR per-entry calls in v3.9.0 migration). Targets v3.9.4 or v3.10 depending on conductor (#134) scope.

## /simplify review

Ran 3-agent parallel review (code-reuse / code-quality / efficiency, all opus). 0 P1 / 0 P2 / 5 P3 adopted + 2 P3 deferred. Polish commit (`36e2089`) addresses adopted P3s.

## Test plan

- [x] pytest full suite green (1505 passed, 0 regression)
- [x] spec + version consistency checks green
- [x] personal-boundary scan: 0 PII / 0 ARS-boundary violations
- [x] /simplify P3 polish applied
- [ ] dual-track codex + Gemini review (pending merge gate)

Refs #128
Carry-over: #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)