### PR TITLE
docs(v3.9.4.2): backfill missing CHANGELOG + README + ARCHITECTURE + metadata entries

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research-skills",
-  "version": "3.9.4.1",
+  "version": "3.9.4.2",
   "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 38-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.9.2 phase boundary fence (#133).",
   "author": {
     "name": "Cheng-I Wu",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ A suite of Claude Code skills for rigorous academic research, paper writing, pee
 | `deep-research` v2.9.4 | 13-agent research team | full, quick, socratic, review, lit-review, fact-check, systematic-review |
 | `academic-paper` v3.1.2 | 12-agent paper writing | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure |
 | `academic-paper-reviewer` v1.9.1 | Multi-perspective paper review (5 reviewers + optional cross-model DA critique) | full, re-review, quick, methodology-focus, guided, calibration |
-| `academic-pipeline` v3.9.4.1 | Full pipeline orchestrator | (coordinates all above) |
+| `academic-pipeline` v3.9.4.2 | Full pipeline orchestrator | (coordinates all above) |
 
 ## v3.7.3 Key Additions (in progress)
 
@@ -230,7 +230,7 @@ Materials: Complete paper text. field_analyst_agent auto-detects domain and conf
 Materials: Editorial Decision Letter, Revision Roadmap, Per-reviewer detailed comments
 
 ## Version Info
-- **Suite version**: 3.9.4.1 (per CHANGELOG.md)
-- **Last Updated**: 2026-05-18
+- **Suite version**: 3.9.4.2 (per CHANGELOG.md)
+- **Last Updated**: 2026-05-19
 - **Author**: Cheng-I Wu
 - **License**: CC-BY-NC 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.9.4.2] - 2026-05-19 — Post-ship hotfix for PR #149 CI discipline gates
