### PR TITLE
Fix #186: Add trigger commands for academic-paper-reviewer and other pipeline skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,5 +19,45 @@
     "systematic-review",
     "peer-review",
     "scholarly-publishing"
+  ],
+  "commands": [
+    {
+      "name": "ars-reviewer",
+      "description": "Trigger the 5-panel academic peer-review simulation for paper evaluation",
+      "usage": "/ars-reviewer [path/to/draft.md]",
+      "examples": [
+        "/ars-reviewer",
+        "/ars-reviewer --mode=quick",
+        "/ars-reviewer --mode=methodology"
+      ],
+      "routing": {
+        "skill": "academic-paper-reviewer",
+        "default_mode": "full"
+      }
+    },
+    {
+      "name": "ars-full",
+      "description": "Launch the complete 10-stage orchestrated academic research and writing pipeline",
+      "usage": "/ars-full [prompt]",
+      "examples": [
+        "/ars-full Write a paper on AI in higher education"
+      ],
+      "routing": {
+        "skill": "academic-pipeline",
+        "default_mode": "full"
+      }
+    },
+    {
+      "name": "ars-lit-review",
+      "description": "Run an intensive literature mapping, screening, and synthesis loop",
+      "usage": "/ars-lit-review [topic]",
+      "examples": [
+        "/ars-lit-review systematic-review"
+      ],
+      "routing": {
+        "skill": "deep-research",
+        "default_mode": "lit-review"
+      }
+    }
   ]
 }

--- a/commands/ars-reviewer.md
+++ b/commands/ars-reviewer.md
@@ -1,0 +1,20 @@
+---
+name: ars-reviewer
+description: "Trigger the simulated peer-review panel for an academic paper draft"
+skills:
+  - academic-paper-reviewer
+---
+
+# /ars-reviewer
+
+When this command is invoked, immediately initialize the `academic-paper-reviewer` team pipeline. 
+
+## Default Execution Flow
+1. **Intake**: Accept the user's paper draft, manuscript text, or repository files.
+2. **Analysis**: Route the text through the 5-panel reviewer agents (`devils_advocate`, `domain_reviewer`, `editorial_synthesizer`, `methodology_reviewer`, `perspective_reviewer`).
+3. **Output**: Deliver the full structured Peer Review Report, including the Five-Dimension Rubric scores and actionable Critical/Major/Minor issues lists.
+
+## Available Modifiers
+- `/ars-reviewer --mode=quick`: Triggers an EIC quick assessment and key issues list.
+- `/ars-reviewer --mode=methodology`: Forces an in-depth focus strictly on methods and data rigor.
+- `/ars-reviewer --mode=re-review`: Initializes a verification checklist to check author revisions against a prior report.


### PR DESCRIPTION
Closes #186. Formats the .claude-plugin/plugin.json file to map the /ars-reviewer, /ars-full, and /ars-lit-review slash commands directly into Claude Code.