### PR TITLE
fix(v3.9.4.2): harden 4 CI discipline gates from PR #149 codex review

### DIFF
--- a/.github/workflows/harness-retirement-monthly.yml
+++ b/.github/workflows/harness-retirement-monthly.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Open audit tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           MONTH: ${{ steps.month.outputs.label }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-cooldown.yml
+++ b/.github/workflows/release-cooldown.yml
@@ -37,22 +37,33 @@ jobs:
 
           echo "New tag: $NEW_TAG"
 
-          # Find previous tag (by creator date, exclude current)
-          PREV_TAG=$(git tag --sort=-creatordate | grep -v "^${NEW_TAG}$" | head -1 || true)
+          # Find previous release tag (v*, by creator date, exclude current).
+          # Filtering to v* avoids non-release tags (e.g., test, internal markers)
+          # being picked as PREV_TAG and bypassing the cooldown classification.
+          PREV_TAG=$(git tag -l 'v*' --sort=-creatordate | grep -v "^${NEW_TAG}$" | head -1 || true)
           if [ -z "$PREV_TAG" ]; then
-            echo "No previous tag — first release, skip cooldown."
+            echo "No previous release tag — first release, skip cooldown."
             exit 0
           fi
           echo "Previous tag: $PREV_TAG"
 
           # Was the previous tag a hotfix?
-          # Heuristic: tag name has 4 dot-segments (v3.9.4.1) OR pointed commit subject matches hotfix pattern.
-          PREV_SUBJECT=$(git log -1 --format=%s "$PREV_TAG")
+          # Three signals (any one is sufficient):
+          #   a) Tag name has 4 dot-segments (e.g., v3.9.4.1)
+          #   b) Pointed commit subject matches hotfix pattern
+          #   c) Annotated tag subject (if any) matches hotfix pattern
+          # The regex accepts both 'hotfix' and 'hot-fix' spellings.
+          PREV_COMMIT_SUBJECT=$(git log -1 --format=%s "$PREV_TAG")
+          PREV_TAG_SUBJECT=$(git for-each-ref "refs/tags/${PREV_TAG}" --format='%(subject)')
+          HOTFIX_REGEX='(hot-?fix|post-ship|^fix\(v)'
           IS_HOTFIX="false"
           if [[ "$PREV_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             IS_HOTFIX="true"
           fi
-          if echo "$PREV_SUBJECT" | grep -qiE '(hotfix|post-ship|^fix\(v)'; then
+          if echo "$PREV_COMMIT_SUBJECT" | grep -qiE "$HOTFIX_REGEX"; then
+            IS_HOTFIX="true"
+          fi
+          if [ -n "$PREV_TAG_SUBJECT" ] && echo "$PREV_TAG_SUBJECT" | grep -qiE "$HOTFIX_REGEX"; then
             IS_HOTFIX="true"
           fi
           echo "Previous tag classified as hotfix: $IS_HOTFIX"

--- a/.github/workflows/test-count-monotonic.yml
+++ b/.github/workflows/test-count-monotonic.yml
@@ -50,23 +50,7 @@ jobs:
         id: head
         run: |
           set -euo pipefail
-          # Run pytest collection separately so collection errors fail the gate.
-          # Without this, `pytest ... | grep -c` would mask non-zero pytest exits
-          # (e.g., import errors during collection) and let a broken PR pass.
-          set +e
-          pytest --collect-only -q > pytest-collect.txt 2> pytest-collect.err
-          PYTEST_EXIT=$?
-          set -e
-          # Tolerate exit 5 (no tests collected — empty repo edge case);
-          # any other non-zero exit is a real collection failure.
-          if [ "$PYTEST_EXIT" -ne 0 ] && [ "$PYTEST_EXIT" -ne 5 ]; then
-            echo "::error::pytest collection failed on head (exit $PYTEST_EXIT)"
-            cat pytest-collect.err >&2 || true
-            tail -20 pytest-collect.txt >&2 || true
-            exit 1
-          fi
-          # grep -c returns 1 when no matches — tolerate only that case.
-          COUNT=$(grep -c '::' pytest-collect.txt || true)
+          COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
           echo "Head test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
@@ -92,18 +76,7 @@ jobs:
         working-directory: ../base
         run: |
           set -euo pipefail
-          # Same discipline as the head count: collection errors fail the gate.
-          set +e
-          pytest --collect-only -q > pytest-collect.txt 2> pytest-collect.err
-          PYTEST_EXIT=$?
-          set -e
-          if [ "$PYTEST_EXIT" -ne 0 ] && [ "$PYTEST_EXIT" -ne 5 ]; then
-            echo "::error::pytest collection failed on base (exit $PYTEST_EXIT)"
-            cat pytest-collect.err >&2 || true
-            tail -20 pytest-collect.txt >&2 || true
-            exit 1
-          fi
-          COUNT=$(grep -c '::' pytest-collect.txt || true)
+          COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
           echo "Base test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-count-monotonic.yml
+++ b/.github/workflows/test-count-monotonic.yml
@@ -50,7 +50,23 @@ jobs:
         id: head
         run: |
           set -euo pipefail
-          COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
+          # Run pytest collection separately so collection errors fail the gate.
+          # Without this, `pytest ... | grep -c` would mask non-zero pytest exits
+          # (e.g., import errors during collection) and let a broken PR pass.
+          set +e
+          pytest --collect-only -q > pytest-collect.txt 2> pytest-collect.err
+          PYTEST_EXIT=$?
+          set -e
+          # Tolerate exit 5 (no tests collected — empty repo edge case);
+          # any other non-zero exit is a real collection failure.
+          if [ "$PYTEST_EXIT" -ne 0 ] && [ "$PYTEST_EXIT" -ne 5 ]; then
+            echo "::error::pytest collection failed on head (exit $PYTEST_EXIT)"
+            cat pytest-collect.err >&2 || true
+            tail -20 pytest-collect.txt >&2 || true
+            exit 1
+          fi
+          # grep -c returns 1 when no matches — tolerate only that case.
+          COUNT=$(grep -c '::' pytest-collect.txt || true)
           echo "Head test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
@@ -76,7 +92,18 @@ jobs:
         working-directory: ../base
         run: |
           set -euo pipefail
-          COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
+          # Same discipline as the head count: collection errors fail the gate.
+          set +e
+          pytest --collect-only -q > pytest-collect.txt 2> pytest-collect.err
+          PYTEST_EXIT=$?
+          set -e
+          if [ "$PYTEST_EXIT" -ne 0 ] && [ "$PYTEST_EXIT" -ne 5 ]; then
+            echo "::error::pytest collection failed on base (exit $PYTEST_EXIT)"
+            cat pytest-collect.err >&2 || true
+            tail -20 pytest-collect.txt >&2 || true
+            exit 1
+          fi
+          COUNT=$(grep -c '::' pytest-collect.txt || true)
           echo "Base test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Codex post-ship review on PR #149 squash commit `be49a42` surfaced 4 P2 findings where the new CI discipline gates would silently fail to enforce their intent.

This PR ships **3 of 4** (F1 + F2 + F3). **F4 was reverted** — the fix is principled but exposes pre-existing repo-level breakage (#154) that's out of v3.9.4.2 scope.

Closes #152.

## Findings & fixes

| ID | File | Symptom | Fix | Status |
|----|------|---------|-----|--------|
| **F1** | `harness-retirement-monthly.yml:38-41` | Scheduled run lacked repo context → `gh issue create` errored "not a git repository" | Add `GH_REPO: ${{ github.repository }}` env | ✅ Shipped |
| **F2** | `release-cooldown.yml:41` | `git tag --sort=-creatordate` walked all tags; the legacy `academic-research-skills--v3.7.0` plugin tag (still in this repo) could shadow `PREV_TAG` | Filter to `git tag -l 'v*'` | ✅ Shipped |
| **F3** | `release-cooldown.yml:50-55` | Read only pointed commit subject; regex required 4-segment tag for the `hot-fix` spelling. **v3.9.2 (subject: "Phase scope inflation hot-fix") was classified as non-hotfix.** | Also read annotated tag subject via `git for-each-ref`; accept both `hotfix` and `hot-fix` spellings | ✅ Shipped |
| **F4** | `test-count-monotonic.yml:53,79` | `pytest --collect-only \| grep -c '::'` swallowed pytest non-zero exits | Separate pytest exit capture from grep count | ❌ Reverted, tracked as #155 |

## Why F4 was reverted

The F4 fix is correct in principle. But running it surfaced #154: **24 test modules cannot be collected from repo root** because `from scripts._test_helpers import ...` requires `scripts/` to be an importable package, which it is not. spec-consistency.yml only works because it invokes pytest one file at a time (sys.path[0] auto-includes the file's directory).

Hardening F4 without first fixing #154 turns the gate red on every PR. Verified locally + on first CI run (26074181289 exited 2 with "24 errors during collection"). Reverted to keep this PR focused on the safe wins.

## Smoke test (local, against real repo tags) — F2 + F3

```
v3.9.4.1     hotfix=true  | 4-segment + commit + annotated tag all match
v3.9.4       hotfix=false | normal release
v3.9.3       hotfix=false | normal release
v3.9.2       hotfix=true  | NOW caught via 'hot-fix' spelling (old regex missed)
v3.8.0       hotfix=false | normal release
```

`git tag -l 'v*'` correctly excludes the 1 known non-release tag (`academic-research-skills--v3.7.0`).

## Why these matter

The 3 fixes shipped here harden the gates that protect **every subsequent release**:

- **F1** — without it, the monthly harness-retirement audit issue never opens
- **F2 + F3** together — without them, release-cooldown silently passes when it should block (v3.9.2 was already a false negative)

## Follow-ups

- **#154** — make `scripts/` importable so root-level pytest collection works
- **#155** — re-attempt F4 once #154 is fixed
- **#156** — unify CI test manifest between spec-consistency.yml + test-count-monotonic.yml (depends on #154)

## CI status

- ✅ `spec-consistency` pass (1m35s)
- ✅ `count-check` pass (16s, with original swallow-everything behaviour — F4 reverted)
- ✅ `closes-check` pass

## Test plan

- [x] CI green on this branch
- [ ] Merge → tag `v3.9.4.2` → release-cooldown gate now correctly identifies v3.9.4.1 as previous hotfix (smoke test on the gate itself)
- [ ] Verify monthly harness-retirement workflow can fire on dispatch (manual `workflow_dispatch` trigger after merge)
- [ ] Close #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)