### PR TITLE
fix(lint): close 4-segment semver + ja-JP needle coverage gaps (#169 #170)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -106,6 +106,11 @@ jobs:
           PYTHONPATH: .
         run: python3 -m unittest scripts.test_check_version_consistency -v
 
+      - name: Run spec consistency unit tests
+        env:
+          PYTHONPATH: .
+        run: python3 -m unittest scripts.test_check_spec_consistency -v
+
       - name: Run check_sprint_contract unit tests
         env:
           PYTHONPATH: .

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -205,6 +205,45 @@ def check_readme_sections() -> None:
     check_relative_markdown_links(rel_path)
 
 
+def check_readme_ja_sections() -> None:
+    """Symmetric coverage of README.ja-JP.md added in PR #161 (closes #170).
+
+    Pre-#170 the lint silently skipped this file. ja-JP uses ASCII parentheses
+    for release blocks (matching the English README), full-width parentheses
+    for mode and skill-detail headings, and "モード" instead of "mode".
+    """
+    rel_path = "README.ja-JP.md"
+    text = read(rel_path)
+
+    expect_contains(rel_path, "version-v3.9.4.2-blue")
+    expect_contains(rel_path, "releases/tag/v3.9.4.2")
+    expect_contains(rel_path, "### v3.9.4.2 (2026-05-19)")
+    expect_contains(rel_path, "### v3.9.4.1 (2026-05-19)")
+    expect_contains(rel_path, "### v3.9.4 (2026-05-18)")
+    expect_contains(rel_path, "### v3.9.1 (2026-05-18)")
+    expect_contains(rel_path, "### v3.9.0 (2026-05-17)")
+    for heading in (
+        "#### Deep Research（7 モード）",
+        "#### Academic Paper（10 モード）",
+        "#### Academic Paper Reviewer（6 モード）",
+        "### Deep Research（v2.8）",
+        "### Academic Paper（v3.0）",
+        "### Academic Paper Reviewer（v1.8）",
+        "### Academic Pipeline（v3.7）",
+    ):
+        if heading not in text:
+            fail(f"{rel_path}: missing heading {heading!r}")
+
+    for forbidden in (
+        "6th independent reviewer",
+        "Peer review gains 6th independent reviewer",
+    ):
+        expect_absent(rel_path, forbidden)
+
+    expect_contains(rel_path, "DOCX（利用可能な場合 Pandoc 経由）")
+    check_relative_markdown_links(rel_path)
+
+
 def check_readme_zh_sections() -> None:
     rel_path = "README.zh-TW.md"
     text = read(rel_path)
@@ -360,6 +399,7 @@ def main() -> int:
     check_pipeline_docs()
     check_readme_sections()
     check_readme_zh_sections()
+    check_readme_ja_sections()
     check_setup_docs()
     check_docx_contract()
     check_reference_docs()

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -222,10 +222,27 @@ def check_readme_ja_sections() -> None:
     expect_contains(rel_path, "### v3.9.4 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.1 (2026-05-18)")
     expect_contains(rel_path, "### v3.9.0 (2026-05-17)")
+    expect_contains(rel_path, "### v3.8.0 (2026-05-16)")
+    expect_contains(rel_path, "### v3.7.0 (2026-05-05)")
+    expect_contains(rel_path, "### v3.6.8 (2026-05-03)")
+    expect_contains(rel_path, "### v3.6.7 (2026-04-30)")
+    expect_contains(rel_path, "### v3.6.5 (2026-04-27)")
+    expect_contains(rel_path, "### v3.6.4 (2026-04-25)")
+    expect_contains(rel_path, "### v3.6.3 (2026-04-23)")
+    expect_contains(rel_path, "### v3.6.2 (2026-04-23)")
+    expect_contains(rel_path, "### v3.5.1 (2026-04-22)")
+    expect_contains(rel_path, "### v3.5.0 (2026-04-21)")
+    expect_contains(rel_path, "### v3.4.0 (2026-04-20)")
+    expect_contains(rel_path, "### v3.3.6 (2026-04-15)")
+    expect_contains(rel_path, "### v3.3.5 (2026-04-15)")
+    expect_contains(rel_path, "### v3.3.4 (2026-04-15)")
+    expect_contains(rel_path, "### v3.3.3 (2026-04-15)")
+    expect_contains(rel_path, "### v3.3.2 (2026-04-15)")
     for heading in (
         "#### Deep Research（7 モード）",
         "#### Academic Paper（10 モード）",
         "#### Academic Paper Reviewer（6 モード）",
+        "#### Academic Pipeline（オーケストレーター）",
         "### Deep Research（v2.8）",
         "### Academic Paper（v3.0）",
         "### Academic Paper Reviewer（v1.8）",

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -240,6 +240,11 @@ def check_readme_ja_sections() -> None:
     ):
         expect_absent(rel_path, forbidden)
 
+    # Mode-section content guards (e.g. `outline-only モード` inside the
+    # Academic Paper usage block) are deliberately not enforced here; the
+    # zh-TW checker uses `extract_section` for that and #171's schema-driven
+    # refactor will fold the three locales together. Adding the extract_section
+    # mirror now would be discarded by that refactor.
     expect_contains(rel_path, "DOCX（利用可能な場合 Pandoc 経由）")
     check_relative_markdown_links(rel_path)
 

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -28,7 +28,7 @@ TABLE_ROW_RE = re.compile(
 SUITE_VERSION_RE = re.compile(
     rf"^\s*-\s*\*\*Suite version\*\*:\s*({SEMVER})(?!\.\d)", re.MULTILINE
 )
-CHANGELOG_ENTRY_RE = re.compile(rf"^##\s*\[({SEMVER})\]", re.MULTILINE)
+CHANGELOG_ENTRY_RE = re.compile(rf"^##\s*\[({SEMVER})\]", re.MULTILINE)  # `]` delimiter blocks 5-segment prefix match without a lookahead
 
 PIPELINE_SKILL_NAME = "academic-pipeline"
 

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -21,11 +21,14 @@ from pathlib import Path
 from _skill_lint import parse_frontmatter, FrontmatterError
 
 
-TABLE_ROW_RE = re.compile(r"^\|\s*`([a-z0-9-]+)`\s+v(\d+\.\d+\.\d+)\s*\|", re.MULTILINE)
-SUITE_VERSION_RE = re.compile(
-    r"^\s*-\s*\*\*Suite version\*\*:\s*(\d+\.\d+\.\d+)", re.MULTILINE
+SEMVER = r"\d+\.\d+\.\d+(?:\.\d+)?"
+TABLE_ROW_RE = re.compile(
+    rf"^\|\s*`([a-z0-9-]+)`\s+v({SEMVER})(?!\.\d)\s*\|", re.MULTILINE
 )
-CHANGELOG_ENTRY_RE = re.compile(r"^##\s*\[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+SUITE_VERSION_RE = re.compile(
+    rf"^\s*-\s*\*\*Suite version\*\*:\s*({SEMVER})(?!\.\d)", re.MULTILINE
+)
+CHANGELOG_ENTRY_RE = re.compile(rf"^##\s*\[({SEMVER})\]", re.MULTILINE)
 
 PIPELINE_SKILL_NAME = "academic-pipeline"
 

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -21,31 +21,84 @@ from pathlib import Path
 from _skill_lint import parse_frontmatter, FrontmatterError
 
 
-SEMVER = r"\d+\.\d+\.\d+(?:\.\d+)?"
-TABLE_ROW_RE = re.compile(
-    rf"^\|\s*`([a-z0-9-]+)`\s+v({SEMVER})(?!\.\d)\s*\|", re.MULTILINE
+# Broad token captures: anything that looks like an identifier inside the
+# expected position. The strict validator below then decides whether the raw
+# token is a canonical semver. Using the regex as a filter (the pre-#169
+# pattern) silently dropped invalid tokens and hid the very drift this lint
+# is meant to surface; see dual-track review on PR for that class of bug.
+TABLE_TOKEN_RE = re.compile(
+    r"^\|\s*`([a-z0-9-]+)`\s+v([A-Za-z0-9.\-_+]+)\s*\|", re.MULTILINE
 )
-SUITE_VERSION_RE = re.compile(
-    rf"^\s*-\s*\*\*Suite version\*\*:\s*({SEMVER})(?!\.\d)", re.MULTILINE
+SUITE_TOKEN_RE = re.compile(
+    r"^\s*-\s*\*\*Suite version\*\*:\s*([A-Za-z0-9.\-_+]+)", re.MULTILINE
 )
-CHANGELOG_ENTRY_RE = re.compile(rf"^##\s*\[({SEMVER})\]", re.MULTILINE)  # `]` delimiter blocks 5-segment prefix match without a lookahead
+CHANGELOG_TOKEN_RE = re.compile(r"^##\s*\[([A-Za-z0-9.\-_+]+)\]", re.MULTILINE)
+SEMVER_STRICT_RE = re.compile(r"^\d+(?:\.\d+){2,}$")  # 3 or more segments
+
+NON_VERSION_CHANGELOG_TOKENS = frozenset({"Unreleased"})
 
 PIPELINE_SKILL_NAME = "academic-pipeline"
 
 
-def _parse_table_versions(claude_md_text: str) -> dict[str, str]:
-    """Return mapping skill_name -> version from the Skills Overview table."""
-    return dict(TABLE_ROW_RE.findall(claude_md_text))
+def _is_strict_semver(token: str) -> bool:
+    return bool(SEMVER_STRICT_RE.match(token))
 
 
-def _parse_suite_version(claude_md_text: str) -> str | None:
-    m = SUITE_VERSION_RE.search(claude_md_text)
-    return m.group(1) if m else None
+def _parse_table_versions(
+    claude_md_text: str,
+) -> tuple[dict[str, str], list[tuple[str, str]]]:
+    """Return (valid_versions, invalid_rows) from the Skills Overview table.
+
+    `valid_versions` maps skill_name -> version for rows whose v-token is a
+    canonical N.N.N(.N)+ string. `invalid_rows` collects (skill_name, raw_token)
+    for rows where the v-token is present but not a canonical version; the
+    caller surfaces these as errors so a malformed table row does not silently
+    drop out of downstream invariants.
+    """
+    valid: dict[str, str] = {}
+    invalid: list[tuple[str, str]] = []
+    for skill, raw in TABLE_TOKEN_RE.findall(claude_md_text):
+        if _is_strict_semver(raw):
+            valid[skill] = raw
+        else:
+            invalid.append((skill, raw))
+    return valid, invalid
 
 
-def _parse_changelog_latest(changelog_text: str) -> str | None:
-    m = CHANGELOG_ENTRY_RE.search(changelog_text)
-    return m.group(1) if m else None
+def _parse_suite_version(claude_md_text: str) -> tuple[str | None, str | None]:
+    """Return (valid_version, invalid_raw_token).
+
+    Exactly one of the two is non-None when a Suite version line is present.
+    Both are None when the line is missing entirely.
+    """
+    m = SUITE_TOKEN_RE.search(claude_md_text)
+    if m is None:
+        return None, None
+    raw = m.group(1)
+    if _is_strict_semver(raw):
+        return raw, None
+    return None, raw
+
+
+def _parse_changelog_latest(
+    changelog_text: str,
+) -> tuple[str | None, str | None]:
+    """Return (valid_latest, invalid_raw_token).
+
+    Walks `## [TOKEN]` headings in document order, skipping pseudo-entries
+    like `[Unreleased]`. The first remaining heading is the latest release.
+    If that heading's token is not a canonical version, it is returned as
+    `invalid_raw_token` so the caller flags it instead of silently falling
+    through to a predecessor and hiding the malformed release entry.
+    """
+    for m in CHANGELOG_TOKEN_RE.finditer(changelog_text):
+        raw = m.group(1)
+        if raw in NON_VERSION_CHANGELOG_TOKENS:
+            continue
+        if _is_strict_semver(raw):
+            return raw, None
+        return None, raw
+    return None, None
 
 
 def check(root: Path) -> list[str]:
@@ -57,26 +110,43 @@ def check(root: Path) -> list[str]:
         return errors
     claude_text = claude_md.read_text(encoding="utf-8")
 
-    table_versions = _parse_table_versions(claude_text)
-    if not table_versions:
+    table_versions, invalid_table_rows = _parse_table_versions(claude_text)
+    if not table_versions and not invalid_table_rows:
         errors.append(
             f"{claude_md}: Skills Overview table has no parseable "
             "`<skill>` vX.Y.Z rows"
         )
+    for skill, raw in invalid_table_rows:
+        errors.append(
+            f"{claude_md}: table row {skill!r} has invalid version "
+            f"token v{raw!r} (expected canonical N.N.N or N.N.N.N)"
+        )
 
-    suite_version = _parse_suite_version(claude_text)
-    if suite_version is None:
+    suite_version, invalid_suite_token = _parse_suite_version(claude_text)
+    if suite_version is None and invalid_suite_token is None:
         errors.append(
             f"{claude_md}: missing '**Suite version**: X.Y.Z' line"
+        )
+    elif invalid_suite_token is not None:
+        errors.append(
+            f"{claude_md}: Suite version token {invalid_suite_token!r} is "
+            "not a canonical N.N.N or N.N.N.N version"
         )
 
     changelog = root / "CHANGELOG.md"
     if not changelog.is_file():
         errors.append(f"{changelog}: not found")
     else:
-        latest = _parse_changelog_latest(changelog.read_text(encoding="utf-8"))
-        if latest is None:
+        latest, invalid_latest = _parse_changelog_latest(
+            changelog.read_text(encoding="utf-8")
+        )
+        if latest is None and invalid_latest is None:
             errors.append(f"{changelog}: no '## [X.Y.Z]' entry found")
+        elif invalid_latest is not None:
+            errors.append(
+                f"{changelog}: latest entry token {invalid_latest!r} is "
+                "not a canonical N.N.N or N.N.N.N version"
+            )
         elif suite_version is not None and latest != suite_version:
             errors.append(
                 f"{claude_md}: Suite version {suite_version!r} does not match "

--- a/scripts/test_check_spec_consistency.py
+++ b/scripts/test_check_spec_consistency.py
@@ -55,6 +55,22 @@ JA_README_TEMPLATE = """\
 ### v3.9.4 (2026-05-18) — temporal verification
 ### v3.9.1 (2026-05-18) — client hardening
 ### v3.9.0 (2026-05-17) — triangulation
+### v3.8.0 (2026-05-16) — L3 audit
+### v3.7.0 (2026-05-05) — plugin packaging
+### v3.6.8 (2026-05-03) — generator-evaluator
+### v3.6.7 (2026-04-30) — pattern protection
+### v3.6.5 (2026-04-27) — corpus consumer
+### v3.6.4 (2026-04-25) — corpus input port
+### v3.6.3 (2026-04-23) — passport reset
+### v3.6.2 (2026-04-23) — reviewer sprint
+### v3.5.1 (2026-04-22) — reading-check probe
+### v3.5.0 (2026-04-21) — collaboration depth
+### v3.4.0 (2026-04-20) — compliance agent
+### v3.3.6 (2026-04-15) — README streamlining
+### v3.3.5 (2026-04-15)
+### v3.3.4 (2026-04-15) — changelog sync
+### v3.3.3 (2026-04-15) — release prep
+### v3.3.2 (2026-04-15) — data access levels
 
 ## Version Info
 - **Suite version**: {ver}

--- a/scripts/test_check_spec_consistency.py
+++ b/scripts/test_check_spec_consistency.py
@@ -1,0 +1,125 @@
+"""Unit tests for check_spec_consistency.py.
+
+Pre-#171, check_spec_consistency.py uses module-level ROOT + ERRORS state.
+These tests monkey-patch ROOT into a TemporaryDirectory containing a minimal
+fixture README, drive a specific checker directly, and read ERRORS. When
+#171 lands the schema-driven manifest, these tests rewrite to call the
+manifest runner instead.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts import check_spec_consistency as csc
+
+
+# Minimal ja-JP README capturing the version-bearing surfaces the lint needs
+# to police: badge, release tag link, three release blocks (current + two
+# prior so the symmetric structure with check_readme_zh_sections is visible),
+# four localized mode headings, four skill-detail headings, and the DOCX line.
+JA_README_TEMPLATE = """\
+# Academic Research Skills
+
+[![Version](https://img.shields.io/badge/version-v{ver}-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v{ver})
+
+## クイックスタート
+
+#### Deep Research（7 モード）
+- outline-only モード
+- abstract-only モード
+- disclosure モード
+- review モード
+
+#### Academic Paper（10 モード）
+
+#### Academic Paper Reviewer（6 モード）
+- calibration モード
+
+#### Academic Pipeline（オーケストレーター）
+
+### Deep Research（v2.8）
+### Academic Paper（v3.0）
+### Academic Paper Reviewer（v1.8）
+### Academic Pipeline（v3.7）
+
+### サポートされる出力フォーマット
+
+- DOCX（利用可能な場合 Pandoc 経由）
+
+## Changelog
+
+### v{ver} (2026-05-19) — latest entry
+### v3.9.4.1 (2026-05-19) — previous hotfix
+### v3.9.4 (2026-05-18) — temporal verification
+### v3.9.1 (2026-05-18) — client hardening
+### v3.9.0 (2026-05-17) — triangulation
+
+## Version Info
+- **Suite version**: {ver}
+"""
+
+
+def _write_ja_readme(root: Path, version: str) -> None:
+    (root / "README.ja-JP.md").write_text(
+        JA_README_TEMPLATE.format(ver=version), encoding="utf-8"
+    )
+
+
+class TestReadmeJaSections(unittest.TestCase):
+    def setUp(self) -> None:
+        # check_spec_consistency uses module-level ROOT and ERRORS. Reset and
+        # restore around each test so state does not leak between cases.
+        self._orig_root = csc.ROOT
+        self._orig_errors = list(csc.ERRORS)
+        csc.ERRORS.clear()
+
+    def tearDown(self) -> None:
+        csc.ROOT = self._orig_root
+        csc.ERRORS.clear()
+        csc.ERRORS.extend(self._orig_errors)
+
+    def test_aligned_ja_readme_passes(self) -> None:
+        """A README.ja-JP.md whose badge / tag link / release headings all
+        agree with the suite version v3.9.4.2 must pass without errors."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_ja_readme(root, version="3.9.4.2")
+
+            csc.check_readme_ja_sections()
+
+            self.assertEqual(
+                csc.ERRORS, [],
+                msg=f"unexpected errors on aligned fixture: {csc.ERRORS!r}",
+            )
+
+    def test_stale_ja_badge_fails(self) -> None:
+        """Regression for #170: if README.ja-JP.md keeps a stale v3.9.4.0
+        badge while CHANGELOG has moved to v3.9.4.2, the lint must surface
+        the drift instead of silently passing (pre-fix behavior: this file
+        was outside the lint's needle list and the drift never surfaced)."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            # Write the "current" v3.9.4.2 release block but downgrade only
+            # the badge and tag link to v3.9.4.0. This is the realistic shape
+            # of drift when one place gets forgotten during a release.
+            stale = JA_README_TEMPLATE.format(ver="3.9.4.2").replace(
+                "version-v3.9.4.2-blue", "version-v3.9.4.0-blue"
+            ).replace(
+                "releases/tag/v3.9.4.2", "releases/tag/v3.9.4.0"
+            )
+            (root / "README.ja-JP.md").write_text(stale, encoding="utf-8")
+
+            csc.check_readme_ja_sections()
+
+            self.assertTrue(
+                any("README.ja-JP.md" in e and "v3.9.4.2" in e for e in csc.ERRORS),
+                msg=f"expected ja-JP drift error in: {csc.ERRORS!r}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -259,6 +259,108 @@ class TestVersionConsistency(unittest.TestCase):
             self.assertIn("3.9.4.1", result.stdout)
             self.assertIn("CHANGELOG", result.stdout)
 
+    def test_five_segment_changelog_does_not_silently_fall_through(self) -> None:
+        """Regression for dual-track review of #169: an N+1 segment latest
+        entry (e.g. 3.9.4.2.1) must not silently skip to the next valid
+        3-or-4 segment predecessor. Pre-fix CHANGELOG_ENTRY_RE failed on
+        the 5-segment heading and `re.search` fell through to a predecessor;
+        if that predecessor happened to equal the suite version, the lint
+        reported PASS even though the actual latest release was a different
+        version."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skills = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2"),
+            ]
+            for name, ver in skills:
+                _write_skill(root, name, ver)
+            _write_claude_md(root, suite_version="3.9.4.2", table_rows=skills)
+            _write_changelog(
+                root, latest_version="3.9.4.2.1", prior_versions=["3.9.4.2"],
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 1,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("3.9.4.2.1", result.stdout)
+            # Either path is acceptable surfacing: either the suite-vs-CHANGELOG
+            # mismatch (if the new 5-seg token is itself accepted as canonical
+            # under the broadened validator) or an invalid-token report.
+            self.assertTrue(
+                "does not match CHANGELOG latest entry" in result.stdout
+                or "canonical" in result.stdout,
+                msg=f"expected either drift or invalid-token surface: {result.stdout!r}",
+            )
+
+    def test_invalid_table_row_token_is_reported(self) -> None:
+        """Regression for dual-track review of #169: a table row carrying a
+        non-canonical version token (e.g. v3.9.4.2-alpha or v3.9.4.2.1) must
+        surface as an error. Pre-fix: TABLE_ROW_RE failed and the row silently
+        vanished from table_versions, so invariant 3 (pipeline tracks suite)
+        was skipped because `pipeline_in_table` ended up None."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skills_on_disk = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2"),
+            ]
+            for name, ver in skills_on_disk:
+                _write_skill(root, name, ver)
+            table_rows_with_junk = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2-alpha"),  # invalid token
+            ]
+            _write_claude_md(
+                root, suite_version="3.9.4.2", table_rows=table_rows_with_junk
+            )
+            _write_changelog(
+                root, latest_version="3.9.4.2", prior_versions=["3.9.4"],
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 1,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("academic-pipeline", result.stdout)
+            self.assertIn("3.9.4.2-alpha", result.stdout)
+            self.assertIn("canonical", result.stdout)
+
+    def test_invalid_suite_token_is_reported(self) -> None:
+        """Regression for dual-track review of #169: a non-canonical suite
+        version token (e.g. 3.9.4.2-alpha) must surface as an error rather
+        than being partially captured as 3.9.4.2 via prefix match."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skills = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2"),
+            ]
+            for name, ver in skills:
+                _write_skill(root, name, ver)
+            _write_claude_md(
+                root, suite_version="3.9.4.2-alpha", table_rows=skills
+            )
+            _write_changelog(
+                root, latest_version="3.9.4.2", prior_versions=["3.9.4"],
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 1,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("3.9.4.2-alpha", result.stdout)
+            self.assertIn("canonical", result.stdout)
+
     def test_four_segment_table_row_drift_fails(self) -> None:
         """Regression for #169: the Skills table row regex must also see the 4th
         segment, so a pipeline row v3.9.4.1 vs suite version 3.9.4.2 is caught."""

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -65,18 +65,17 @@ def _write_claude_md(
     (claude_dir / "CLAUDE.md").write_text(text, encoding="utf-8")
 
 
-def _write_changelog(root: Path, latest_version: str) -> None:
+def _write_changelog(
+    root: Path,
+    latest_version: str,
+    prior_versions: list[str] | None = None,
+) -> None:
+    """Write fixture CHANGELOG with `latest_version` first, then any `prior_versions`."""
+    entries = [f"## [{latest_version}] - 2026-04-22\n\n### Added\n- fixture entry\n"]
+    for prev in prior_versions or []:
+        entries.append(f"## [{prev}] - 2026-04-15\n\n### Added\n- prior fixture entry\n")
     (root / "CHANGELOG.md").write_text(
-        textwrap.dedent(
-            f"""\
-            # Changelog
-
-            ## [{latest_version}] - 2026-04-22
-
-            ### Added
-            - fixture entry
-            """
-        ),
+        "# Changelog\n\n" + "\n".join(entries),
         encoding="utf-8",
     )
 
@@ -227,6 +226,74 @@ class TestVersionConsistency(unittest.TestCase):
             result = _run(root)
             self.assertEqual(result.returncode, 1)
             self.assertIn("Suite version", result.stdout)
+
+    def test_four_segment_suite_vs_changelog_drift_fails(self) -> None:
+        """Regression for #169: 4-segment hotfix versions (e.g. 3.9.4.1 vs 3.9.4.2)
+        must not be silently parsed as a shared 3-segment prefix.
+
+        Scenario: suite claims v3.9.4.2 but CHANGELOG's latest entry is v3.9.4.1.
+        Pre-fix behavior: both got truncated to "3.9.4" and the lint passed silently.
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skills = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2"),
+            ]
+            for name, ver in skills:
+                _write_skill(root, name, ver)
+            _write_claude_md(root, suite_version="3.9.4.2", table_rows=skills)
+            # Include the 3-segment ancestor so the pre-fix regex would still find
+            # *something* and silently report a passing 3.9.4 == 3.9.4 comparison.
+            _write_changelog(
+                root, latest_version="3.9.4.1", prior_versions=["3.9.4"],
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 1,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("3.9.4.2", result.stdout)
+            self.assertIn("3.9.4.1", result.stdout)
+            self.assertIn("CHANGELOG", result.stdout)
+
+    def test_four_segment_table_row_drift_fails(self) -> None:
+        """Regression for #169: the Skills table row regex must also see the 4th
+        segment, so a pipeline row v3.9.4.1 vs suite version 3.9.4.2 is caught."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # Pipeline SKILL.md and CHANGELOG both at 3.9.4.2, but the table row
+            # in CLAUDE.md still says v3.9.4.1 (forgot to bump one place).
+            skills_on_disk = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2"),
+            ]
+            for name, ver in skills_on_disk:
+                _write_skill(root, name, ver)
+            table_rows_drifted = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.1"),  # drift inside the 4th segment
+            ]
+            _write_claude_md(
+                root, suite_version="3.9.4.2", table_rows=table_rows_drifted
+            )
+            _write_changelog(
+                root, latest_version="3.9.4.2", prior_versions=["3.9.4"],
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 1,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("academic-pipeline", result.stdout)
+            self.assertIn("3.9.4.1", result.stdout)
+            self.assertIn("3.9.4.2", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two lint gaps in `scripts/check_version_consistency.py` and `scripts/check_spec_consistency.py`, both surfaced from the v3.9.4.2 doc-backfill post-mortem (PR #165).

- **#169** — version-lint regexes used `\d+\.\d+\.\d+`, so 4-segment hotfix versions (e.g. `3.9.4.2`) silently truncated to `3.9.4` and within-4th-segment drift passed the lint.
- **#170** — `README.ja-JP.md` (added in PR #161 by @eltociear) was outside the spec-consistency needle list entirely. PR #165 had to ship a `[machine-translated, pending native review]` workaround because the lint did not police this file.

## Commits

| | |
|---|---|
| `9910887` | `fix(lint): widen check_version_consistency regex to 4-segment semver (#169)` |
| `2e99ef2` | `fix(lint): add README.ja-JP.md to check_spec_consistency needle coverage (#170)` |
| `e4d2b6a` | `chore(lint): clarify regex boundary + ja-JP coverage scope (review feedback)` |
| `8f1f140` | `fix(lint): broad-capture-then-validate semver tokens (dual-track review)` |
| `cfc1507` | `fix(lint): expand README.ja-JP.md needle list to full historical coverage (dual-track review P3)` |

Commits 1-3 land the surgical fixes for #169 / #170 plus simplify-review comments. Commits 4-5 absorb dual-track review (codex gpt-5.5 xhigh + gemini-3.1-pro-preview) findings — both reviewers independently flagged that the regex-as-filter approach still had a silent-pass class for N+1 segment tokens, malformed table rows, and suffix junk like `3.9.4.2-alpha`. Commit 4 replaces the filter with broad-capture + strict-validate, which closes that class. Commit 5 extends the ja-JP needle list to historical parity with zh-TW.

## Test coverage

- `scripts/test_check_version_consistency.py` grows from 9 → 13 tests (4-segment drift, 5-segment fall-through, invalid table-row token, invalid suite token).
- `scripts/test_check_spec_consistency.py` is new (2 tests; aligned ja-JP fixture + stale-badge mutation). Wired into spec-consistency.yml as a fresh `Run spec consistency unit tests` step.
- Real-repo lint still passes; no behavior change for canonical versions.

## Carved out as follow-ups

- `git tag -l 'v*' | sort -V | tail -1` cross-check in `check_version_consistency.py` would require subprocess mocking in fixture tests; nice-to-have not root cause for #169.
- `.github/workflows/spec-consistency.yml` line 119 sprint-contract step also has a 3-segment `## [X.Y.Z]` grep that feeds a soft warning. Same defect class as #169 but lives in a different code path; tracking as a small follow-up issue rather than expanding this PR.
- `#171` schema-driven refactor of `check_spec_consistency.py` will fold the three locale README checkers together. The three near-clone functions in this PR are a deliberate holding position that makes the manifest schema obvious.

## Test plan

- [x] `python3 scripts/check_version_consistency.py` passes on real repo
- [x] `python3 scripts/check_spec_consistency.py` passes on real repo
- [x] `python3 -m unittest scripts.test_check_version_consistency` (13/13 pass)
- [x] `python3 -m unittest scripts.test_check_spec_consistency` (2/2 pass)
- [x] `python3 scripts/check_ci_pytest_manifest.py` still validates
- [x] personal-boundary lint clean

Closes #169, closes #170.