### PR TITLE
fix: make root pytest collection import scripts

### DIFF
--- a/.github/workflows/test-count-monotonic.yml
+++ b/.github/workflows/test-count-monotonic.yml
@@ -50,7 +50,7 @@ jobs:
         id: head
         run: |
           set -euo pipefail
-          COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
+          COUNT=$(pytest --collect-only -q | grep -c '::')
           echo "Head test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest bootstrap for repository-root test collection."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+ROOT_STR = str(ROOT)
+
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)


### PR DESCRIPTION
## Summary

Fixes root-level pytest collection for script tests that import shared helpers via `scripts.*`.

## What changed

- Added a root `conftest.py` that prepends the repository root to `sys.path` before pytest imports test modules.
- Updated the PR-head test-count workflow step to stop hiding collection errors with `2>/dev/null` and `|| true`.

## Why `conftest.py`

This keeps `scripts/` as a plain scripts directory and avoids adding package semantics via `scripts/__init__.py`. It also avoids moving `_test_helpers` or refactoring the existing test layout.

## Reproduction

Before this change, running the console-script pytest entry point from the repo root failed during collection:

- `/Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin/pytest --collect-only -q`

Observed failure: 24 collection errors, including `ModuleNotFoundError: No module named 'scripts'` from imports such as `from scripts._test_helpers import run_script`.

## Testing

- `/Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin/pytest --collect-only -q` — `1564 tests collected`
- `/Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin/python -m pytest --collect-only -q` — `1564 tests collected`
- `/Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin/python -m pytest scripts/test_check_collaboration_depth_rubric.py scripts/test_check_compliance_report.py scripts/test_check_data_access_level.py scripts/test_check_passport_reset_contract.py -q` — `57 passed`
- `PATH=/Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin:$PATH /Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin/python -m pytest scripts -q` — `1561 passed, 3 skipped, 111 subtests passed`
- `/Users/sungjh/Projects/Codex/2026-05-19/.venvs/academic-research-skills/bin/python -m py_compile conftest.py`

Note: `python -m pytest scripts -q` without the venv at the front of `PATH` selected the system `python3` for one direct-exec smoke test and failed because that interpreter did not have `pyyaml`. Re-running with the venv first in `PATH` exercised the same direct-exec path with the installed dev dependencies.

Fixes #154

Disclosure: I used Codex for candidate scouting and planning, then manually reviewed the final diff and ran the verification commands locally.
