### PR TITLE
feat(commands): add /ars-reviewer + sync announce list to 13 commands

### DIFF
--- a/commands/ars-reviewer.md
+++ b/commands/ars-reviewer.md
@@ -1,0 +1,9 @@
+---
+description: ARS academic-paper-reviewer `full` mode — simulated peer-review panel
+model: opus
+---
+
+Trigger the `academic-paper-reviewer` skill in `full` mode. Honor explicit alternate modes when present: `quick`, `methodology-focus`, `re-review`, `guided`, or `calibration`. Uses opus per project policy for review-interpretation depth.
+
+Mode reference: `MODE_REGISTRY.md` § academic-paper-reviewer.
+Skill entry: `academic-paper-reviewer/SKILL.md`.

--- a/scripts/announce-ars-loaded.sh
+++ b/scripts/announce-ars-loaded.sh
@@ -54,14 +54,15 @@ fi
 # ---------------------------------------------------------------------------
 case "${SOURCE}" in
   compact|resume)
-    ANNOUNCE="ARS v3.7.0 plugin still loaded after ${SOURCE}. Slash commands: /ars-full /ars-plan /ars-outline /ars-revision /ars-revision-coach /ars-abstract /ars-lit-review /ars-format-convert /ars-citation-check /ars-disclosure. Plugin agents: synthesis_agent, research_architect_agent, report_compiler_agent."
+    ANNOUNCE="ARS plugin still loaded after ${SOURCE}. Slash commands: /ars-full /ars-plan /ars-outline /ars-revision /ars-revision-coach /ars-abstract /ars-lit-review /ars-reviewer /ars-format-convert /ars-citation-check /ars-disclosure /ars-mark-read /ars-unmark-read. Plugin agents: synthesis_agent, research_architect_agent, report_compiler_agent."
     ;;
   startup|clear|*)
-    ANNOUNCE="ARS v3.7.0 (academic-research-skills) plugin loaded.
+    ANNOUNCE="ARS (academic-research-skills) plugin loaded.
 
-Slash commands (10) — model routing pinned in frontmatter:
+Slash commands (13) — model routing pinned in frontmatter:
   /ars-full              opus    Full pipeline (research → write → review → revise → finalize)
   /ars-revision-coach    opus    Parse reviewer comments → Revision Roadmap + Response Letter skeleton
+  /ars-reviewer          opus    academic-paper-reviewer full mode — simulated peer-review panel
   /ars-plan              sonnet  Socratic chapter-by-chapter planning
   /ars-outline           sonnet  Detailed outline + evidence map (no full draft)
   /ars-revision          sonnet  Revised draft + R&R responses
@@ -70,6 +71,8 @@ Slash commands (10) — model routing pinned in frontmatter:
   /ars-format-convert    sonnet  Convert paper between LaTeX / DOCX / PDF / Markdown
   /ars-citation-check    sonnet  Citation error report
   /ars-disclosure        sonnet  Venue-specific AI-usage disclosure statement
+  /ars-mark-read         sonnet  Record human-read signal for one or more citation keys
+  /ars-unmark-read       sonnet  Rescind a prior human-read mark for one or more citation keys
 
 Plugin agents (3, v3.6.7-hardened, model: inherit) — dispatched by ARS pipeline:
   synthesis_agent             Cross-source integration, contradiction resolution, gap analysis


### PR DESCRIPTION
## Summary

Adds `/ars-reviewer` slash command for the `academic-paper-reviewer` skill, closing the `/ars-*` UX-symmetry gap that plugin users see (every other branded mode has a `/ars-*` entry, reviewer didn't).

Also syncs `scripts/announce-ars-loaded.sh` — the SessionStart hook was still announcing "v3.7.0 plugin, 10 commands" after v3.9.5 shipped two more (`/ars-mark-read`, `/ars-unmark-read`); this PR brings the announce list to the actual 13 commands and drops the hardcoded version prefix from the runtime announce.

Closes #186.

## Replaces PR #189

External contributor @madtriceps opened #189 to address the same issue but the proposed approach had schema-level problems (object-shaped `commands` array in `plugin.json` would have load-errored and replaced the existing `commands/` auto-discovery, silently orphaning 10 other commands). This PR ships the maintainer-shipped equivalent — single `commands/ars-reviewer.md` matching the existing 12-command convention, no `plugin.json` touch. Co-authored by @madtriceps via commit trailer.

## Note for users hitting this gap

`academic-paper-reviewer` skill already triggers via the skill name itself (`/academic-paper-reviewer`) — that's the base Claude Code skill auto-discovery and was never broken. This PR adds the branded `/ars-reviewer` shortcut that pins `full` mode + `opus` model in frontmatter, matching how the other `/ars-*` commands work.

## Test plan

- [x] `commands/ars-reviewer.md` follows repo convention (matches `commands/ars-lit-review.md` and `commands/ars-revision-coach.md` shape)
- [x] `scripts/announce-ars-loaded.sh` syntax: `bash -n` passes
- [x] `scripts/announce-ars-loaded.sh` runtime: emits valid JSON for both `startup` and `compact` SessionStart sources, contains all 13 commands
- [x] Codex review (3 rounds): 0 P0/P1/P2 findings on final commit
- [x] Personal boundary lint: 735 files scanned, 0 violations
- [x] Reviewer skill modes (`full`, `re-review`, `quick`, `methodology-focus`, `guided`, `calibration`) verified against `MODE_REGISTRY.md` and `academic-paper-reviewer/SKILL.md`

## Carry-over (separate work)

The hardcoded 13-row list in `announce-ars-loaded.sh` will drift on every command add/remove. Toolkit-level lint to auto-validate the announce + `plugin.json` against `commands/*.md` is tracked as follow-up work in `release-discipline-toolkit`.