### PR TITLE
docs(readme): add Academic Writing Skills as a companion plugin (per #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ ARS Stage 2 WRITE     →  write paper with verified experiment results
 
 ---
 
+## Companion: Academic Writing Skills (post-writing polish)
+
+If your manuscript is already drafted and needs format-level polish (LaTeX/Typst compile diagnosis, bibliography hygiene, or AI-tone removal), [Academic Writing Skills](https://github.com/bahayonghang/academic-writing-skills) (AWS, MIT) covers the post-writing layer after ARS Stage 2 (WRITE) / Stage 5 (FINALIZE).
+
+```
+ARS Stage 2 WRITE / Stage 5 FINALIZE  →  draft manuscript (.tex / .typ)
+        ↓
+  academic-writing-skills              →  compile checks · bib verification · de-AI polish
+        ↓
+  submission-ready manuscript
+```
+
+**What it does**: format-level polish on existing manuscripts. `latex-paper-en` (ChkTeX/latexmk + AXES coherence), `latex-thesis-zh` (GB/T 7714-2015; thuthesis/pkuthss/ustcthesis/fduthesis), `typst-paper` (millisecond compile + Hayagriva), `bib-search-citation` (local BibTeX/Zotero search), and `aiwei-zh` (Chinese AI-tone removal with em-dash/quote hard gates).
+
+**How to use together**: ARS `academic-paper` produces a draft from scratch; AWS polishes a draft you already have. The two suites install independently and need zero modification to either. AWS `aiwei-zh` complements ARS's general-purpose `writing_quality_check.md` with Chinese-specific typographic gates. See the [AWS README](https://github.com/bahayonghang/academic-writing-skills) for setup.
+
+---
+
 ## Usage
 
 ### Quick Start


### PR DESCRIPTION
## Summary

Follow-up to #159, taking the path you suggested: a small adjacent-projects README pointer instead of a core merge.

Adds a `## Companion: Academic Writing Skills (post-writing polish)` section right after the existing `## Companion: Experiment Agent`, mirroring that pattern. It points to [bahayonghang/academic-writing-skills](https://github.com/bahayonghang/academic-writing-skills) (AWS, MIT) as an independently-installable companion for the post-writing polish layer (LaTeX/Typst compile checks, bibliography hygiene, Chinese AI-tone removal) that sits after ARS Stage 2 (WRITE) / Stage 5 (FINALIZE).

## Why this shape

- **Zero maintenance burden for ARS** — the two suites install independently with no modification to either, so none of the upstream-drift / license-provenance / routing-contract concerns from #159 apply.
- **Consistent with existing docs** — same length and structure as the experiment-agent companion block.
- **One file, +18 lines** — `README.md` only. No skills, no manifest changes, no NOTICE.

## Changes

- `README.md` — one new `## Companion` subsection (18 lines added, nothing removed)

## Test plan

- [ ] Companion section renders correctly on GitHub
- [ ] Both companion blocks (experiment-agent + AWS) read consistently
- [ ] No other files touched (`git diff --stat` shows only `README.md`)

Thanks again for the thoughtful close on #159 — this is the cleaner shape.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)