### PR TITLE
fix(ci): widen sprint-contract changelog grep to N-segment semver (#175)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -121,7 +121,10 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s globstar nullglob
-          ARS_VERSION=$(grep -m1 -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          # Widened from 3-segment to N-segment so 4+ segment hotfix entries
+          # (e.g. ## [3.9.4.2]) match without falling through to a predecessor.
+          # Same defect class as #169 (closed by PR #173).
+          ARS_VERSION=$(grep -m1 -oE '## \[[0-9]+(\.[0-9]+)+\]' CHANGELOG.md | grep -oE '[0-9]+(\.[0-9]+)+' || true)
           if [[ -z "$ARS_VERSION" ]]; then
             echo "ERROR: could not extract ARS version from CHANGELOG.md (need '## [X.Y.Z]' heading)" >&2
             exit 1


### PR DESCRIPTION
## Summary

The \`Validate sprint contract templates\` step in \`spec-consistency.yml\` extracts the ARS version from CHANGELOG with two chained greps using a 3-segment semver pattern. A 4-segment hotfix entry like \`## [3.9.4.2]\` did not match, and \`-m1\` fell through to the next 3-segment entry (\`## [3.9.4]\`). The sprint-contract validator then ran with \`--ars-version v3.9.4\` while the actual tag was \`v3.9.4.2\`.

Same defect class as #169 (closed by PR #173), in a different code path. The validator emits a soft warning on mismatch today so this has not been a CI failure, but the step silently disagreed with the rest of the version-consistency pipeline on every 4+ segment release.

## Fix

1-line widening of both grep patterns from \`[0-9]+\.[0-9]+\.[0-9]+\` to \`[0-9]+(\.[0-9]+)+\`, mirroring the broad-capture-then-validate approach PR #173 took for the Python lint. POSIX ERE does not support non-capturing groups so the standard capture form is used.

## Verification

Sanity check on the current CHANGELOG.md:

\`\`\`
=== 3-seg pattern (pre-fix) ===
3.9.4
=== widened pattern ===
3.9.4.2
\`\`\`

## Test plan

- [x] Local re-run of the workflow snippet produces \`ARS_VERSION=3.9.4.2\`
- [x] No changes to \`scripts/check_sprint_contract.py\` itself
- [x] No changes to validator semantics (still soft warning on mismatch)

Closes #175.