### PR TITLE
fix(ci): use fromJSON for numeric threshold compare in post-squash-review

### DIFF
--- a/.github/workflows/post-squash-review.yml
+++ b/.github/workflows/post-squash-review.yml
@@ -15,6 +15,12 @@ name: Post-Squash Codex Review (Advisory)
 #
 # Codex 0.130 known broken in ARS context (6 sample), so this is
 # advisory: any non-zero exit just opens an issue, never fails CI.
+#
+# Numeric gate: step `if` expressions use fromJSON() on both sides
+# because GitHub Actions does lexicographic comparison on bare
+# `outputs.x < env.y` (both are strings). Without fromJSON, "73" < "500"
+# evaluates to false and small PRs trip the threshold. fromJSON()
+# parses the string as a JSON number, forcing numeric comparison.
 
 on:
   pull_request:
@@ -54,13 +60,8 @@ jobs:
           echo "lines=$TOTAL" >> "$GITHUB_OUTPUT"
           echo "Total lines changed: $TOTAL (threshold: $REVIEW_LINE_THRESHOLD)"
 
-      - name: Skip if below threshold
-        if: steps.size.outputs.lines < env.REVIEW_LINE_THRESHOLD
-        run: |
-          echo "Below threshold — no review needed."
-          exit 0
-
       - name: Check codex CLI availability
+        if: fromJSON(steps.size.outputs.lines) >= fromJSON(env.REVIEW_LINE_THRESHOLD)
         id: codex
         continue-on-error: true
         run: |
@@ -72,7 +73,7 @@ jobs:
           fi
 
       - name: Run codex review on squash commit
-        if: steps.size.outputs.lines >= env.REVIEW_LINE_THRESHOLD && steps.codex.outputs.available == 'true'
+        if: fromJSON(steps.size.outputs.lines) >= fromJSON(env.REVIEW_LINE_THRESHOLD) && steps.codex.outputs.available == 'true'
         id: review
         continue-on-error: true
         env:
@@ -91,7 +92,7 @@ jobs:
           head -200 codex-review.txt || true
 
       - name: Open advisory issue
-        if: steps.size.outputs.lines >= env.REVIEW_LINE_THRESHOLD
+        if: fromJSON(steps.size.outputs.lines) >= fromJSON(env.REVIEW_LINE_THRESHOLD)
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUM: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Closes #179

## Summary

- `post-squash-review.yml` uses lexicographic string compare on the line-count threshold, so 2-digit PRs (73, 58 lines) trip the 500-line gate
- Wraps both sides of the `if:` condition in `fromJSON()` to force numeric compare
- Drops the dedicated "Skip" step (its `exit 0` rendered as a noisy passing step); gates the 3 downstream steps directly

## Evidence

Python repro of GH Actions string compare semantics:

```
"73"  < "500" → false  (numeric 73 < 500 = true)
"58"  < "500" → false  (numeric 58 < 500 = true)
"518" < "500" → false  (numeric 518 < 500 = false)
```

Resulting false-positive issues from the last 24h:

| Issue | Triggering PR | Lines | True positive? |
|-------|---------------|-------|----------------|
| #166  | #165 (docs backfill) | 73 | ❌ FP |
| #172  | #168 (CI hardening)  | 58 | ❌ FP |
| #174  | #173 (lint coverage) | 518 | ✅ |

(#166 and #172 closed as not planned; #174 reviewed locally with codex — 0 P0/P1, 1 P2 spun off as #178.)

## Verification

- `actionlint .github/workflows/post-squash-review.yml` → 0 errors
- YAML parses with `python3 -c "import yaml; yaml.safe_load(...)"`
- Workflow step structure preserved (5 steps after removing the dead Skip step)

## Test plan

- [x] actionlint passes
- [x] YAML parses
- [ ] On next merged PR < 500 lines: confirm no issue opened
- [ ] On next merged PR ≥ 500 lines: confirm issue still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)