### PR TITLE
fix(v3.9.4.1): hotfix for 4 codex post-ship findings + docs align (#135)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research-skills",
-  "version": "3.9.4",
+  "version": "3.9.4.1",
   "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 38-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.9.2 phase boundary fence (#133).",
   "author": {
     "name": "Cheng-I Wu",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 | `deep-research` v2.9.4 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
 | `academic-paper` v3.1.2 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.9.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.9.4 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.9.4.1 | Full pipeline orchestrator | (coordinates all above) |
 
 ## v3.7.3 Key Additions (in progress)
 
@@ -230,7 +230,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.9.4 (per CHANGELOG.md)
+- **Suite version**: 3.9.4.1 (per CHANGELOG.md)
 - **Last Updated**: 2026-05-18
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.9.4.1] - 2026-05-19 — Post-ship hotfix for v3.9.4 temporal verification
+
+**Trigger:** Codex post-ship review of v3.9.4 squash commit `af09cf5` surfaced 4 real bugs that per-task subagent reviewers missed during v3.9.4 implementation. v3.9.4 tag remains immutable; v3.9.4.1 patches the verifier and schema layer + brings docs in alignment.
+
+**Bug fixes:**
+- **#135 P1 (audit wiring):** `audit()` now passes `citation_provenance` through to `_pass_2_anachronism` and `_pass_4_causal`. When a ref slug has `confidence: low` or `conflict` in citation_provenance.yaml, the verifier emits `TEMPORAL-METADATA-MISSING` instead of using timeline dates as arithmetic ground truth. v3.9.4 dropped citation_provenance on the floor — spec §3.4 first-party safety check was structurally broken.
+- **#135 P1 (date parser):** `_date_to_interval()` now parses all schema-valid date shapes including `YYYY-MM` (Crossref month-precision output) and `YYYY-MM-DD..YYYY-MM-DD` (interval precision used by effective_date_range). v3.9.4 only handled day/year/prose-month forms — schema-valid month/interval shapes raised ValueError and P2/P4 silently skipped the check via the existing `except ValueError: continue` guard.
+- **#135 P2 (P4 direct-date binding):** P4 now binds each side of a causal trigger to either a `<!--ref:slug-->` marker OR a direct date capture in the sentence. v3.9.4 required refs on both sides, silently dropping sentences like "The 2026 policy enabled the 2020 rollout." `bound_dates.source` distinguishes `timeline_ref` from `draft_capture`; `bound_refs` is empty when both sides came from direct date capture.
+- **#135 P2 (schema absent-property bypass):** `citation_provenance.schema.json` `confidence:high` allOf branch now requires both `crossref_issued` and `pdftotext_cover_first_line` to be present in addition to non-null (`then.required` added). v3.9.4 used `then.properties` only, which doesn't fire when a property is absent — so entries with `confidence:high` and both source fields omitted silently passed validation.
+
+**Documentation:**
+- `docs/ARCHITECTURE.md` updated from stale v3.8.0 baseline to v3.9.4.1; Section 8 Evolution Timeline filled in v3.8.1 / v3.8.2 / v3.9.0 / v3.9.1 / v3.9.2 / v3.9.3 / v3.9.4 / v3.9.4.1 entries; Section 9 Skill Modes table aligned to current versions.
+- Suite-version needles aligned across MODE_REGISTRY.md, README.md badge + tag URL + section heading, README.zh-TW.md badge + tag URL + section heading, academic-pipeline/SKILL.md frontmatter, `.claude-plugin/plugin.json`, `scripts/check_spec_consistency.py` expected-text constants, `.claude/CLAUDE.md` skill suite table.
+
+**Test count:** 1549 → **1561** (+12 net new tests covering all 4 fixes, 0 regression).
+
+---
+
 ## [3.9.4] - 2026-05-18 — Temporal Verification Layer (advisory)
 
 **External motivation:** Issue #135 — LLM next-token objectives are systematically blind to deterministic factual classes including temporal ordering. v3.9.4 adds a deterministic advisory verifier at the Phase 4 → 5 boundary covering 5 failure modes.

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.9.4 (2026-05-18)
+Last updated: v3.9.4.1 (2026-05-19)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4)
+[![Version](https://img.shields.io/badge/version-v3.9.4.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.1)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -318,6 +318,10 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.9.4.1 (2026-05-19) — post-ship hotfix for v3.9.4 temporal verification (#135 codex post-ship)
+
+> Codex post-ship review of v3.9.4 caught 4 real bugs that per-task subagent reviewers missed. Hotfix patches all 4: (1) `audit()` now wires `citation_provenance` through to P2 and P4 — when a ref slug has `confidence: low` or `conflict`, the verifier emits `TEMPORAL-METADATA-MISSING` instead of using timeline dates as ground truth (spec §3.4 first-party safety check was broken). (2) `_date_to_interval` parses all schema-valid date shapes including `YYYY-MM` (Crossref month precision) and `YYYY-MM-DD..YYYY-MM-DD` (interval); v3.9.4 silently `ValueError`'d on these and skipped the check. (3) P4 now binds direct date captures when ref markers are absent — sentences like "The 2026 policy enabled the 2020 rollout" actually trigger now. (4) `citation_provenance.schema.json` `confidence:high` allOf now requires presence (`then.required`) in addition to non-null, closing the absent-property bypass. 1561 passed (+12 new tests vs v3.9.4 baseline, 0 regression). ARCHITECTURE.md aligned to current state (was stale at v3.8.0).
 
 ### v3.9.4 (2026-05-18) — #135 temporal verification layer (advisory)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.4-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4)
+[![Version](https://img.shields.io/badge/version-v3.9.4.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.1)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -299,6 +299,10 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.9.4.1（2026-05-19）— v3.9.4 時序驗證 post-ship hotfix（#135 codex post-ship）
+
+> Codex post-ship review 抓到 4 個 per-task subagent reviewer 漏掉的真 bug。Hotfix 一次修齊：(1) `audit()` 把 `citation_provenance` 接到 P2 + P4，遇到 ref slug 在 provenance.yaml 是 `confidence: low` 或 `conflict` 時，驗證器改發 `TEMPORAL-METADATA-MISSING` 而不是直接用 timeline 日期當算術 ground truth（spec §3.4 第一手 safety check 原本沒接線）。(2) `_date_to_interval` 補齊全部 schema-valid 日期形狀，包括 `YYYY-MM`（Crossref 月精度）和 `YYYY-MM-DD..YYYY-MM-DD`（interval），v3.9.4 對這兩種 silently `ValueError` 跳過。(3) P4 在 ref marker 缺席時可 bind 直接 prose 日期 — 「The 2026 policy enabled the 2020 rollout」這種句現在會 trigger。(4) `citation_provenance.schema.json` `confidence:high` allOf 加 `then.required`，補 absent-property bypass 漏洞。1561 passed（+12 新測試、0 regression）。ARCHITECTURE.md 同步補齊（先前停在 v3.8.0）。
 
 ### v3.9.4（2026-05-18）— #135 時序驗證層（advisory）
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,8 +2,8 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.9.4"
-  last_updated: "2026-05-18"
+  version: "3.9.4.1"
+  last_updated: "2026-05-19"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active
   data_access_level: verified_only

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# ARS Pipeline Architecture (v3.8.0)
+# ARS Pipeline Architecture (v3.9.4.1)
 
 Full pipeline view across stages × skills × artifacts × gates. Every completed stage requires a user-confirmation checkpoint (per `academic-pipeline/SKILL.md` and `pipeline_state_machine.md`); the diagrams below surface the **decision-heavy** checkpoints visually so they are easy to locate. The post-stage confirmation checkpoints at 2.5 and 4.5 are machine-verified first, then confirmed by the user — they are not skipped.
 
@@ -327,13 +327,36 @@ timeline
            : 8-row finalizer matrix + 5 new HIGH-WARN classes (formatter REFUSE rules 6-10)
            : Calibration runner (20-tuple gold set, FNR<0.15 + FPR<0.10 acceptance gate)
            : check_claim_audit_consistency.py (38 invariants) + check_v3_8_annotation_literal_sync.py
+    v3.8.1 : claim_audit lint hardening (#119 + #120 4×P2 closures)
+    v3.8.2 : uncited audit_tool_failure surface (#118)
+    v3.9.0 : cross-index triangulation measurement (S2 + OpenAlex + Crossref, 4-tier advisory)
+           : openalex_unmatched + crossref_unmatched contamination signals
+           : 4-tier advisory (CONTAMINATED-COVERAGE-NOISE / PARTIAL-UNMATCH / TRIANGULATION-UNMATCHED)
+    v3.9.1 : client hardening — wrap response-read failures (#129) + manifest_id guard (#130)
+    v3.9.2 : Phase scope inflation hot-fix (#133)
+           : phase-boundary blocks across 22 single-phase agents
+           : intent-clarification gate for ambiguous cross-phase materials
+    v3.9.3 : housekeeping — shared client utilities + dedup resolvers (#128)
+           : sibling-first dual-path import convention
+           : time.monotonic standardization
+    v3.9.4 : temporal verification advisory layer (#135)
+           : M1 timeline_extraction_agent (Phase 2 sibling)
+           : M2 5-pass verifier at Phase 4→5 boundary (P1 arithmetic / P2 anachronism / P3 comparator / P4 causal / P5 deictic)
+           : M3 Temporal Integrity Iron Rule in compiler+writer
+           : M6 first-party Crossref + pdftotext verification
+           : F2 invariant — bibliography_agent.md UNMODIFIED (sha256-guarded)
+    v3.9.4.1 : post-ship hotfix (4 codex findings: P1×2 + P2×2)
+             : audit() wires citation_provenance through to P2/P4 (spec §3.4 promise)
+             : _date_to_interval parses all schema-valid date shapes (YYYY-MM + interval)
+             : P4 binds direct-date captures (not only ref markers)
+             : citation_provenance.schema.json confidence:high requires presence
 ```
 
 ## 9. Skill Modes
 
 | Skill | Modes |
 |---|---|
-| `deep-research` v2.9.2 | full, quick, socratic, review, lit-review, fact-check, systematic-review (7) |
-| `academic-paper` v3.1.1 | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure (10) |
-| `academic-paper-reviewer` v1.9.0 | full, re-review, quick, methodology-focus, guided, calibration (6) |
-| `academic-pipeline` v3.8.0 | orchestrator (delegates to sub-skill modes) + `resume_from_passport=<hash>` (v3.6.3 — resume a prior pipeline run from a Material Passport reset boundary; no flag required to invoke. The producing session must have set `ARS_PASSPORT_RESET=1` to emit boundary entries.) + `ARS_CLAIM_AUDIT=1` (v3.8 — opt-in Stage 4→5 L3 claim-faithfulness audit gate; default OFF) |
+| `deep-research` v2.9.4 | full, quick, socratic, review, lit-review, fact-check, systematic-review (7) |
+| `academic-paper` v3.1.2 | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure (10) |
+| `academic-paper-reviewer` v1.9.1 | full, re-review, quick, methodology-focus, guided, calibration (6) |
+| `academic-pipeline` v3.9.4.1 | orchestrator (delegates to sub-skill modes) + `resume_from_passport=<hash>` (v3.6.3 — resume a prior pipeline run from a Material Passport reset boundary; no flag required to invoke. The producing session must have set `ARS_PASSPORT_RESET=1` to emit boundary entries.) + `ARS_CLAIM_AUDIT=1` (v3.8 — opt-in Stage 4→5 L3 claim-faithfulness audit gate; default OFF) + v3.9.4 temporal verification advisory layer (M1 timeline_extraction_agent + M2 5-pass verifier at Phase 4→5 + M3 IRON RULE + M6 first-party Crossref/pdftotext) |

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.9.4 (2026-05-18)")
+    expect_contains(rel_path, "Last updated: v3.9.4.1 (2026-05-19)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.9.4")
+    expect_contains(rel_path, "**Suite version**: 3.9.4.1")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.4-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.4")
+    expect_contains(rel_path, "version-v3.9.4.1-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.4.1")
+    expect_contains(rel_path, "### v3.9.4.1 (2026-05-19)")
     expect_contains(rel_path, "### v3.9.4 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.1 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.0 (2026-05-17)")
@@ -207,8 +208,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.4-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.4")
+    expect_contains(rel_path, "version-v3.9.4.1-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.4.1")
+    expect_contains(rel_path, "### v3.9.4.1（2026-05-19）")
     expect_contains(rel_path, "### v3.9.4（2026-05-18）")
     expect_contains(rel_path, "### v3.9.1（2026-05-18）")
     expect_contains(rel_path, "### v3.9.0（2026-05-17）")

--- a/scripts/temporal_integrity_audit.py
+++ b/scripts/temporal_integrity_audit.py
@@ -93,19 +93,41 @@ LAST_DAY = {"01": "31", "02": "28", "03": "31", "04": "30", "05": "31", "06": "3
 def _date_to_interval(raw: str) -> tuple[str, str]:
     """Normalize a date capture into (start, end) ISO 8601 day strings.
 
-    Handles 3 forms:
-    - YYYY-MM-DD → (date, date) point interval
-    - 'MonthName YYYY' → first of month .. last of month
-    - YYYY → YYYY-01-01 .. YYYY-12-31
+    Handles all v3.9.4 schema-valid date shapes:
+    - YYYY-MM-DD → (date, date) point interval (day precision)
+    - YYYY-MM → YYYY-MM-01 .. YYYY-MM-last (month precision, v3.9.4.1 hotfix)
+    - YYYY-MM-DD..YYYY-MM-DD → parsed interval (interval precision, v3.9.4.1 hotfix)
+    - 'MonthName YYYY' → first of month .. last of month (prose form)
+    - YYYY → YYYY-01-01 .. YYYY-12-31 (year precision)
+
+    v3.9.4 only handled 3 prose forms — Crossref month-precision lookups from
+    bootstrap_timeline_yaml.py emit `YYYY-MM`, and effective_date_range with
+    precision:interval emits `YYYY-MM-DD..YYYY-MM-DD`. Both were schema-valid
+    but raised ValueError here, causing P2/P4 to silently skip the check.
     """
     raw = raw.strip()
+    # Day precision: YYYY-MM-DD
     if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
         return raw, raw
+    # Interval precision: YYYY-MM-DD..YYYY-MM-DD (v3.9.4.1 hotfix)
+    m_interval = re.fullmatch(r"(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})", raw)
+    if m_interval:
+        return m_interval.group(1), m_interval.group(2)
+    # Month precision: YYYY-MM (v3.9.4.1 hotfix)
+    m_month = re.fullmatch(r"(\d{4})-(\d{2})", raw)
+    if m_month:
+        yr = m_month.group(1)
+        mo = m_month.group(2)
+        if mo not in LAST_DAY:
+            raise ValueError(f"invalid month in date: {raw!r}")
+        return f"{yr}-{mo}-01", f"{yr}-{mo}-{LAST_DAY[mo]}"
+    # Prose form: "MonthName YYYY"
     m = re.fullmatch(r"(" + MONTH_NAMES + r")\s+(\d{4})", raw, re.IGNORECASE)
     if m:
         mo = MONTH_TO_NUM[m.group(1).lower()]
         yr = m.group(2)
         return f"{yr}-{mo}-01", f"{yr}-{mo}-{LAST_DAY[mo]}"
+    # Year precision: YYYY
     if re.fullmatch(r"(?:19|20)\d{2}", raw):
         return f"{raw}-01-01", f"{raw}-12-31"
     raise ValueError(f"unrecognized date format: {raw!r}")

--- a/scripts/temporal_integrity_audit.py
+++ b/scripts/temporal_integrity_audit.py
@@ -166,6 +166,25 @@ def _compute_line_number(draft: str, char_pos: int) -> int:
     return draft[:char_pos].count("\n") + 1
 
 
+def _provenance_confidence(slug: str, citation_provenance: dict) -> str | None:
+    """v3.9.4.1 hotfix: look up citation_provenance.entries[*].confidence for a ref slug.
+
+    Returns the confidence string ('high' | 'medium' | 'low' | 'conflict') or None
+    if the slug has no provenance entry (treated as 'not first-party verified').
+
+    Per spec §3.4: when confidence is 'low' or 'conflict', P2/P4 must NOT use the
+    timeline dates for arithmetic; instead emit TEMPORAL-METADATA-MISSING. v3.9.4
+    audit() never threaded citation_provenance through to P2/P4, defeating this
+    safety check.
+    """
+    if not citation_provenance:
+        return None
+    for entry in citation_provenance.get("entries", []):
+        if entry.get("citation_key") == slug:
+            return entry.get("confidence")
+    return None
+
+
 def _pass_1_arithmetic(draft: str, findings: list[dict]) -> None:
     """P1 Mode 1 future-as-past arithmetic.
 
@@ -253,24 +272,50 @@ def _pass_1_arithmetic(draft: str, findings: list[dict]) -> None:
         })
 
 
-def _pass_2_anachronism(draft: str, timeline: dict, findings: list[dict]) -> None:
+def _pass_2_anachronism(draft: str, timeline: dict, citation_provenance: dict, findings: list[dict]) -> None:
     """P2 Mode 2 version-as-evidence-past anachronism.
 
     For each <!--ref:slug--> marker:
-    1. Lookup slug in timeline sources. Absent → emit TEMPORAL-METADATA-MISSING.
-    2. Lookup effective_date_range. Absent or start unverified/low → emit METADATA-MISSING.
-    3. Find nearest event date in ±200 chars around the ref marker.
-    4. Predicate (future-version): start > event.end → emit TEMPORAL-ANACHRONISTIC-CITATION.
-    5. Predicate (superseded-version): end < event.start (only when end.open_ended: false
+    1. v3.9.4.1 hotfix: Lookup slug in citation_provenance. If confidence is 'low' or
+       'conflict' → emit TEMPORAL-METADATA-MISSING and skip arithmetic (spec §3.4 promise:
+       first-party-unverified dates are NOT used as ground truth).
+    2. Lookup slug in timeline sources. Absent → emit TEMPORAL-METADATA-MISSING.
+    3. Lookup effective_date_range. Absent or start unverified/low → emit METADATA-MISSING.
+    4. Find nearest event date in ±200 chars around the ref marker.
+    5. Predicate (future-version): start > event.end → emit TEMPORAL-ANACHRONISTIC-CITATION.
+    6. Predicate (superseded-version): end < event.start (only when end.open_ended: false
        and end.value known and confidence high/medium) → emit TEMPORAL-ANACHRONISTIC-CITATION.
     """
     sources_by_key = {s["citation_key"]: s for s in timeline.get("sources", [])}
 
     for m_ref in REF_MARKER_PATTERN.finditer(draft):
         slug = m_ref.group(1)
-        source = sources_by_key.get(slug)
         ref_line_no = _compute_line_number(draft, m_ref.start())
 
+        # v3.9.4.1 hotfix: provenance confidence gate (spec §3.4)
+        prov_conf = _provenance_confidence(slug, citation_provenance)
+        if prov_conf in {"low", "conflict"}:
+            findings.append({
+                "finding_id": f"TF-{_next_finding_id(findings):03d}",
+                "finding_kind": "TEMPORAL-METADATA-MISSING",
+                "severity": "LOW",
+                "mode": None,
+                "block_eligible": False,
+                "draft_locator": {
+                    "file": "phase4_composition/draft.md",
+                    "line": ref_line_no,
+                    "sentence": _sentence_around(draft, m_ref.start()),
+                },
+                "matched_span": None,
+                "bound_refs": [{"ref_slug": slug, "timeline_entry": None}],
+                "bound_event": None,
+                "bound_dates": None,
+                "rationale": f"<!--ref:{slug}--> citation_provenance confidence={prov_conf}; per spec §3.4 not used as arithmetic ground truth.",
+                "suggested_fix": None,
+            })
+            continue
+
+        source = sources_by_key.get(slug)
         if source is None:
             findings.append({
                 "finding_id": f"TF-{_next_finding_id(findings):03d}",
@@ -511,15 +556,21 @@ def _pass_3_comparator(draft: str, timeline: dict, findings: list[dict]) -> None
                     # do NOT break — spec allows one finding per match
 
 
-def _pass_4_causal(draft: str, timeline: dict, findings: list[dict]) -> None:
+def _pass_4_causal(draft: str, timeline: dict, citation_provenance: dict, findings: list[dict]) -> None:
     """P4 Mode 4 causal inversion.
 
-    For each causal trigger phrase, identifies the nearest <!--ref:slug--> on either side.
-    Looks up both refs' published_date and verifies the required ordering.
-    If violated, emits TEMPORAL-CAUSAL-INVERSION with bound_dates.left/right.
-    Direct date capture (without refs) deferred to v3.10 M8 relation manifest.
+    For each causal trigger phrase, identifies left and right arguments. Each side
+    may bind to either a <!--ref:slug--> marker (preferred) or a direct date capture
+    in the sentence (v3.9.4.1 hotfix: spec §3.2 P4 fallback).
+
+    v3.9.4.1 also adds citation_provenance gate (spec §3.4): if either bound slug has
+    confidence:low or conflict, emit TEMPORAL-METADATA-MISSING and skip predicate.
+
+    Looks up refs' published_date OR uses direct date capture, then verifies the
+    required ordering. If violated, emits TEMPORAL-CAUSAL-INVERSION.
     """
     sources_by_key = {s["citation_key"]: s for s in timeline.get("sources", [])}
+    date_pattern = re.compile(DATE_REGEX, re.IGNORECASE)
 
     pos = 0
     for sentence in re.split(r"(?<=[.!?])\s+", draft):
@@ -536,26 +587,103 @@ def _pass_4_causal(draft: str, timeline: dict, findings: list[dict]) -> None:
 
             pre = sentence[:m_trig.start()]
             post = sentence[m_trig.end():]
-            left_refs = list(REF_MARKER_PATTERN.finditer(pre))
-            right_refs = list(REF_MARKER_PATTERN.finditer(post))
-            if not left_refs or not right_refs:
-                continue  # ambiguous binding — no finding in v3.9.4
 
-            left_slug = left_refs[-1].group(1)
-            right_slug = right_refs[0].group(1)
-            left_src = sources_by_key.get(left_slug)
-            right_src = sources_by_key.get(right_slug)
-            if not (left_src and right_src):
+            # Bind left: nearest ref BEFORE trigger; else nearest direct date BEFORE
+            left_refs = list(REF_MARKER_PATTERN.finditer(pre))
+            left_slug = left_refs[-1].group(1) if left_refs else None
+            left_date_raw = None
+            if left_slug is None:
+                # v3.9.4.1 fix #3: direct date fallback (spec §3.2 P4)
+                left_dates = list(date_pattern.finditer(pre))
+                if left_dates:
+                    left_date_raw = left_dates[-1].group(0)
+
+            # Bind right: nearest ref AFTER trigger; else nearest direct date AFTER
+            right_refs = list(REF_MARKER_PATTERN.finditer(post))
+            right_slug = right_refs[0].group(1) if right_refs else None
+            right_date_raw = None
+            if right_slug is None:
+                right_dates = list(date_pattern.finditer(post))
+                if right_dates:
+                    right_date_raw = right_dates[0].group(0)
+
+            # At least one side must bind
+            if not (left_slug or left_date_raw) or not (right_slug or right_date_raw):
                 continue
-            left_pd = left_src.get("published_date", {}).get("value")
-            right_pd = right_src.get("published_date", {}).get("value")
-            if not (left_pd and right_pd):
+
+            # v3.9.4.1 hotfix: provenance gate for either slug
+            for chk_slug in [left_slug, right_slug]:
+                if chk_slug is None:
+                    continue
+                prov_conf = _provenance_confidence(chk_slug, citation_provenance)
+                if prov_conf in {"low", "conflict"}:
+                    findings.append({
+                        "finding_id": f"TF-{_next_finding_id(findings):03d}",
+                        "finding_kind": "TEMPORAL-METADATA-MISSING",
+                        "severity": "LOW",
+                        "mode": None,
+                        "block_eligible": False,
+                        "draft_locator": {
+                            "file": "phase4_composition/draft.md", "line": line_no,
+                            "sentence": sentence.strip(),
+                        },
+                        "matched_span": None,
+                        "bound_refs": [{"ref_slug": chk_slug, "timeline_entry": None}],
+                        "bound_event": None,
+                        "bound_dates": None,
+                        "rationale": f"<!--ref:{chk_slug}--> citation_provenance confidence={prov_conf}; per spec §3.4 not used as arithmetic ground truth for P4.",
+                        "suggested_fix": None,
+                    })
+                    # Skip this trigger after emitting METADATA-MISSING for either side
+                    break
+            else:
+                pass  # no provenance issue, continue to predicate
+            # Re-check: if any prov gate fired, the for-else didn't run, we want to skip predicate
+            if any(
+                _provenance_confidence(s, citation_provenance) in {"low", "conflict"}
+                for s in [left_slug, right_slug] if s is not None
+            ):
                 continue
-            try:
-                left_start, _ = _date_to_interval(left_pd)
-                right_start, _ = _date_to_interval(right_pd)
-            except ValueError:
-                continue
+
+            # Resolve left date
+            if left_slug:
+                left_src = sources_by_key.get(left_slug)
+                if not left_src:
+                    continue
+                left_pd = left_src.get("published_date", {}).get("value")
+                if not left_pd:
+                    continue
+                try:
+                    left_start, _ = _date_to_interval(left_pd)
+                except ValueError:
+                    continue
+                left_source = "timeline_ref"
+            else:
+                try:
+                    left_start, _ = _date_to_interval(left_date_raw)
+                except ValueError:
+                    continue
+                left_source = "draft_capture"
+
+            # Resolve right date
+            if right_slug:
+                right_src = sources_by_key.get(right_slug)
+                if not right_src:
+                    continue
+                right_pd = right_src.get("published_date", {}).get("value")
+                if not right_pd:
+                    continue
+                try:
+                    right_start, _ = _date_to_interval(right_pd)
+                except ValueError:
+                    continue
+                right_source = "timeline_ref"
+            else:
+                try:
+                    right_start, _ = _date_to_interval(right_date_raw)
+                except ValueError:
+                    continue
+                right_source = "draft_capture"
 
             violated = (
                 (required_order == "left<right" and left_start >= right_start)
@@ -563,6 +691,13 @@ def _pass_4_causal(draft: str, timeline: dict, findings: list[dict]) -> None:
             )
             if not violated:
                 continue
+
+            # v3.9.4.1 hotfix: bound_refs and bound_dates.source vary by binding mode
+            bound_refs_list = []
+            if left_slug:
+                bound_refs_list.append({"ref_slug": left_slug, "timeline_entry": left_slug})
+            if right_slug:
+                bound_refs_list.append({"ref_slug": right_slug, "timeline_entry": right_slug})
 
             findings.append({
                 "finding_id": f"TF-{_next_finding_id(findings):03d}",
@@ -579,16 +714,13 @@ def _pass_4_causal(draft: str, timeline: dict, findings: list[dict]) -> None:
                     "char_start": m_trig.start(),
                     "char_end": m_trig.end(),
                 },
-                "bound_refs": [
-                    {"ref_slug": left_slug, "timeline_entry": left_slug},
-                    {"ref_slug": right_slug, "timeline_entry": right_slug},
-                ],
+                "bound_refs": bound_refs_list,
                 "bound_event": None,
                 "bound_dates": {
                     "left": {"role": "left_arg", "value": left_start,
-                             "source": "timeline_ref", "ref_slug": left_slug},
+                             "source": left_source, "ref_slug": left_slug},
                     "right": {"role": "right_arg", "value": right_start,
-                              "source": "timeline_ref", "ref_slug": right_slug},
+                              "source": right_source, "ref_slug": right_slug},
                 },
                 "rationale": (
                     f"Trigger '{m_trig.group(0)}' requires ordering {required_order}, "
@@ -633,12 +765,15 @@ def _pass_5_deictic(draft: str, findings: list[dict]) -> None:
 
 def audit(draft: str, timeline: dict, citation_provenance: dict,
           report_reference_date: str, audit_run_id: str) -> dict:
-    """Run the 5-pass verifier. Returns an aggregate matching temporal_audit_results.schema.json."""
+    """Run the 5-pass verifier. Returns an aggregate matching temporal_audit_results.schema.json.
+
+    v3.9.4.1 hotfix: citation_provenance now flows through to P2 and P4 (per spec §3.4).
+    """
     findings: list[dict] = []
     _pass_1_arithmetic(draft, findings)
-    _pass_2_anachronism(draft, timeline, findings)
+    _pass_2_anachronism(draft, timeline, citation_provenance, findings)
     _pass_3_comparator(draft, timeline, findings)
-    _pass_4_causal(draft, timeline, findings)
+    _pass_4_causal(draft, timeline, citation_provenance, findings)
     _pass_5_deictic(draft, findings)
     return {
         "schema_version": "1.0",

--- a/scripts/test_check_v3_9_4_temporal_verification.py
+++ b/scripts/test_check_v3_9_4_temporal_verification.py
@@ -169,6 +169,29 @@ def test_citation_provenance_high_requires_both_sources():
         jsonschema.validate(bad, schema)
 
 
+def test_citation_provenance_high_rejects_absent_sources():
+    """v3.9.4.1 hotfix: confidence:high MUST also reject entries that OMIT crossref_issued
+    and pdftotext_cover_first_line entirely. The v3.9.4 allOf used `then.properties` only,
+    which does not fire when the property is absent — so an entry with confidence:high and
+    no source fields silently passed validation. v3.9.4.1 adds `then.required` to enforce presence."""
+    schema = _load_schema("citation_provenance.schema.json")
+    bad = {
+        "schema_version": "1.0",
+        "audit_run_id": "2026-05-18T12:34:56Z-a1b2",
+        "entries": [
+            {
+                "citation_key": "x",
+                # Both crossref_issued AND pdftotext_cover_first_line absent.
+                "verification_method": "crossref_and_pdftotext",
+                "confidence": "high",
+                "notes": None,
+            }
+        ],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
 @pytest.mark.parametrize("finding_kind,mode,severity,bound_refs,bound_event,bound_dates,matched_span", [
     ("TEMPORAL-ARITHMETIC-IMPOSSIBLE", 1, "HIGH", [], None,
      {"left": {"role": "anchor", "value": "2025-03", "source": "draft_capture", "ref_slug": None},

--- a/scripts/test_temporal_integrity_audit.py
+++ b/scripts/test_temporal_integrity_audit.py
@@ -369,3 +369,70 @@ def test_date_to_interval_rejects_invalid_month():
     """Defensive: YYYY-13 (month > 12) should raise, not produce garbage."""
     with pytest.raises(ValueError):
         _audit_mod._date_to_interval("2024-13")
+
+
+def test_p2_provenance_low_emits_metadata_missing_skips_anachronism(tmp_path):
+    """v3.9.4.1 fix #1: P2 must consult citation_provenance and emit METADATA-MISSING
+    (not ANACHRONISTIC-CITATION) when confidence is low — spec §3.4 first-party safety check."""
+    # Even though timeline says handbook-2026ed is way in the future, citation_provenance
+    # confidence:low must downgrade to METADATA-MISSING instead of anachronism finding.
+    timeline = {
+        "schema_version": "1.0",
+        "sources": [{
+            "citation_key": "handbook-2026ed",
+            "type": "institutional-document",
+            "effective_date_range": {
+                "start": {"value": "2026-09-15", "precision": "day", "open_ended": False,
+                          "provenance": {"method": "crossref_lookup", "confidence": "high"}},
+                "end": {"value": None, "precision": "unknown", "open_ended": True,
+                        "provenance": {"method": "user_override", "confidence": "high"}},
+            },
+        }],
+        "events": [],
+    }
+    citation_provenance = {
+        "schema_version": "1.0",
+        "audit_run_id": "2026-05-19T00:00:00Z-test",
+        "entries": [{
+            "citation_key": "handbook-2026ed",
+            "crossref_issued": None,
+            "pdftotext_cover_first_line": None,
+            "verification_method": "none",
+            "confidence": "low",
+            "notes": None,
+        }],
+    }
+    result = _run_audit(
+        tmp_path,
+        draft="The 2026 Handbook governed the 2022 review cycle.<!--ref:handbook-2026ed-->\n",
+        timeline=timeline,
+        citation_provenance=citation_provenance,
+    )
+    # No anachronism findings (the v3.9.4 silent-bypass bug would have emitted one).
+    anachronism = [f for f in result["findings"] if f["finding_kind"] == "TEMPORAL-ANACHRONISTIC-CITATION"]
+    assert anachronism == [], f"v3.9.4.1 fix #1 broken — anachronism emitted despite confidence:low: {anachronism}"
+    # Exactly one METADATA-MISSING citing the provenance reason.
+    metadata_missing = [f for f in result["findings"]
+                        if f["finding_kind"] == "TEMPORAL-METADATA-MISSING"
+                        and "confidence=low" in f.get("rationale", "")]
+    assert len(metadata_missing) == 1, f"expected 1 METADATA-MISSING with provenance reason; got {result['findings']}"
+
+
+def test_p4_direct_date_causal_inversion_no_refs(tmp_path):
+    """v3.9.4.1 fix #3: P4 must bind to direct date captures when ref markers absent
+    (spec §3.2 P4: each side may bind to ref marker OR direct date capture)."""
+    # No ref markers; both sides are bare dates. "enabled" requires left.date < right.date.
+    # Here left=2026 right=2020 → violation.
+    result = _run_audit(
+        tmp_path,
+        draft="The 2026 policy enabled the 2020 rollout.\n",
+        timeline={"schema_version": "1.0", "sources": [], "events": []},
+    )
+    causal = [f for f in result["findings"] if f["finding_kind"] == "TEMPORAL-CAUSAL-INVERSION"]
+    assert len(causal) == 1, f"expected 1 causal inversion via direct date binding; got {result['findings']}"
+    f0 = causal[0]
+    assert f0["bound_dates"] is not None
+    assert f0["bound_dates"]["left"]["source"] == "draft_capture"
+    assert f0["bound_dates"]["right"]["source"] == "draft_capture"
+    # bound_refs should be empty (no slugs bound).
+    assert f0["bound_refs"] == []

--- a/scripts/test_temporal_integrity_audit.py
+++ b/scripts/test_temporal_integrity_audit.py
@@ -328,3 +328,44 @@ def test_freeze_regression_byte_identical_across_dates(tmp_path):
         )
         assert result.returncode == 0, f"stderr={result.stderr}"
     assert out1.read_bytes() == out2.read_bytes(), "byte-identical regression failed"
+
+
+# v3.9.4.1 hotfix: _date_to_interval coverage for all schema-valid shapes
+import importlib.util
+
+_AUDIT_SPEC = importlib.util.spec_from_file_location(
+    "temporal_integrity_audit", REPO_ROOT / "scripts/temporal_integrity_audit.py"
+)
+_audit_mod = importlib.util.module_from_spec(_AUDIT_SPEC)
+_AUDIT_SPEC.loader.exec_module(_audit_mod)
+
+
+@pytest.mark.parametrize("raw,expected", [
+    # Day precision (already worked in v3.9.4)
+    ("2024-09-15", ("2024-09-15", "2024-09-15")),
+    # Year precision (already worked in v3.9.4)
+    ("2024", ("2024-01-01", "2024-12-31")),
+    # Prose month (already worked in v3.9.4)
+    ("March 2025", ("2025-03-01", "2025-03-31")),
+    # v3.9.4.1 hotfix: month precision YYYY-MM
+    ("2024-09", ("2024-09-01", "2024-09-30")),
+    ("2024-02", ("2024-02-01", "2024-02-28")),
+    ("2024-12", ("2024-12-01", "2024-12-31")),
+    # v3.9.4.1 hotfix: interval precision YYYY-MM-DD..YYYY-MM-DD
+    ("2022-04-01..2022-12-31", ("2022-04-01", "2022-12-31")),
+    ("2020-10-01..2024-09-30", ("2020-10-01", "2024-09-30")),
+])
+def test_date_to_interval_parses_all_schema_valid_shapes(raw, expected):
+    """v3.9.4.1 hotfix: verifier handles all 5 v3.9.4 schema date shapes.
+
+    v3.9.4 only parsed day/year/prose-month — schema-valid month (YYYY-MM)
+    and interval (YYYY-MM-DD..YYYY-MM-DD) shapes raised ValueError, causing
+    P2/P4 to silently skip checks. Real-world Crossref returns month precision;
+    real-world effective_date_range uses interval. This test locks the fix."""
+    assert _audit_mod._date_to_interval(raw) == expected
+
+
+def test_date_to_interval_rejects_invalid_month():
+    """Defensive: YYYY-13 (month > 12) should raise, not produce garbage."""
+    with pytest.raises(ValueError):
+        _audit_mod._date_to_interval("2024-13")

--- a/shared/contracts/passport/citation_provenance.schema.json
+++ b/shared/contracts/passport/citation_provenance.schema.json
@@ -88,12 +88,13 @@
       },
       "allOf": [
         {
-          "description": "confidence:high requires both crossref_issued AND pdftotext_cover_first_line non-null (spec §3.4 agreement table row 1).",
+          "description": "confidence:high requires both crossref_issued AND pdftotext_cover_first_line PRESENT and non-null (spec §3.4 agreement table row 1). v3.9.4.1 hotfix: also require the properties so absent ones don't bypass the non-null check.",
           "if": {
             "properties": { "confidence": { "const": "high" } },
             "required": ["confidence"]
           },
           "then": {
+            "required": ["crossref_issued", "pdftotext_cover_first_line"],
             "properties": {
               "crossref_issued": { "not": { "type": "null" } },
               "pdftotext_cover_first_line": { "not": { "type": "null" } }


### PR DESCRIPTION
## Summary

Post-ship hotfix for v3.9.4 temporal verification. Codex review of v3.9.4 squash commit `af09cf5` surfaced 4 real bugs that per-task subagent reviewers missed during impl. v3.9.4 tag stays immutable; v3.9.4.1 patches the verifier/schema + brings docs to alignment.

## Bug fixes (4 codex findings)

| # | Severity | Issue | Fix commit |
|---|---|---|---|
| 1 | **P1** | `audit()` never passed `citation_provenance` to P2/P4; `low`/`conflict` slugs were silently used as arithmetic ground truth — broke spec §3.4 first-party safety check | `f84aab6` |
| 2 | **P1** | `_date_to_interval` only handled day/year/prose-month; `YYYY-MM` (Crossref month-precision) and `YYYY-MM-DD..YYYY-MM-DD` (interval) silently `ValueError`'d and P2/P4 skipped checks | `e50e443` |
| 3 | P2 | P4 required ref markers on both sides — direct-date sentences like "The 2026 policy enabled the 2020 rollout" silently dropped | `f84aab6` |
| 4 | P2 | `citation_provenance.schema.json` `confidence:high` allOf used `then.properties` only; absent properties bypassed the non-null check | `9a0f3d8` |

## Documentation alignment

- **`docs/ARCHITECTURE.md`** was stale at v3.8.0 (6 minor versions behind). Header bumped to v3.9.4.1; Section 9 Skill Modes table updated (deep-research v2.9.2→v2.9.4 / academic-paper v3.1.1→v3.1.2 / academic-paper-reviewer v1.9.0→v1.9.1 / academic-pipeline v3.8.0→v3.9.4.1); Section 8 Evolution Timeline filled in v3.8.1 / v3.8.2 / v3.9.0-v3.9.4.1.
- Suite version bumped 3.9.4 → 3.9.4.1 across MODE_REGISTRY.md / README.md badge+tag URL+heading / README.zh-TW.md / academic-pipeline/SKILL.md / .claude-plugin/plugin.json / .claude/CLAUDE.md / scripts/check_spec_consistency.py (8 needles).

Historical version markers in agent docs (e.g., \`Phase Boundary (v3.9.4)\` in timeline_extraction_agent.md, \`PATTERN PROTECTION (v3.6.7)\` etc.) are intentionally **NOT** renamed — they're version-locked by design; renaming would break v3.9.4 boundary lint.

## Test results

- **v3.9.4 baseline**: 1549 passed + 3 skipped + 111 subtests
- **v3.9.4.1**: **1561 passed** + 3 skipped + 111 subtests (+12 new tests covering all 4 fixes, 0 regression)

New tests:
- `test_citation_provenance_high_rejects_absent_sources` — fix #4 regression
- `test_date_to_interval_parses_all_schema_valid_shapes` (8 parametrized cases) — fix #2 regression + existing form regression
- `test_date_to_interval_rejects_invalid_month` — fix #2 defensive
- `test_p2_provenance_low_emits_metadata_missing_skips_anachronism` — fix #1 regression
- `test_p4_direct_date_causal_inversion_no_refs` — fix #3 regression

## CI

- pytest: 1561 passed
- spec-consistency lint: exit 0
- v3.9.2/v3.9.4 phase boundary lint: exit 0 (23 Bucket A agents)
- v3.9.4 temporal verification lint: exit 0 over 12 fixtures (unchanged from v3.9.4)

## Out of scope

- v3.10 features (active conductor #134, hard-block policy, OpenAlex triangulation, M4 reviewer dimension, M5 full version discovery, M8 relation manifest)
- Bibliography_agent.md still UNMODIFIED — F2 invariant preserved (sha256 guard unchanged)

## Tag plan

After merge: `git tag -a v3.9.4.1` on the squash commit + push tag. v3.9.4 tag itself unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>