+
+**Trigger:** Codex post-ship review of PR #149 (7 CI discipline gates mechanizing the release-cycle review chain) surfaced 4 P2 findings. v3.9.4.2 hardens 3 of 4; the 4th (test-count-monotonic harden) was reverted because it surfaced a pre-existing `scripts/` package issue, tracked as #154 (since fixed by PR #158) and re-attempt #155.
+
+**CI gate hardening (PR #149 + #153):**
+- **F1 — harness-retirement scheduler context:** `harness-retirement-monthly.yml` adds `GH_REPO` so scheduled runs have repo context for `gh issue create` (workflow was silently failing on cron without it).
+- **F2 — release-cooldown tag filter:** `release-cooldown.yml` filters `PREV_TAG` lookup to `v*` tags so non-release tags (e.g., legacy plugin tags) cannot bypass the cooldown gate.
+- **F3 — release-cooldown hot-fix detection:** `release-cooldown.yml` also reads annotated tag subject + accepts the `hot-fix` spelling variant; v3.9.2 was previously a false-negative hotfix under the old detector.
+- **F4 (reverted):** `test-count-monotonic.yml` harden landed in 8121dfa and reverted in 4abf9de when it surfaced `scripts/` package import errors (`ModuleNotFoundError: No module named 'scripts'`) — pre-existing latent defect masked by the prior `2>/dev/null | || true` pattern. Tracked as #154 (now closed by PR #158) and re-attempt #155.
+
+**Release-cooldown symmetry follow-up (PR #157):**
+- Override token `[skip-cooldown]` now read from both the commit message AND the annotated tag message. This v3.9.4.2 tag itself is the self-bootstrapping fix — the gate correctly identified v3.9.4.1 (3h prior) as the previous hotfix and fired the 24h cooldown, proving F2+F3 work end-to-end. The override symmetry patch makes the tag shippable.
+
+**Closes:** #152. **Follow-ups:** #154 (closed by PR #158), #155, #156.
+
+---
+
 ## [3.9.4.1] - 2026-05-19 — Post-ship hotfix for v3.9.4 temporal verification
 
 **Trigger:** Codex post-ship review of v3.9.4 squash commit `af09cf5` surfaced 4 real bugs that per-task subagent reviewers missed during v3.9.4 implementation. v3.9.4 tag remains immutable; v3.9.4.1 patches the verifier and schema layer + brings docs in alignment.

--- a/MODE_REGISTRY.md
+++ b/MODE_REGISTRY.md
@@ -4,7 +4,7 @@ Single source of truth for all modes across the ARS suite. **25 modes** across 4
 
 When adding or modifying modes, update this file first — SKILL.md files and CLAUDE.md should reference this registry.
 
-Last updated: v3.9.4.1 (2026-05-19)
+Last updated: v3.9.4.2 (2026-05-19)
 
 ---
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,6 +1,6 @@
 # Claude Code 向け Academic Research Skills
 
-[![Version](https://img.shields.io/badge/version-v3.9.4.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.1)
+[![Version](https://img.shields.io/badge/version-v3.9.4.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -320,6 +320,12 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.9.4.2 (2026-05-19) — PR #149 CI 規律ゲートのポストシップホットフィックス（codex post-ship）
+
+> *[machine-translated, pending native review by @eltociear]*
+>
+> PR #149（7 つの CI 規律ゲート）の Codex post-ship レビューが 4 つの P2 finding を検出。v3.9.4.2 は 4 つのうち 3 つを強化。F1：`harness-retirement-monthly.yml` に `GH_REPO` を追加し、スケジュール実行が `gh issue create` のための repo context を取得できるようにする。F2：`release-cooldown.yml` が `PREV_TAG` ルックアップを `v*` タグにフィルタリングし、非リリースタグ（例：レガシー plugin タグ）がクールダウンゲートをバイパスできないようにする。F3：`release-cooldown.yml` が annotated タグの subject も読み取り、`hot-fix` スペル変種を受け入れる（v3.9.2 は以前の検出器では false-negative hotfix だった）。PR #157 follow-up：`[skip-cooldown]` override が commit message と annotated タグ message の両方から読み取られるようになる（self-bootstrapping fix — 本タグのクールダウンバイパスが F2+F3 がエンドツーエンドで機能することを実証）。F4（test-count-monotonic 強化）は事前存在する `scripts/` パッケージ問題を surface したため revert され、#154（PR #158 で修正済み）+ 再試行 #155 として追跡。Closes #152。Follow-ups：#155、#156。
 
 ### v3.9.4.1 (2026-05-19) — v3.9.4 temporal verification のポストシップホットフィックス（#135 codex post-ship）
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.4.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.1)
+[![Version](https://img.shields.io/badge/version-v3.9.4.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -320,6 +320,10 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## Changelog
+
+### v3.9.4.2 (2026-05-19) — post-ship hotfix for PR #149 CI discipline gates (codex post-ship)
+
+> Codex post-ship review of PR #149 (7 CI discipline gates) surfaced 4 P2 findings; v3.9.4.2 hardens 3 of 4. F1: `harness-retirement-monthly.yml` adds `GH_REPO` so scheduled runs have repo context for `gh issue create`. F2: `release-cooldown.yml` filters `PREV_TAG` lookup to `v*` tags so non-release tags cannot bypass cooldown. F3: `release-cooldown.yml` also reads annotated tag subject + accepts `hot-fix` spelling (v3.9.2 was previously a false-negative hotfix). PR #157 follow-up: `[skip-cooldown]` override now read from both commit message AND annotated tag message (self-bootstrapping fix — this tag's cooldown bypass demonstrates F2+F3 work end-to-end). F4 (test-count-monotonic harden) reverted because it surfaced pre-existing `scripts/` package issue, tracked as #154 (since fixed by PR #158) + re-attempt #155. Closes #152. Follow-ups: #155, #156.
 
 ### v3.9.4.1 (2026-05-19) — post-ship hotfix for v3.9.4 temporal verification (#135 codex post-ship)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Academic Research Skills for Claude Code
 
-[![Version](https://img.shields.io/badge/version-v3.9.4.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.1)
+[![Version](https://img.shields.io/badge/version-v3.9.4.2-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.9.4.2)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 
@@ -301,6 +301,10 @@ https://github.com/Imbad0202/academic-research-skills
 ---
 
 ## 更新紀錄
+
+### v3.9.4.2（2026-05-19）— PR #149 CI 紀律 gate post-ship hotfix（codex post-ship）
+
+> Codex post-ship review 對 PR #149（7 道 CI 紀律 gate）抓到 4 個 P2 finding；v3.9.4.2 修齊其中 3 個。F1：`harness-retirement-monthly.yml` 補 `GH_REPO`，讓排程跑能取到 repo context 給 `gh issue create`。F2：`release-cooldown.yml` 把 `PREV_TAG` 查詢 filter 到 `v*` tag，避免非 release tag（如舊 plugin tag）繞過 cooldown gate。F3：`release-cooldown.yml` 加讀 annotated tag subject + 接受 `hot-fix` 拼寫變體（v3.9.2 在舊偵測器下是 false-negative hotfix）。PR #157 follow-up：`[skip-cooldown]` override 改從 commit message 跟 annotated tag message 雙處讀取（self-bootstrapping fix — 本 tag 的 cooldown 繞過正好證明 F2+F3 端到端可用）。F4（test-count-monotonic 強化）被 revert，因為它 surface 了 `scripts/` package 預存問題，追蹤為 #154（已由 PR #158 修復）+ 再次嘗試 #155。Closes #152。Follow-ups：#155、#156。
 
 ### v3.9.4.1（2026-05-19）— v3.9.4 時序驗證 post-ship hotfix（#135 codex post-ship）
 

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -2,7 +2,7 @@
 name: academic-pipeline
 description: "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow."
 metadata:
-  version: "3.9.4.1"
+  version: "3.9.4.2"
   last_updated: "2026-05-19"
   depends_on: "deep-research, academic-paper, academic-paper-reviewer"
   status: active

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# ARS Pipeline Architecture (v3.9.4.1)
+# ARS Pipeline Architecture (v3.9.4.2)
 
 Full pipeline view across stages × skills × artifacts × gates. Every completed stage requires a user-confirmation checkpoint (per `academic-pipeline/SKILL.md` and `pipeline_state_machine.md`); the diagrams below surface the **decision-heavy** checkpoints visually so they are easy to locate. The post-stage confirmation checkpoints at 2.5 and 4.5 are machine-verified first, then confirmed by the user — they are not skipped.
 
@@ -350,6 +350,12 @@ timeline
              : _date_to_interval parses all schema-valid date shapes (YYYY-MM + interval)
              : P4 binds direct-date captures (not only ref markers)
              : citation_provenance.schema.json confidence:high requires presence
+    v3.9.4.2 : CI discipline hardening (PR #149 + #153 + #157; codex post-ship 3 of 4 P2)
+             : F1 harness-retirement-monthly adds GH_REPO for scheduled runs
+             : F2 release-cooldown filters PREV_TAG lookup to v* tags only
+             : F3 release-cooldown reads annotated tag subject + accepts hot-fix spelling
+             : [skip-cooldown] override now read from both commit message and tag message
+             : F4 test-count-monotonic harden reverted (surfaced #154; re-attempt #155)
 ```
 
 ## 9. Skill Modes
@@ -359,4 +365,4 @@ timeline
 | `deep-research` v2.9.4 | full, quick, socratic, review, lit-review, fact-check, systematic-review (7) |
 | `academic-paper` v3.1.2 | full, plan, outline-only, revision, revision-coach, abstract-only, lit-review, format-convert, citation-check, disclosure (10) |
 | `academic-paper-reviewer` v1.9.1 | full, re-review, quick, methodology-focus, guided, calibration (6) |
-| `academic-pipeline` v3.9.4.1 | orchestrator (delegates to sub-skill modes) + `resume_from_passport=<hash>` (v3.6.3 — resume a prior pipeline run from a Material Passport reset boundary; no flag required to invoke. The producing session must have set `ARS_PASSPORT_RESET=1` to emit boundary entries.) + `ARS_CLAIM_AUDIT=1` (v3.8 — opt-in Stage 4→5 L3 claim-faithfulness audit gate; default OFF) + v3.9.4 temporal verification advisory layer (M1 timeline_extraction_agent + M2 5-pass verifier at Phase 4→5 + M3 IRON RULE + M6 first-party Crossref/pdftotext) |
+| `academic-pipeline` v3.9.4.2 | orchestrator (delegates to sub-skill modes) + `resume_from_passport=<hash>` (v3.6.3 — resume a prior pipeline run from a Material Passport reset boundary; no flag required to invoke. The producing session must have set `ARS_PASSPORT_RESET=1` to emit boundary entries.) + `ARS_CLAIM_AUDIT=1` (v3.8 — opt-in Stage 4→5 L3 claim-faithfulness audit gate; default OFF) + v3.9.4 temporal verification advisory layer (M1 timeline_extraction_agent + M2 5-pass verifier at Phase 4→5 + M3 IRON RULE + M6 first-party Crossref/pdftotext) |

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -61,7 +61,7 @@ def check_relative_markdown_links(rel_path: str) -> None:
 def check_mode_registry() -> None:
     rel_path = "MODE_REGISTRY.md"
     text = read(rel_path)
-    expect_contains(rel_path, "Last updated: v3.9.4.1 (2026-05-19)")
+    expect_contains(rel_path, "Last updated: v3.9.4.2 (2026-05-19)")
     for heading in (
         "## deep-research (7 modes)",
         "## academic-paper (10 modes)",
@@ -75,7 +75,7 @@ def check_claude_md() -> None:
     rel_path = ".claude/CLAUDE.md"
     expect_contains(rel_path, "integrity check (Stage 2.5)")
     expect_contains(rel_path, "final integrity check (Stage 4.5)")
-    expect_contains(rel_path, "**Suite version**: 3.9.4.1")
+    expect_contains(rel_path, "**Suite version**: 3.9.4.2")
     for forbidden in (
         "6th independent reviewer",
         "Peer review gains 6th independent reviewer",
@@ -136,8 +136,9 @@ def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.4.1-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.4.1")
+    expect_contains(rel_path, "version-v3.9.4.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.4.2")
+    expect_contains(rel_path, "### v3.9.4.2 (2026-05-19)")
     expect_contains(rel_path, "### v3.9.4.1 (2026-05-19)")
     expect_contains(rel_path, "### v3.9.4 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.1 (2026-05-18)")
@@ -208,8 +209,9 @@ def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
 
-    expect_contains(rel_path, "version-v3.9.4.1-blue")
-    expect_contains(rel_path, "releases/tag/v3.9.4.1")
+    expect_contains(rel_path, "version-v3.9.4.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.4.2")
+    expect_contains(rel_path, "### v3.9.4.2（2026-05-19）")
     expect_contains(rel_path, "### v3.9.4.1（2026-05-19）")
     expect_contains(rel_path, "### v3.9.4（2026-05-18）")
     expect_contains(rel_path, "### v3.9.1（2026-05-18）")


### PR DESCRIPTION
## Summary

- v3.9.4.2 tag shipped 2026-05-19 (3 commits: PR #149 + #153 + #157) but the release-doc alignment sweep was skipped — CHANGELOG / README badges / README \"What's new\" / package metadata / ARCHITECTURE all stayed on v3.9.4.1.
- This PR backfills all 10 sites where the version pointer needed to advance. No behavior change.
- Dual-track review (codex gpt-5.5 xhigh + gemini-3.5-flash via REST): codex 0 findings, gemini 1 P2 (Last Updated date mismatch — fixed in-PR).

[skip-closes-check] — no single issue maps to a release-doc backfill; this is process hygiene catching up to an already-shipped tag.

## Files touched (10)

| File | Change |
|---|---|
| `CHANGELOG.md` | new `[3.9.4.2]` entry — F1/F2/F3 hardening summary, F4 revert reason, #157 override symmetry |
| `README.md` | badge bump + new \"What's new\" v3.9.4.2 block |
| `README.zh-TW.md` | badge bump + 中文 v3.9.4.2 block |
| `README.ja-JP.md` | badge bump + machine-translated v3.9.4.2 block with `[pending native review by @eltociear]` disclaimer |
| `docs/ARCHITECTURE.md` | title v3.9.4.1 → v3.9.4.2 + evolution timeline sub-entry + Skill Modes table |
| `.claude/CLAUDE.md` | Suite version + academic-pipeline table row + Last Updated |
| `MODE_REGISTRY.md` | \"Last updated\" header |
| `.claude-plugin/plugin.json` | `version` field |
| `academic-pipeline/SKILL.md` | frontmatter `version` |
| `scripts/check_spec_consistency.py` | 5 hardcoded needles bumped, v3.9.4.1 entries kept as history protection |

## Verification

- [x] `python scripts/check_version_consistency.py` — PASS
- [x] `python scripts/check_spec_consistency.py` — PASS
- [x] `pytest scripts/test_check_version_consistency.py` — 8/8 pass
- [x] Personal-boundary lint — 722 files / 0 violations
- [x] Dual-track review applied: codex 0 P1/P2 + gemini 0 P1 / 1 P2 (Last Updated 2026-05-20 → 2026-05-19; fixed)

## Follow-ups (not in this PR scope)

- `check_version_consistency.py` 4-segment semver regex blind spot — `3.9.4.1` and `3.9.4.2` both parse as `3.9.4`, silent drift possible. Worth a separate issue.
- `README.ja-JP.md` outside `check_spec_consistency.py` needle coverage — added in PR #161 but lint not extended. Worth a separate issue.
- `check_spec_consistency.py` is hardcoded needle list — invariants 1-6 in the release-doc alignment rule deserve a schema-driven refactor (each release currently bumps 7+ needles manually).

[doc-aligned: 2026-05-20]

🤖 Generated with [Claude Code](https://claude.com/claude-code)