### PR TITLE
fix(lint): cap check_version_consistency semver regex at 4 segments (#178)

### DIFF
--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -33,7 +33,7 @@ SUITE_TOKEN_RE = re.compile(
     r"^\s*-\s*\*\*Suite version\*\*:\s*([A-Za-z0-9.\-_+]+)", re.MULTILINE
 )
 CHANGELOG_TOKEN_RE = re.compile(r"^##\s*\[([A-Za-z0-9.\-_+]+)\]", re.MULTILINE)
-SEMVER_STRICT_RE = re.compile(r"^\d+(?:\.\d+){2,}$")  # 3 or more segments
+SEMVER_STRICT_RE = re.compile(r"^\d+(?:\.\d+){2,3}$")  # exactly 3 or 4 segments (N.N.N or N.N.N.N)
 
 NON_VERSION_CHANGELOG_TOKENS = frozenset({"Unreleased"})
 

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -397,6 +397,45 @@ class TestVersionConsistency(unittest.TestCase):
             self.assertIn("3.9.4.1", result.stdout)
             self.assertIn("3.9.4.2", result.stdout)
 
+    def test_five_segment_token_rejected_as_non_canonical(self) -> None:
+        """Regression for #178: post-ship codex review of PR #173 flagged that
+        SEMVER_STRICT_RE used `{2,}` (3 or more dot segments) with no upper
+        bound, so a 5-segment token like 3.9.4.2.1 passed the canonical check
+        even though the file-level docstrings and #173 design defined canonical
+        as N.N.N or N.N.N.N. If a 5-segment typo were copied consistently to
+        CLAUDE.md, CHANGELOG.md, and the pipeline table, the lint would have
+        passed despite the malformed shape. Cap to {2,3}: 4 segments max."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # All four sources self-consistent on a 5-segment typo. Pre-fix:
+            # all three regexes captured "3.9.4.2.1" verbatim, _is_strict_semver
+            # returned True (matched {2,} = 3 or more segments), and every
+            # invariant compared two identical strings — lint reported PASS
+            # even though the shape was malformed. Post-fix: SEMVER_STRICT_RE
+            # rejects 5+ segments, so the suite, table row, and CHANGELOG
+            # entry all surface as "canonical" violations.
+            skills_5seg = [
+                ("deep-research", "2.9.4"),
+                ("academic-paper", "3.1.2"),
+                ("academic-paper-reviewer", "1.9.1"),
+                ("academic-pipeline", "3.9.4.2.1"),
+            ]
+            for name, ver in skills_5seg:
+                _write_skill(root, name, ver)
+            _write_claude_md(
+                root, suite_version="3.9.4.2.1", table_rows=skills_5seg
+            )
+            _write_changelog(
+                root, latest_version="3.9.4.2.1", prior_versions=["3.9.4.2"],
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 1,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("3.9.4.2.1", result.stdout)
+            self.assertIn("canonical", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #178

## Summary

`SEMVER_STRICT_RE` used `{2,}` (3 or more segments, no upper bound). A self-consistent 5-segment typo like `3.9.4.2.1` across CLAUDE.md / CHANGELOG.md / table row / pipeline SKILL.md frontmatter would pass the lint because every invariant compared two identical strings. Cap to `{2,3}` so only N.N.N and N.N.N.N are canonical.

## Source

Post-ship codex review of PR #173 squash commit `9729d29`:

```
codex review --commit 9729d29 --title 'post-squash integration review (PR #173)'
# codex-cli 0.128.0, model gpt-5.5, reasoning xhigh
# 0 P0 / 0 P1 / 1 P2
```

The P2 was:

> When a five-segment typo is copied consistently across `.claude/CLAUDE.md`, `CHANGELOG.md`, and the pipeline table/SKILL metadata, for example `3.9.4.2.1`, this regex treats it as valid because it allows three or more dot segments. The new invalid-token path therefore never runs and the version consistency check passes, even though the emitted errors and PR scope define only `N.N.N` / `N.N.N.N` as canonical.

(Full review at #174 closing comment.)

## Test

Adds `test_five_segment_token_rejected_as_non_canonical`:

- Writes a self-consistent 5-segment typo to all four sources
- Pre-fix: `Version consistency check passed.` (the bug)
- Post-fix: three "not canonical" errors fire, exit 1

Existing `test_five_segment_changelog_does_not_silently_fall_through` used `assertTrue(A or B)` to accept either drift or invalid-token surfacing — post-fix it follows the invalid-token branch and stays green.

## Verification

```
$ PYTHONPATH=scripts python3 -m pytest scripts/test_check_version_consistency.py -v
14 passed in 0.81s

$ python3 scripts/check_version_consistency.py
Version consistency check passed.
```

## Test plan

- [x] New test fails on baseline, passes after fix
- [x] All 14 existing tests pass
- [x] Real repo (3.9.4.2 = 4 segments) still validates as canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)