### PR TITLE
docs(readme): backfill missing v2.9.1 changelog entry in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,10 @@ Inspired by patterns from [aspi6246/Claude-Code-Skills-for-Academics](https://gi
 - Origin: Discovered through a 4-round dialectic experiment where the DA conceded too quickly, the Socratic Mentor tried to converge prematurely, and the entire debate stayed locked in a frame the human set.
 - Versions: deep-research v2.5, academic-paper-reviewer v1.5, academic-pipeline v2.8
 
+### v2.9.1 (2026-04-03) — Skill Metadata
+- Added `status: active` and `related_skills` cross-references to all 4 SKILL.md frontmatters.
+- Enables skill discovery tools and cross-skill navigation across `deep-research` ↔ `academic-paper` ↔ `academic-paper-reviewer` ↔ `academic-pipeline`.
+
 ### v2.9 (2026-03-27) — Style Calibration + Writing Quality Check
 - **Style Calibration** (academic-paper intake Step 10, optional): Provide 3+ past papers and the pipeline learns your writing voice — sentence rhythm, vocabulary preferences, citation integration style. Applied as a soft guide during drafting; discipline conventions always take priority. Priority system: discipline norms (hard) > journal conventions (strong) > personal style (soft). See `shared/style_calibration_protocol.md`
 - **Writing Quality Check** (`academic-paper/references/writing_quality_check.md`): Writing quality checklist applied during draft self-review. 5 categories: AI high-frequency term warnings (25 terms), punctuation pattern control (em dash ≤3), throat-clearing opener detection, structural pattern warnings (Rule of Three, uniform paragraphs, synonym cycling), and burstiness checks (sentence length variation). These are good writing rules — not detection evasion


### PR DESCRIPTION
## Summary

`README.zh-TW.md` and `CHANGELOG.md` both list the **v2.9.1 (2026-04-03) — Skill Metadata** release, but the embedded changelog in `README.md` skips straight from `v3.0` to `v2.9`. This PR backfills that one entry so the two READMEs stay in sync per the project's stated policy (`CONTRIBUTING.md`: *"Keep READMEs in sync — if your change affects user-facing documentation, update both `README.md` and `README.zh-TW.md`"*).

This finishes the sweep that PR #16 (v3.3.4 "README Changelog Sync Patch") started — that PR backfilled the missing `v3.3.3` / `v3.3.2` summaries but didn't catch this older miss.

## Problem

`CHANGELOG.md` has the canonical v2.9.1 entry:

```markdown
## [2.9.1] - 2026-04-03

### Added
- `status` and `related_skills` metadata to all 4 SKILL.md frontmatters
  - Enables skill discovery tools and cross-skill navigation for users with multiple skills installed
  - `deep-research` ↔ `academic-paper` ↔ `academic-paper-reviewer` ↔ `academic-pipeline`
```

`README.zh-TW.md` (line 547) mirrors it:

```markdown
### v2.9.1 (2026-04-03) — Skill Metadata
- 為 4 個 SKILL.md 加入 `status: active` 和 `related_skills` 交叉引用
- 支援 skill 探索工具及跨技能導航
```

But `README.md` (between line 565 and 567, in the reverse-chronological changelog section) jumps from `### v3.0 (2026-04-03)` directly to `### v2.9 (2026-03-27)` — no v2.9.1.

The only occurrence of `2.9.1` in the EN README today is inside an unrelated v3.5.1 entry mentioning a SKILL version bump (`2.9.0 → 2.9.1`), which a reader could easily mistake for the release entry.

## Solution

Add the missing entry in `README.md` between `v3.0` and `v2.9` so the EN README matches the zh-TW README and CHANGELOG. Wording mirrors the zh-TW entry plus the CHANGELOG `[2.9.1]` body, kept to 2 bullets to match the zh-TW shape.

## Out of scope

- No changes to `CHANGELOG.md` — it already has the entry.
- No changes to `README.zh-TW.md` — it already has the entry.
- Did not touch `scripts/check_spec_consistency.py` to add a v2.9.1 `expect_contains` row. The script's current floor is v3.3.2 (the entries v3.3.4 PR #16 backfilled), and extending it further opens a question about whether the CI floor should walk all the way down — happy to do that in a follow-up PR if you'd like.

## Test plan

- [x] `python3 scripts/check_spec_consistency.py` — passes locally (baseline + after edit).
- [x] No new markdown links introduced, so `check_relative_markdown_links` is unaffected.
- [x] Diff is +3 lines (entry header + 2 bullets), placement preserves reverse-chronological order.
- [ ] CI to confirm the rest.

## Related

- PR #16 / commit 46099ec — `docs: align repo metadata with v3.3.4 release` (prior README changelog sync, same shape of fix).
- `CONTRIBUTING.md` → "PR guidelines" → *Keep READMEs in sync*.

Made with [Cursor](https://cursor.com)