### PR TITLE
ci: unify pytest invocation manifest (#156)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -36,10 +36,32 @@ jobs:
           cache-dependency-path: requirements-dev.txt
 
       - name: Install lint dependencies
-        run: pip install -r requirements-dev.txt
+        # pytest is installed once here so the unified manifest runner (#156)
+        # and the legacy `python3 -m unittest scripts.test_*` steps share one
+        # pip install. Previously each pytest step did its own `pip install
+        # pytest [pyyaml] [jsonschema]`; consolidating saves ~12 redundant
+        # installs per workflow run.
+        run: pip install -r requirements-dev.txt pytest
 
       - name: Run spec consistency check
         run: python3 scripts/check_spec_consistency.py
+
+      - name: Lint CI pytest manifest (#156)
+        # Drift guard for scripts/_ci_pytest_manifest.toml — verifies entry
+        # path existence, id/(path,args) uniqueness, args shape, and that
+        # spec-consistency.yml contains no direct `pytest scripts/test_*.py`
+        # outside the runner. Runs before the runner so a malformed manifest
+        # fails fast.
+        run: python3 scripts/check_ci_pytest_manifest.py
+
+      - name: Run CI pytest manifest (#156)
+        # Single entry point for the 12 pytest invocations spec-consistency.yml
+        # used to run file-by-file. Each manifest entry is wrapped in a
+        # `::group::<id>` annotation so the GitHub UI collapses one block
+        # per invocation. Manifest at scripts/_ci_pytest_manifest.toml.
+        env:
+          PYTHONPATH: .
+        run: python3 scripts/run_ci_pytest_manifest.py
 
       - name: Check PREPRINT_VENUES list consistency (#105)
         run: python3 scripts/check_preprint_venues_consistency.py
@@ -145,25 +167,11 @@ jobs:
         # and asserts equality. Requires fetch-depth: 0 on the checkout step.
         run: python3 scripts/check_v3_6_8_pattern_protection.py
 
-      - name: Run v3.7.1 SHA gate mutation tests
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest
-          pytest scripts/test_check_v3_6_8_pattern_protection.py -v
-
       - name: Validate v3.7.1 trust-chain frontmatter schema
         # Step 1 of v3.7.1: enforces three firm rules from spec §3.1
         # (verified⇒acquired+method, not-acquired⇒no-real-audit-round, no
         # literal human_read_*) across literature_corpus[] entries.
         run: python3 scripts/check_v3_6_8_frontmatter_trust_schema.py
-
-      - name: Run v3.7.1 trust-chain frontmatter schema tests
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest pyyaml jsonschema
-          pytest scripts/test_check_v3_6_8_frontmatter_trust_schema.py -v
 
       - name: Validate v3.7.1 audit Scope Report block (Step 2 / D2)
         # Step 2 of v3.7.1: enforces spec §3.2 Scope Report contract on the
@@ -172,13 +180,6 @@ jobs:
         # combined-aggregate "PASSED" verb (spec line 152).
         run: python3 scripts/check_v3_6_8_audit_scope_block.py
 
-      - name: Run v3.7.1 audit Scope Report block mutation tests
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest
-          pytest scripts/test_check_v3_6_8_audit_scope_block.py -v
-
       - name: Validate v3.7.1 Cite-Time Provenance Finalizer (Step 3b)
         # Step 3b of v3.7.1: enforces spec §3.3 4-cell matrix + §3.6 peer-file
         # join + idempotency + revision-loop preservation on the
@@ -186,39 +187,16 @@ jobs:
         # academic-pipeline/agents/pipeline_orchestrator_agent.md.
         run: python3 scripts/check_v3_6_8_cite_provenance_pipeline.py
 
-      - name: Run v3.7.1 Cite-Time Provenance Finalizer mutation tests
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest
-          pytest scripts/test_check_v3_6_8_cite_provenance_pipeline.py -v
-
-      - name: Run v3.7.3 Three-Layer Citation lint regression tests
-        # v3.7.3 F18 closure (codex round-7): the v3.7.3 three-layer
-        # citation lint enforces the L3-1 claim-faithfulness locator
-        # contract (per-citation `<!--anchor:<kind>:<value>-->` marker,
-        # hyphen-encoding for quote values, malformed-ref detection,
-        # empty-value rejection, fenced-code-block isolation). Without
-        # this CI step, prompt-vs-lint regressions could ship without
-        # PR checks flagging them. Spec:
-        # docs/design/2026-05-12-ars-v3.7.3-claim-faithfulness-and-contaminated-source-spec.md
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest
-          pytest scripts/test_check_v3_7_3_three_layer_citation.py -v
-
       - name: v3.9.0 cross-index triangulation lint
         # §3.8 rules 5-6 (R3 P2 closure): verifies formatter pass-through
         # allowlist equals the canonical 9-suffix set (exact-token extraction
         # from backtick spans, not substring matching) and that refusal rules
         # 1-10 contain no CONTAMINATED-* tokens (R-L3-2-E invariant).
+        # The pytest companion `test_check_v3_9_0_triangulation.py` runs via
+        # the unified manifest (#156).
         env:
           PYTHONPATH: .
-        run: |
-          pip install pytest
-          python scripts/check_v3_9_0_triangulation.py
-          pytest scripts/test_check_v3_9_0_triangulation.py -v
+        run: python scripts/check_v3_9_0_triangulation.py
 
       - name: Run v3.9.2 Phase Boundary coverage lint (#133)
         # Enforces 22 Bucket A agents have ## Phase Boundary (v3.9.2)
@@ -226,22 +204,12 @@ jobs:
         # contains the four load-bearing phrases (Phase Boundary v3.9.2,
         # MUST NOT, MAY READ, Enforcement v3.9.2). See
         # docs/design/2026-05-18-ars-v3.9.2-agent-phase-classification.md.
+        # The pytest companion `test_check_v3_9_2_phase_boundary.py` and the
+        # #133 pipeline-integrity advisory verifier tests run via the unified
+        # manifest (#156).
         env:
           PYTHONPATH: .
-        run: |
-          pip install pytest
-          python3 scripts/check_v3_9_2_phase_boundary.py
-          pytest scripts/test_check_v3_9_2_phase_boundary.py -v
-
-      - name: Run v3.9.2 pipeline integrity advisory verifier tests (#133)
-        # Tests for scripts/check_pipeline_integrity.py — the post-hoc
-        # advisory verifier that flags #133-pattern Phase 5 outputs
-        # missing independent reviewer attribution.
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest
-          pytest scripts/test_check_pipeline_integrity.py -v
+        run: python3 scripts/check_v3_9_2_phase_boundary.py
 
       - name: Run v3.9.4 temporal verification lint (#135)
         # Verifies check_v3_9_4_temporal_verification.py against all bundled
@@ -315,18 +283,6 @@ jobs:
             scripts.test_claim_audit_calibration \
             -v
 
-      - name: Run v3.7.1 audit_snapshot render-side Section 0 regression tests
-        # PR #78 codex round-5 P2-7: lint enforces the static template
-        # contract, but render_prompt is the runtime path that actually
-        # builds the codex prompt. Without this CI step, render_prompt
-        # could drop Section 0 again silently while the template lint
-        # stays green — exactly the failure mode round-1 P1 closed.
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest
-          pytest scripts/test_audit_snapshot_render_section_0.py -v
-
       - name: Run v3.6.7 Step 6 audit schema + helper tests (Phase 6.2 + 6.4)
         env:
           PYTHONPATH: .
@@ -337,41 +293,8 @@ jobs:
           PYTHONPATH: .
         run: python3 -m unittest scripts.test_v3_6_7_phase_6_6 -v
 
-      - name: Run v3.6.7 Step 6 Phase 6.3 lint script tests (pytest)
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest pyyaml jsonschema
-          pytest scripts/test_check_audit_artifact_consistency.py -v
-
       - name: Validate v3.6.7 Step 8 pattern-eval fixture manifests (Phase 6.8)
         run: python3 scripts/check_pattern_eval_manifest.py
-
-      - name: Run v3.6.7 Step 8 pattern-eval-unit tests (Phase 6.8 micro fixtures)
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest pyyaml jsonschema
-          pytest scripts/test_check_pattern_eval_manifest.py -v
-          # Includes micro/run_id/coverage + inventory-coverage + synthetic per-phase
-          # injection tests (F-301/F-1001 closures). Synthetic supersession lives in
-          # the integration step below.
-          pytest scripts/test_pattern_eval_runtime.py -v -k "micro or run_id or coverage or phase_inventory or fixture_phase or (synthetic and not supersession)"
-
-      - name: Run v3.6.7 Step 8 pattern-eval-integration tests (Phase 6.8 integration fixture)
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest pyyaml jsonschema
-          pytest scripts/test_pattern_eval_runtime.py -v -k "integration or (synthetic and supersession)"
-
-      - name: Run v3.6.7 Phase 6.1 wrapper end-to-end dispatch test (Linux Bash 4+)
-        if: runner.os == 'Linux'
-        env:
-          PYTHONPATH: .
-        run: |
-          pip install pytest pyyaml jsonschema
-          pytest scripts/test_run_codex_audit_e2e.py -v
 
       - name: "Check policy anchor table structural lint (#108)"
         run: python3 scripts/check_policy_anchor_table.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-(empty — next development cycle)
+**CI / infrastructure (no version bump — no behavior change to skills):**
+
+- **#156 — Unified pytest invocation manifest.** Twelve `pytest scripts/test_*.py` invocations in `.github/workflows/spec-consistency.yml` are now declared in `scripts/_ci_pytest_manifest.toml` and run via `scripts/run_ci_pytest_manifest.py`. Drift guard `scripts/check_ci_pytest_manifest.py` rejects (a) missing `path`, (b) duplicate `id`, (c) duplicate `(path, args)`, (d) malformed `args`, (e) any `pytest scripts/test_*.py` re-introduced in the workflow outside the runner. `pip install pytest` consolidates from 12 redundant installs to one. 17 unit tests for runner + lint. `python3 -m unittest scripts.test_*` invocations stay inline (out of scope for #156). 41 disk `test_*.py` files that the manifest does not list remain unclassified — separate follow-up.
 
 ---
 

--- a/scripts/_ci_pytest_manifest.toml
+++ b/scripts/_ci_pytest_manifest.toml
@@ -1,0 +1,83 @@
+# CI pytest invocation manifest (issue #156)
+#
+# Single source of truth for the pytest invocations spec-consistency.yml runs
+# file-by-file. The workflow consumes this via `python scripts/run_ci_pytest_manifest.py`.
+#
+# Drift guard: scripts/check_ci_pytest_manifest.py validates:
+#   - every `path` exists on disk
+#   - `id` values unique
+#   - (path, args) tuples unique (so the manifest stays a single source, not a
+#     parallel list)
+#   - `args` is a list of strings
+#   - spec-consistency.yml has no direct `pytest scripts/test_*.py` outside the runner
+#
+# Out of scope (deliberate):
+#   - whether every `scripts/test_*.py` on disk is listed here (41 currently
+#     unlisted; that's a separate policy decision, see #156 follow-up)
+#   - `python3 -m unittest scripts.test_*` invocations (different runner family;
+#     stays inline in spec-consistency.yml)
+#
+# Adding a new entry:
+#   1. add a [[pytest]] block with a unique `id`, the test file `path`, and
+#      optional `args` (list of strings, passed to pytest verbatim).
+#   2. run `python scripts/check_ci_pytest_manifest.py` to validate.
+#   3. run `python scripts/run_ci_pytest_manifest.py --id <id>` to smoke-test
+#      locally before opening a PR.
+
+[[pytest]]
+id = "v3.7.1-sha-gate"
+path = "scripts/test_check_v3_6_8_pattern_protection.py"
+
+[[pytest]]
+id = "v3.7.1-trust-chain-frontmatter"
+path = "scripts/test_check_v3_6_8_frontmatter_trust_schema.py"
+
+[[pytest]]
+id = "v3.7.1-audit-scope-block"
+path = "scripts/test_check_v3_6_8_audit_scope_block.py"
+
+[[pytest]]
+id = "v3.7.1-cite-time-provenance"
+path = "scripts/test_check_v3_6_8_cite_provenance_pipeline.py"
+
+[[pytest]]
+id = "v3.7.3-three-layer-citation"
+path = "scripts/test_check_v3_7_3_three_layer_citation.py"
+
+[[pytest]]
+id = "v3.9.0-triangulation"
+path = "scripts/test_check_v3_9_0_triangulation.py"
+
+[[pytest]]
+id = "v3.9.2-phase-boundary"
+path = "scripts/test_check_v3_9_2_phase_boundary.py"
+
+[[pytest]]
+id = "v3.9.2-pipeline-integrity"
+path = "scripts/test_check_pipeline_integrity.py"
+
+[[pytest]]
+id = "v3.7.1-audit-snapshot-section-0"
+path = "scripts/test_audit_snapshot_render_section_0.py"
+
+[[pytest]]
+id = "v3.6.7-phase-6.3-lint"
+path = "scripts/test_check_audit_artifact_consistency.py"
+
+[[pytest]]
+id = "v3.6.7-pattern-eval-manifest"
+path = "scripts/test_check_pattern_eval_manifest.py"
+
+[[pytest]]
+id = "v3.6.7-pattern-eval-unit"
+path = "scripts/test_pattern_eval_runtime.py"
+args = ["-k", "micro or run_id or coverage or phase_inventory or fixture_phase or (synthetic and not supersession)"]
+
+[[pytest]]
+id = "v3.6.7-pattern-eval-integration"
+path = "scripts/test_pattern_eval_runtime.py"
+args = ["-k", "integration or (synthetic and supersession)"]
+
+[[pytest]]
+id = "v3.6.7-wrapper-e2e"
+path = "scripts/test_run_codex_audit_e2e.py"

--- a/scripts/check_ci_pytest_manifest.py
+++ b/scripts/check_ci_pytest_manifest.py
@@ -27,7 +27,25 @@ import tomllib
 from pathlib import Path
 
 
-DIRECT_PYTEST_RE = re.compile(r"\bpytest\s+scripts/test_[A-Za-z0-9_]+\.py\b")
+# Drift guard regex: catches direct pytest invocations on `scripts/test_*.py`
+# files outside the manifest runner. Built to tolerate the bypass paths
+# observed in dual-track review (gemini P1 + codex empirical probe):
+#   - intermediate flags: `pytest -v scripts/test_x.py`, `pytest --tb=short ...`
+#   - quoted paths: `pytest "scripts/test_x.py"`, `pytest 'scripts/...'`
+#   - explicit relative prefix: `pytest ./scripts/test_x.py`
+#   - alt invocation: `python -m pytest scripts/...`, `python3 -m pytest scripts/...`,
+#     `py.test scripts/...`, `uv run pytest scripts/...`
+# Line continuations (`pytest \<newline>scripts/...`) are handled by collapsing
+# backslash-newline sequences before scanning (see `_validate_workflow`).
+DIRECT_PYTEST_RE = re.compile(
+    r"\b(?:py\.test|pytest)\b"      # invocation token (pytest or py.test)
+    r"(?:\s+(?:-[^\s]+|--[^\s]+))*"  # zero or more flag args (short -x or long --x=y)
+    r"\s+"                           # whitespace before path
+    r"['\"]?"                        # optional quote
+    r"(?:\./)?"                      # optional ./ prefix
+    r"scripts/test_[A-Za-z0-9_]+\.py"
+    r"['\"]?"                        # optional closing quote
+)
 
 
 def _fail(msg: str, errors: list[str]) -> None:
@@ -50,6 +68,9 @@ def _load_manifest(path: Path, errors: list[str]) -> list[dict] | None:
     return entries
 
 
+ALLOWED_ENTRY_KEYS = {"id", "path", "args"}
+
+
 def _validate_entries(entries: list[dict], root: Path, errors: list[str]) -> None:
     seen_ids: dict[str, int] = {}
     seen_invocations: dict[tuple, int] = {}
@@ -57,6 +78,14 @@ def _validate_entries(entries: list[dict], root: Path, errors: list[str]) -> Non
         if not isinstance(entry, dict):
             _fail(f"entry #{idx}: not a table", errors)
             continue
+        extra_keys = set(entry.keys()) - ALLOWED_ENTRY_KEYS
+        if extra_keys:
+            _fail(
+                f"entry #{idx}: unknown keys {sorted(extra_keys)!r} "
+                f"(allowed: {sorted(ALLOWED_ENTRY_KEYS)!r}). "
+                f"Likely a typo — e.g. `arg` for `args` would silently broaden the test run.",
+                errors,
+            )
         entry_id = entry.get("id")
         entry_path = entry.get("path")
         entry_args = entry.get("args", [])
@@ -117,6 +146,10 @@ def _validate_workflow(workflow_path: Path, errors: list[str]) -> None:
             raw_line = raw_line[:comment_idx]
         stripped_lines.append(raw_line)
     stripped = "\n".join(stripped_lines)
+    # Normalize bash line continuations (`pytest \<newline>scripts/...`) so the
+    # regex sees one logical command per scan. Without this a developer could
+    # split a bypass across two YAML lines and slip past the guard.
+    stripped = stripped.replace("\\\n", " ")
     matches = DIRECT_PYTEST_RE.findall(stripped)
     if matches:
         for m in matches:

--- a/scripts/check_ci_pytest_manifest.py
+++ b/scripts/check_ci_pytest_manifest.py
@@ -1,0 +1,171 @@
+"""Drift guard for the unified pytest invocation manifest (issue #156).
+
+Validates `scripts/_ci_pytest_manifest.toml` and the surrounding workflow:
+
+1. every manifest entry's `path` exists on disk
+2. `id` values are unique across entries
+3. (path, args) tuples are unique across entries (catches accidental duplication
+   that would silently double-run a test or bypass the manifest as a single
+   source of truth; same path with DIFFERENT args is the legitimate -k case)
+4. when present, `args` is a list of strings
+5. `.github/workflows/spec-consistency.yml` contains no direct
+   `pytest scripts/test_*.py` invocation outside the runner (the manifest
+   would otherwise become a parallel list nobody updates)
+
+Out of scope (deliberately, per issue #156):
+- whether every `scripts/test_*.py` on disk is listed in the manifest
+- `python3 -m unittest scripts.test_*` invocations (unittest is a separate
+  runner family; renaming the manifest to `_ci_test_manifest.toml` would
+  require also migrating those, which expands scope)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+DIRECT_PYTEST_RE = re.compile(r"\bpytest\s+scripts/test_[A-Za-z0-9_]+\.py\b")
+
+
+def _fail(msg: str, errors: list[str]) -> None:
+    errors.append(msg)
+
+
+def _load_manifest(path: Path, errors: list[str]) -> list[dict] | None:
+    if not path.exists():
+        _fail(f"manifest not found: {path}", errors)
+        return None
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        _fail(f"manifest parse error: {exc}", errors)
+        return None
+    entries = data.get("pytest", [])
+    if not isinstance(entries, list):
+        _fail("manifest [[pytest]] must be an array of tables", errors)
+        return None
+    return entries
+
+
+def _validate_entries(entries: list[dict], root: Path, errors: list[str]) -> None:
+    seen_ids: dict[str, int] = {}
+    seen_invocations: dict[tuple, int] = {}
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            _fail(f"entry #{idx}: not a table", errors)
+            continue
+        entry_id = entry.get("id")
+        entry_path = entry.get("path")
+        entry_args = entry.get("args", [])
+
+        if not isinstance(entry_id, str) or not entry_id:
+            _fail(f"entry #{idx}: missing/invalid `id`", errors)
+            continue
+        if not isinstance(entry_path, str) or not entry_path:
+            _fail(f"entry id={entry_id!r}: missing/invalid `path`", errors)
+            continue
+        if not isinstance(entry_args, list) or not all(
+            isinstance(a, str) for a in entry_args
+        ):
+            _fail(
+                f"entry id={entry_id!r}: `args` must be a list of strings "
+                f"(got {type(entry_args).__name__})",
+                errors,
+            )
+            continue
+
+        if entry_id in seen_ids:
+            _fail(
+                f"duplicate id {entry_id!r}: appears at entries #{seen_ids[entry_id]} and #{idx}",
+                errors,
+            )
+        else:
+            seen_ids[entry_id] = idx
+
+        invocation_key = (entry_path, tuple(entry_args))
+        if invocation_key in seen_invocations:
+            _fail(
+                f"duplicate invocation: entry #{idx} (id={entry_id!r}) repeats "
+                f"path={entry_path!r} args={entry_args!r} from entry #{seen_invocations[invocation_key]}",
+                errors,
+            )
+        else:
+            seen_invocations[invocation_key] = idx
+
+        resolved = root / entry_path
+        if not resolved.exists():
+            _fail(
+                f"entry id={entry_id!r}: path does not exist on disk: {entry_path}",
+                errors,
+            )
+
+
+def _validate_workflow(workflow_path: Path, errors: list[str]) -> None:
+    if not workflow_path.exists():
+        _fail(f"workflow not found: {workflow_path}", errors)
+        return
+    text = workflow_path.read_text(encoding="utf-8")
+    # Strip YAML comments before scanning so commented-out historical examples
+    # don't trip the drift guard.
+    stripped_lines = []
+    for raw_line in text.splitlines():
+        comment_idx = raw_line.find("#")
+        if comment_idx >= 0:
+            raw_line = raw_line[:comment_idx]
+        stripped_lines.append(raw_line)
+    stripped = "\n".join(stripped_lines)
+    matches = DIRECT_PYTEST_RE.findall(stripped)
+    if matches:
+        for m in matches:
+            _fail(
+                f"direct pytest invocation in {workflow_path.name} (outside runner): {m!r}",
+                errors,
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default="scripts/_ci_pytest_manifest.toml",
+        help="Path to the manifest TOML file (default: scripts/_ci_pytest_manifest.toml)",
+    )
+    parser.add_argument(
+        "--workflow",
+        default=".github/workflows/spec-consistency.yml",
+        help="Path to spec-consistency workflow (default: .github/workflows/spec-consistency.yml)",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repo root for resolving manifest `path` entries (default: cwd)",
+    )
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    manifest_path = Path(args.manifest)
+    workflow_path = Path(args.workflow)
+    root = Path(args.root).resolve()
+
+    entries = _load_manifest(manifest_path, errors)
+    if entries is not None:
+        _validate_entries(entries, root, errors)
+    _validate_workflow(workflow_path, errors)
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        print(f"\nCI pytest manifest lint FAILED ({len(errors)} issue(s)).", file=sys.stderr)
+        return 1
+    print(
+        f"CI pytest manifest lint ok ({len(entries or [])} entries, "
+        f"workflow scanned: {workflow_path.name})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_ci_pytest_manifest.py
+++ b/scripts/run_ci_pytest_manifest.py
@@ -1,0 +1,116 @@
+"""Unified runner for the pytest invocations CI exercises (issue #156).
+
+Reads `scripts/_ci_pytest_manifest.toml` and executes
+`python -m pytest <path> <args...> -v` for each entry. Each invocation is
+wrapped in `::group::<id>` / `::endgroup::` annotations so GitHub Actions
+collapses one log block per entry.
+
+Failure semantics: the runner CONTINUES through every entry instead of
+failing fast on the first non-zero exit, so a single PR sees every test
+suite that broke (not just the first one). The aggregate exit code is
+non-zero if any entry failed. The runner does NOT install pip deps — that
+happens once at the workflow level via
+`pip install -r requirements-dev.txt pytest`.
+
+Local use:
+    python scripts/run_ci_pytest_manifest.py            # run everything
+    python scripts/run_ci_pytest_manifest.py --id <id>  # run one entry
+
+The drift guard at scripts/check_ci_pytest_manifest.py validates the manifest
+shape; this runner trusts the lint and does the minimum schema checks needed
+to fail safely if the manifest is malformed.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+def _load_manifest(path: Path) -> list[dict]:
+    if not path.exists():
+        print(f"ERROR: manifest not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        print(f"ERROR: manifest parse error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    entries = data.get("pytest", [])
+    if not isinstance(entries, list):
+        print("ERROR: manifest [[pytest]] must be an array of tables", file=sys.stderr)
+        sys.exit(1)
+    return entries
+
+
+def _run_entry(entry: dict, root: Path) -> int:
+    entry_id = entry.get("id", "<no-id>")
+    entry_path = entry.get("path", "")
+    entry_args = list(entry.get("args", []))
+
+    cmd = [sys.executable, "-m", "pytest", entry_path, *entry_args, "-v"]
+    print(f"::group::{entry_id}")
+    print(f"# {' '.join(cmd)}")
+    sys.stdout.flush()
+    result = subprocess.run(cmd, cwd=str(root))
+    print("::endgroup::")
+    sys.stdout.flush()
+    return result.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default="scripts/_ci_pytest_manifest.toml",
+        help="Path to the manifest TOML file (default: scripts/_ci_pytest_manifest.toml)",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repo root pytest should run from (default: cwd)",
+    )
+    parser.add_argument(
+        "--id",
+        dest="only_id",
+        default=None,
+        help="Run a single named entry instead of the whole manifest (for local debug)",
+    )
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    root = Path(args.root).resolve()
+
+    entries = _load_manifest(manifest_path)
+
+    if args.only_id is not None:
+        matches = [e for e in entries if e.get("id") == args.only_id]
+        if not matches:
+            print(
+                f"ERROR: --id {args.only_id!r} not found in manifest",
+                file=sys.stderr,
+            )
+            return 1
+        entries = matches
+
+    failed: list[str] = []
+    for entry in entries:
+        rc = _run_entry(entry, root)
+        if rc != 0:
+            failed.append(str(entry.get("id", "<no-id>")))
+
+    if failed:
+        print(
+            f"\nCI pytest manifest run FAILED on {len(failed)} entr(y/ies): "
+            + ", ".join(failed),
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nCI pytest manifest run ok ({len(entries)} entr(y/ies)).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_ci_pytest_manifest.py
+++ b/scripts/test_check_ci_pytest_manifest.py
@@ -1,13 +1,16 @@
 """Unit tests for scripts/check_ci_pytest_manifest.py (issue #156).
 
-Lint guards 5 failure modes on the unified pytest manifest:
+Lint guards 6 failure modes on the unified pytest manifest:
 1. manifest entry path does not exist on disk
 2. duplicate `id` across entries
 3. duplicate exact (path, args) invocation across entries (unless an explicit
    allowlist marker is present)
 4. malformed `args` (not a list, or list elements not strings)
-5. `.github/workflows/spec-consistency.yml` contains a direct
-   `pytest scripts/test_*.py` invocation outside the runner
+5. unknown keys in a manifest entry (catches typos like `arg` for `args`)
+6. `.github/workflows/spec-consistency.yml` contains a direct
+   `pytest scripts/test_*.py` invocation outside the runner — including
+   bypass variants with flags, quotes, `./` prefix, `python -m pytest`,
+   `py.test`, and backslash line continuations
 
 The lint reads the manifest at scripts/_ci_pytest_manifest.toml by default and
 the workflow at .github/workflows/spec-consistency.yml.
@@ -15,6 +18,7 @@ the workflow at .github/workflows/spec-consistency.yml.
 from __future__ import annotations
 
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -32,7 +36,7 @@ def _run(
     extra_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     cmd = [
-        "python3",
+        sys.executable,
         str(SCRIPT),
         "--manifest",
         str(manifest_path),
@@ -269,3 +273,153 @@ def test_missing_workflow_fails(workdir: Path) -> None:
     """)
     result = _run(manifest, workdir / ".github" / "workflows" / "missing.yml", root=workdir)
     assert result.returncode != 0
+
+
+def test_unknown_entry_key_fails(workdir: Path) -> None:
+    """A typo'd key (e.g., `arg` instead of `args`) must NOT silently pass —
+    otherwise the runner would skip the intended -k filter and run the full
+    test set."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    arg = ["-k", "this-should-be-args"]
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "arg" in combined.lower()
+
+
+@pytest.mark.parametrize(
+    "bypass_invocation",
+    [
+        # intermediate flags
+        "          - run: pytest -v scripts/test_real_a.py",
+        "          - run: pytest --tb=short scripts/test_real_a.py",
+        "          - run: pytest -xvs --tb=short scripts/test_real_a.py",
+        # quoted paths
+        '          - run: pytest "scripts/test_real_a.py"',
+        "          - run: pytest 'scripts/test_real_a.py'",
+        # explicit relative prefix
+        "          - run: pytest ./scripts/test_real_a.py",
+        # alternative invocations
+        "          - run: python -m pytest scripts/test_real_a.py",
+        "          - run: python3 -m pytest scripts/test_real_a.py",
+        "          - run: python -m pytest -q scripts/test_real_a.py",
+        "          - run: py.test scripts/test_real_a.py",
+        "          - run: uv run pytest scripts/test_real_a.py",
+        # quoted + flag combo
+        '          - run: pytest -v "scripts/test_real_a.py"',
+    ],
+    ids=[
+        "flag-first-short",
+        "flag-first-long",
+        "multiple-flags",
+        "double-quoted-path",
+        "single-quoted-path",
+        "relative-path-prefix",
+        "python-m-pytest",
+        "python3-m-pytest",
+        "python-m-pytest-with-flag",
+        "py.test-shorthand",
+        "uv-run-pytest",
+        "flag-and-quote-combo",
+    ],
+)
+def test_direct_pytest_bypass_variants_fail(workdir: Path, bypass_invocation: str) -> None:
+    """Drift-guard regex must catch every common bypass pattern: flags
+    between `pytest` and the path, quoted paths, `./` prefix, `python -m
+    pytest`, `py.test`, `uv run pytest`. (Dual-track review: gemini P1.1-P1.2
+    + codex empirical probe.)"""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    workflow_body = (
+        "jobs:\n"
+        "  spec:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: python scripts/run_ci_pytest_manifest.py\n"
+        f"{bypass_invocation}\n"
+    )
+    workflow.write_text(workflow_body, encoding="utf-8")
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0, (
+        f"bypass variant should have failed lint but did not: "
+        f"{bypass_invocation!r}\nstdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    combined = result.stdout + result.stderr
+    assert "test_real_a.py" in combined
+
+
+def test_line_continuation_bypass_fails(workdir: Path) -> None:
+    """Backslash-newline line continuations must be normalized so the regex
+    sees one logical command. (Dual-track review: gemini P1.3.)"""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    workflow.write_text(
+        "jobs:\n"
+        "  spec:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: python scripts/run_ci_pytest_manifest.py\n"
+        "      - run: |\n"
+        "          pytest \\\n"
+        "            scripts/test_real_a.py\n",
+        encoding="utf-8",
+    )
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "test_real_a.py" in combined
+
+
+def test_pytest_path_substring_in_comment_does_not_match(workdir: Path) -> None:
+    """The drift guard strips YAML comments before scanning, so an example
+    inside a `#` comment must NOT trip the lint. This test pins that
+    behavior so the comment-strip can't be regressed accidentally."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    # The drift guard rejects direct `pytest scripts/test_real_a.py` calls
+    # outside the runner — this comment must not trip it.
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/scripts/test_check_ci_pytest_manifest.py
+++ b/scripts/test_check_ci_pytest_manifest.py
@@ -1,0 +1,271 @@
+"""Unit tests for scripts/check_ci_pytest_manifest.py (issue #156).
+
+Lint guards 5 failure modes on the unified pytest manifest:
+1. manifest entry path does not exist on disk
+2. duplicate `id` across entries
+3. duplicate exact (path, args) invocation across entries (unless an explicit
+   allowlist marker is present)
+4. malformed `args` (not a list, or list elements not strings)
+5. `.github/workflows/spec-consistency.yml` contains a direct
+   `pytest scripts/test_*.py` invocation outside the runner
+
+The lint reads the manifest at scripts/_ci_pytest_manifest.toml by default and
+the workflow at .github/workflows/spec-consistency.yml.
+"""
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parent / "check_ci_pytest_manifest.py"
+
+
+def _run(
+    manifest_path: Path,
+    workflow_path: Path,
+    *,
+    root: Path | None = None,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "python3",
+        str(SCRIPT),
+        "--manifest",
+        str(manifest_path),
+        "--workflow",
+        str(workflow_path),
+    ]
+    if root is not None:
+        cmd.extend(["--root", str(root)])
+    if extra_args:
+        cmd.extend(extra_args)
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    # Plant two real test files referenced by happy-path manifest entries.
+    (tmp_path / "scripts" / "test_real_a.py").write_text("def test_a(): assert True\n")
+    (tmp_path / "scripts" / "test_real_b.py").write_text("def test_b(): assert True\n")
+    return tmp_path
+
+
+def test_clean_manifest_passes(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+
+    [[pytest]]
+    id = "real-b"
+    path = "scripts/test_real_b.py"
+    args = ["-k", "fast"]
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    name: Spec Consistency
+    on: [pull_request]
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "ok" in result.stdout.lower() or result.stdout.strip() != ""
+
+
+def test_missing_path_fails(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "ghost"
+    path = "scripts/test_does_not_exist.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "ghost" in combined
+    assert "test_does_not_exist.py" in combined
+
+
+def test_duplicate_id_fails(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_b.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, "jobs: {}\n")
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "duplicate" in combined.lower() and "real-a" in combined
+
+
+def test_duplicate_invocation_fails(workdir: Path) -> None:
+    """Two distinct ids pointing at the same (path, args) is bypass-prone."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a-1"
+    path = "scripts/test_real_a.py"
+
+    [[pytest]]
+    id = "real-a-2"
+    path = "scripts/test_real_a.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, "jobs: {}\n")
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "duplicate" in combined.lower()
+    assert "test_real_a.py" in combined
+
+
+def test_duplicate_invocation_with_distinct_args_passes(workdir: Path) -> None:
+    """Same path with DIFFERENT -k filters is the legitimate use case."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a-unit"
+    path = "scripts/test_real_a.py"
+    args = ["-k", "micro"]
+
+    [[pytest]]
+    id = "real-a-integration"
+    path = "scripts/test_real_a.py"
+    args = ["-k", "integration"]
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_malformed_args_fails(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    args = "this should be a list, not a string"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, "jobs: {}\n")
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "args" in combined.lower()
+
+
+def test_direct_pytest_invocation_in_workflow_fails(workdir: Path) -> None:
+    """Drift guard: spec-consistency.yml must NOT have `pytest scripts/test_*.py` outside runner."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    name: Spec Consistency
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+          - run: pytest scripts/test_real_a.py -v
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "pytest" in combined.lower()
+    assert "scripts/test_real_a.py" in combined
+
+
+def test_unittest_invocations_in_workflow_pass(workdir: Path) -> None:
+    """`python3 -m unittest scripts.test_X` is out of scope for #156 — should NOT trigger drift guard."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    """)
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, """
+    jobs:
+      spec:
+        runs-on: ubuntu-latest
+        steps:
+          - run: python scripts/run_ci_pytest_manifest.py
+          - run: python3 -m unittest scripts.test_real_b -v
+    """)
+
+    result = _run(manifest, workflow, root=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_missing_manifest_fails(workdir: Path) -> None:
+    workflow = workdir / ".github" / "workflows" / "spec-consistency.yml"
+    _write(workflow, "jobs: {}\n")
+    result = _run(workdir / "scripts" / "missing_manifest.toml", workflow, root=workdir)
+    assert result.returncode != 0
+
+
+def test_missing_workflow_fails(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "real-a"
+    path = "scripts/test_real_a.py"
+    """)
+    result = _run(manifest, workdir / ".github" / "workflows" / "missing.yml", root=workdir)
+    assert result.returncode != 0

--- a/scripts/test_run_ci_pytest_manifest.py
+++ b/scripts/test_run_ci_pytest_manifest.py
@@ -1,0 +1,178 @@
+"""Unit tests for scripts/run_ci_pytest_manifest.py (issue #156).
+
+The runner reads scripts/_ci_pytest_manifest.toml and invokes pytest for each
+entry. Behavior contract:
+
+- runs `python -m pytest <path> <args...> -v` per entry
+- wraps each invocation in `::group::<id>` / `::endgroup::` annotations
+- fails on first failing entry (or runs all and reports? — we chose
+  fail-fast: stop on first non-zero exit and propagate)
+- supports `--id <id>` to run a single named entry (local debug)
+- supports `--manifest <path>` and `--root <dir>` overrides for tests
+"""
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parent / "run_ci_pytest_manifest.py"
+
+
+def _run(
+    manifest_path: Path,
+    *,
+    root: Path | None = None,
+    only_id: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = ["python3", str(SCRIPT), "--manifest", str(manifest_path)]
+    if root is not None:
+        cmd.extend(["--root", str(root)])
+    if only_id is not None:
+        cmd.extend(["--id", only_id])
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    (tmp_path / "scripts").mkdir()
+    # Two passing test files, one failing test file.
+    _write(tmp_path / "scripts" / "test_pass_a.py", """
+    def test_alpha(): assert True
+    """)
+    _write(tmp_path / "scripts" / "test_pass_b.py", """
+    def test_beta(): assert 1 + 1 == 2
+    """)
+    _write(tmp_path / "scripts" / "test_fail.py", """
+    def test_should_fail(): assert False, "boom"
+    """)
+    _write(tmp_path / "scripts" / "test_marked.py", """
+    def test_unit_one(): assert True
+    def test_unit_two(): assert True
+    def test_integration_alpha(): assert True
+    """)
+    return tmp_path
+
+
+def test_runs_all_passing_entries(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "pass-a"
+    path = "scripts/test_pass_a.py"
+
+    [[pytest]]
+    id = "pass-b"
+    path = "scripts/test_pass_b.py"
+    """)
+
+    result = _run(manifest, root=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "::group::pass-a" in combined
+    assert "::endgroup::" in combined
+    assert "::group::pass-b" in combined
+
+
+def test_fails_when_any_entry_fails(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "pass-a"
+    path = "scripts/test_pass_a.py"
+
+    [[pytest]]
+    id = "fail"
+    path = "scripts/test_fail.py"
+
+    [[pytest]]
+    id = "pass-b"
+    path = "scripts/test_pass_b.py"
+    """)
+
+    result = _run(manifest, root=workdir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "::group::fail" in combined
+
+
+def test_args_passed_through_to_pytest(workdir: Path) -> None:
+    """Args like `-k <expr>` must reach pytest verbatim."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "unit-only"
+    path = "scripts/test_marked.py"
+    args = ["-k", "unit"]
+    """)
+
+    result = _run(manifest, root=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    # Two `test_unit_*` ran, the `test_integration_alpha` was excluded by -k.
+    assert "test_unit_one" in combined
+    assert "test_unit_two" in combined
+    assert "test_integration_alpha" not in combined
+
+
+def test_id_filter_runs_only_named_entry(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "pass-a"
+    path = "scripts/test_pass_a.py"
+
+    [[pytest]]
+    id = "fail"
+    path = "scripts/test_fail.py"
+    """)
+
+    # Explicitly run only pass-a — even though the manifest contains a failing
+    # entry, --id filter should isolate the run.
+    result = _run(manifest, root=workdir, only_id="pass-a")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "::group::pass-a" in combined
+    # The fail entry should NOT have been invoked.
+    assert "::group::fail" not in combined
+
+
+def test_unknown_id_filter_fails(workdir: Path) -> None:
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    _write(manifest, """
+    [[pytest]]
+    id = "pass-a"
+    path = "scripts/test_pass_a.py"
+    """)
+
+    result = _run(manifest, root=workdir, only_id="nope")
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "nope" in combined
+
+
+def test_missing_manifest_fails(workdir: Path) -> None:
+    result = _run(workdir / "scripts" / "missing.toml", root=workdir)
+    assert result.returncode != 0
+
+
+def test_empty_manifest_passes(workdir: Path) -> None:
+    """A manifest with zero entries should exit 0 (degenerate but not an error)."""
+    manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
+    manifest.write_text("# empty manifest\n", encoding="utf-8")
+
+    result = _run(manifest, root=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/scripts/test_run_ci_pytest_manifest.py
+++ b/scripts/test_run_ci_pytest_manifest.py
@@ -5,14 +5,15 @@ entry. Behavior contract:
 
 - runs `python -m pytest <path> <args...> -v` per entry
 - wraps each invocation in `::group::<id>` / `::endgroup::` annotations
-- fails on first failing entry (or runs all and reports? — we chose
-  fail-fast: stop on first non-zero exit and propagate)
+- runs ALL entries even when some fail (accumulate-failures, not fail-fast)
+  so CI surfaces every broken suite in one PR
 - supports `--id <id>` to run a single named entry (local debug)
 - supports `--manifest <path>` and `--root <dir>` overrides for tests
 """
 from __future__ import annotations
 
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -28,7 +29,7 @@ def _run(
     root: Path | None = None,
     only_id: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    cmd = ["python3", str(SCRIPT), "--manifest", str(manifest_path)]
+    cmd = [sys.executable, str(SCRIPT), "--manifest", str(manifest_path)]
     if root is not None:
         cmd.extend(["--root", str(root)])
     if only_id is not None:
@@ -83,6 +84,8 @@ def test_runs_all_passing_entries(workdir: Path) -> None:
 
 
 def test_fails_when_any_entry_fails(workdir: Path) -> None:
+    """Runner accumulates failures: every entry runs even if an earlier one
+    failed, then the aggregate exit code reports the failure."""
     manifest = workdir / "scripts" / "_ci_pytest_manifest.toml"
     _write(manifest, """
     [[pytest]]
@@ -102,7 +105,12 @@ def test_fails_when_any_entry_fails(workdir: Path) -> None:
 
     assert result.returncode != 0
     combined = result.stdout + result.stderr
+    assert "::group::pass-a" in combined
     assert "::group::fail" in combined
+    # The runner must NOT stop at the first failure. `pass-b` runs after
+    # `fail` in the manifest; this assertion pins the accumulate-failures
+    # contract so a future refactor to fail-fast would fail this test.
+    assert "::group::pass-b" in combined
 
 
 def test_args_passed_through_to_pytest(workdir: Path) -> None:


### PR DESCRIPTION
## Summary

Twelve `pytest scripts/test_*.py` invocations in `spec-consistency.yml` are replaced by a single declarative manifest at `scripts/_ci_pytest_manifest.toml`. A workflow step `python scripts/run_ci_pytest_manifest.py` consumes the manifest; a drift guard `scripts/check_ci_pytest_manifest.py` runs first to reject malformed manifests + bypass attempts before the runner executes.

**No behavior change to which tests CI runs.** The 14 manifest entries reproduce the exact 12 unique pytest invocations + 2 `-k` filter splits the workflow previously made.

Closes #156.

## What changed

| File | Change |
|---|---|
| `scripts/_ci_pytest_manifest.toml` | new — 14 TOML `[[pytest]]` entries (`id` + `path` + optional `args`) |
| `scripts/check_ci_pytest_manifest.py` | new — drift guard (6 fail modes after review) |
| `scripts/run_ci_pytest_manifest.py` | new — Python runner with `::group::<id>` annotations |
| `scripts/test_check_ci_pytest_manifest.py` | new — 25 unit tests (10 base + 12 parametrized bypass + 3 other) |
| `scripts/test_run_ci_pytest_manifest.py` | new — 7 unit tests |
| `.github/workflows/spec-consistency.yml` | 14 pytest steps removed → 2 new steps (lint + runner); workflow 396 → 319 lines; pip install consolidated 12 → 1 |
| `CHANGELOG.md` | `[Unreleased]` entry (no version bump) |

## Drift guard (6 fail modes after dual-track review hardening)

1. manifest entry's `path` does not exist on disk
2. duplicate `id`
3. duplicate `(path, args)` tuple (same path with DIFFERENT args is the legitimate -k case)
4. `args` not a list of strings
5. unknown keys on a manifest entry (catches typos like `arg` for `args`)
6. `.github/workflows/spec-consistency.yml` contains a direct pytest invocation on a `scripts/test_*.py` file outside the runner — including bypass variants with intermediate flags, quoted paths, `./` prefix, `python -m pytest`, `py.test`, `uv run pytest`, and backslash line continuations

## Out of scope (explicit)

- `python3 -m unittest scripts.test_*` invocations stay inline in spec-consistency.yml. Different runner family; renaming to `_ci_test_manifest` would balloon scope. Drift guard tolerates them.
- 41 disk `scripts/test_*.py` files NOT listed in the manifest. Whether they belong in CI is a separate policy decision — follow-up issue.
- `test-count-monotonic.yml` is independent of the manifest. It counts ALL collected tests via root-level pytest, and consuming the manifest would weaken that gate. The asymmetric head/base strictness there is tracked separately as #155.

## Dual-track review

| Source | P1 | P2 | P3 | Recommendation |
|---|---|---|---|---|
| Codex (gpt-5.5 xhigh) | 0 | 0 | 0 | (implicit) SHIP |
| Gemini (3.5-flash REST) | 4 | 3 | 2 | FIX-P1-FIRST |

Findings applied (5):

- **P1.1-P1.3 (gemini, codex empirical)**: drift-guard regex was too strict — bypass paths included `pytest -v <path>`, quoted paths, `./` prefix, `python -m pytest`, `py.test`, `uv run pytest`, and bash line continuations. Loosened regex + backslash-newline normalization + 12 parametrized bypass-variant test cases.
- **P1.4 (gemini)**: typo'd manifest key (e.g. `arg` instead of `args`) was silently ignored — would skip the intended `-k` filter and run the full test set. Added `ALLOWED_ENTRY_KEYS` allowlist + explicit unit test.
- **P2.2 (gemini)**: test file docstring claimed "fail-fast" but runner accumulates failures. Docstring corrected.
- **P2.3 (gemini)**: `test_fails_when_any_entry_fails` did not assert that subsequent entries run after a failure. Added pin so a refactor to fail-fast would fail the test.
- **P3.1 (gemini)**: hardcoded `python3` in test subprocess invocations. Replaced with `sys.executable` for cross-platform portability.

Findings rejected with reason (2):

- **P2.1 (gemini)**: "lost `if: runner.os == 'Linux'` guard" — verified non-issue. The e2e test file has `pytestmark = pytest.mark.skipif(...)` at module scope, so it self-skips on non-Linux. The removed YAML-level `if:` was redundant. Local smoke run confirmed 3 skipped tests on macOS.
- **P3.2 (gemini)**: "data not dict defensive check" — verified non-issue. TOML spec guarantees `tomllib.loads()` returns a dict at the top level; the AttributeError path can never fire.

## Verification

- [x] 32 unit tests pass (25 lint + 7 runner; includes 12 parametrized bypass variants)
- [x] `python3 scripts/check_ci_pytest_manifest.py` — ok (14 entries)
- [x] `python3 scripts/check_version_consistency.py` — pass
- [x] `python3 scripts/check_spec_consistency.py` — pass
- [x] `python3 scripts/run_ci_pytest_manifest.py` — runs all 14 entries end-to-end ok locally
- [x] Personal-boundary scan — 726 files / 0 violations

## Design

Design rationale documented in commit message body. Codex consulted before design lock (1 round + 1 follow-up round); recommendations folded in (TOML over YAML, Python runner over bash, single workflow step over 14 one-liners, accumulate-failures over fail-fast, manifest pytest-only with explicit naming, 41 disk-only files punted to follow-up).

[skip-closes-check] — closes #156 (auto-detect handles this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)