### PR TITLE
ci: harden test-count-monotonic to fail on pytest collection errors (#155)

### DIFF
--- a/.github/workflows/test-count-monotonic.yml
+++ b/.github/workflows/test-count-monotonic.yml
@@ -50,7 +50,26 @@ jobs:
         id: head
         run: |
           set -euo pipefail
-          COUNT=$(pytest --collect-only -q | grep -c '::')
+          # Capture pytest exit code separately from grep so a collection
+          # error (broken import, missing fixture file, etc.) fails the gate
+          # instead of being swallowed by the pipe (#155 / re-attempt of F4
+          # from the v3.9.4.2 cycle, originally in PR #153 commit 8121dfa
+          # before being reverted in 4abf9de while #154 was still open).
+          set +e
+          pytest --collect-only -q > pytest-collect.txt 2> pytest-collect.err
+          PYTEST_EXIT=$?
+          set -e
+          # Exit 5 = pytest "no tests collected"; tolerable for degenerate
+          # cases (empty repo, path filter that matches nothing). Any other
+          # non-zero exit is a real collection failure and must fail the gate.
+          if [ "$PYTEST_EXIT" -ne 0 ] && [ "$PYTEST_EXIT" -ne 5 ]; then
+            echo "::error::pytest collection failed on PR head (exit $PYTEST_EXIT)"
+            cat pytest-collect.err >&2 || true
+            tail -20 pytest-collect.txt >&2 || true
+            exit 1
+          fi
+          # grep -c exits 1 when there are zero matches — tolerate only that.
+          COUNT=$(grep -c '::' pytest-collect.txt || true)
           echo "Head test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
@@ -76,7 +95,22 @@ jobs:
         working-directory: ../base
         run: |
           set -euo pipefail
-          COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
+          # Symmetric strict collection — mirrors the PR-head step above.
+          # The previous `2>/dev/null | grep -c '::' || true` pattern would
+          # set BASE_COUNT to 0 on any collection error, making the
+          # monotonic comparison (head >= base) vacuously pass and hiding
+          # genuine drift. Fail the gate on real collection errors instead.
+          set +e
+          pytest --collect-only -q > pytest-collect.txt 2> pytest-collect.err
+          PYTEST_EXIT=$?
+          set -e
+          if [ "$PYTEST_EXIT" -ne 0 ] && [ "$PYTEST_EXIT" -ne 5 ]; then
+            echo "::error::pytest collection failed on base (exit $PYTEST_EXIT)"
+            cat pytest-collect.err >&2 || true
+            tail -20 pytest-collect.txt >&2 || true
+            exit 1
+          fi
+          COUNT=$(grep -c '::' pytest-collect.txt || true)
           echo "Base test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-count-monotonic.yml
+++ b/.github/workflows/test-count-monotonic.yml
@@ -68,10 +68,20 @@ jobs:
             tail -20 pytest-collect.txt >&2 || true
             exit 1
           fi
-          # grep -c exits 1 when there are zero matches — tolerate only that.
-          COUNT=$(grep -c '::' pytest-collect.txt || true)
+          # grep -c exits 1 when there are zero matches — tolerate ONLY that;
+          # any other non-zero exit from grep is a real error (unreadable
+          # file, missing binary) and must propagate.
+          set +e
+          COUNT=$(grep -c '::' pytest-collect.txt)
+          GREP_EXIT=$?
+          set -e
+          if [ "$GREP_EXIT" -ne 0 ] && [ "$GREP_EXIT" -ne 1 ]; then
+            echo "::error::grep failed unexpectedly (exit $GREP_EXIT)"
+            exit 1
+          fi
           echo "Head test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          rm -f pytest-collect.txt pytest-collect.err
 
       - name: Add base via worktree
         env:
@@ -110,9 +120,17 @@ jobs:
             tail -20 pytest-collect.txt >&2 || true
             exit 1
           fi
-          COUNT=$(grep -c '::' pytest-collect.txt || true)
+          set +e
+          COUNT=$(grep -c '::' pytest-collect.txt)
+          GREP_EXIT=$?
+          set -e
+          if [ "$GREP_EXIT" -ne 0 ] && [ "$GREP_EXIT" -ne 1 ]; then
+            echo "::error::grep failed unexpectedly (exit $GREP_EXIT)"
+            exit 1
+          fi
           echo "Base test count: $COUNT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          rm -f pytest-collect.txt pytest-collect.err
 
       - name: Compare
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **#156 — Unified pytest invocation manifest.** Twelve `pytest scripts/test_*.py` invocations in `.github/workflows/spec-consistency.yml` are now declared in `scripts/_ci_pytest_manifest.toml` and run via `scripts/run_ci_pytest_manifest.py`. Drift guard `scripts/check_ci_pytest_manifest.py` rejects (a) missing `path`, (b) duplicate `id`, (c) duplicate `(path, args)`, (d) malformed `args`, (e) any `pytest scripts/test_*.py` re-introduced in the workflow outside the runner. `pip install pytest` consolidates from 12 redundant installs to one. 17 unit tests for runner + lint. `python3 -m unittest scripts.test_*` invocations stay inline (out of scope for #156). 41 disk `test_*.py` files that the manifest does not list remain unclassified — separate follow-up.
 
+- **#155 — Re-attempt F4: harden `test-count-monotonic.yml` to fail on pytest collection errors.** Both head and base count steps now capture pytest's exit code separately from the pipe, treat exit 5 (no tests collected) as a tolerable degenerate case, and fail the gate on any other non-zero exit. Previously, a `2>/dev/null | grep -c '::' || true` swallow on the base step would silently set BASE_COUNT to 0 on a broken-import or fixture-missing error in the base commit, making the head-vs-base monotonic check vacuously pass. The original F4 fix landed in PR #153 commit 8121dfa during the v3.9.4.2 cycle but was reverted in 4abf9de when it surfaced #154 (now closed by PR #158). With #154 fixed and #156 keeping CI test discovery clean, F4 v2 ships symmetrically across head and base.
+
 ---
 
 ## [3.9.4.2] - 2026-05-19 — Post-ship hotfix for PR #149 CI discipline gates


### PR DESCRIPTION
## Summary

Re-attempts F4 from the v3.9.4.2 post-ship review cycle. The original F4 landed in PR #153 commit 8121dfa, was reverted in 4abf9de because it surfaced #154, and was kept for follow-up here once #154 closed (PR #158).

Closes #155.

## What changed

| File | Change |
|---|---|
| `.github/workflows/test-count-monotonic.yml` | Both `Count tests on PR head` and `Count tests on base` steps capture pytest's exit code separately from grep, tolerate exit 5 (no tests collected), and fail on any other non-zero exit. After dual-track review: also capture grep's exit code separately (tolerate only exit 1 = no matches) and clean up temp files on success. |
| `CHANGELOG.md` | `[Unreleased]` entry |

## The bug this closes

Previously the base count step ran:

```bash
COUNT=$(pytest --collect-only -q 2>/dev/null | grep -c '::' || true)
```

`2>/dev/null` hid pytest's stderr, the pipe masked pytest's exit code from `set -euo pipefail`, and `|| true` swallowed everything else. On a broken-import or missing-fixture error in the base commit, BASE_COUNT silently became 0 and the head >= base monotonic check vacuously passed — hiding the very drift this gate exists to protect against.

## The fix

Both head and base now:

1. capture pytest's exit code separately from grep (no pipe, no pipefail loss)
2. tolerate pytest exit 5 (pytest "no tests collected") as a degenerate legitimate case
3. capture grep's exit code separately and tolerate ONLY exit 1 (no matches); other non-zero from grep is a real error
4. fail on any other non-zero exit with a `::error::` annotation showing stderr + last 20 lines of stdout for diagnosis
5. clean up `pytest-collect.txt` / `pytest-collect.err` on success paths

[skip-closes-check] — closes #155 (auto-detect handles this).

## Dual-track review

| Source | P1 | P2 | P3 | Recommendation |
|---|---|---|---|---|
| Codex (gpt-5.5 xhigh) | 0 | 0 | 0 | (implicit) SHIP |
| Gemini (3.5-flash REST) | 0 | 1 | 1 | SHIP-WITH-P2-FIXES |

Findings applied (2):

- **P2.1 (gemini)**: `COUNT=$(grep -c '::' pytest-collect.txt || true)` over-tolerates. The `|| true` swallows ALL non-zero grep exits, but only exit 1 ("no matches") is a legitimate degenerate state. Exit 2+ from grep would be a real error (file unreadable, etc.) and silently passing zero. Tightened to capture grep's exit code separately and only tolerate exit 1.
- **P3.1 (gemini)**: head/base steps left `pytest-collect.txt` / `pytest-collect.err` in the workspace. Added `rm -f` cleanup on success paths.

## Smoke testing

Verified locally against three scenarios in a throwaway tmpdir, both before and after the dual-track review tightening:

| Scenario | Pytest exit | Grep exit | Expected | Actual |
|---|---|---|---|---|
| broken import | 2 | n/a (early exit) | step fails | step exited 1, stderr surfaced |
| no test files at all | 5 | 1 | step passes, count=0 | step passed, count=0 |
| one normal test | 0 | 0 | step passes, count=1 | step passed, count=1, temp files cleaned up |

## Verification

- [x] `python3 scripts/check_version_consistency.py` — pass
- [x] `python3 scripts/check_spec_consistency.py` — pass
- [x] `python3 scripts/check_ci_pytest_manifest.py` — ok (14 entries; #156 still happy)
- [x] Personal-boundary scan — 726 files / 0 violations
- [x] Dual-track review (codex + gemini) — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)