### PR TITLE
fix(lint): re-cite REQUIRED_BLOCK source (#197 local, not spec §3.6 Step 7)

### DIFF
--- a/scripts/check_v3_6_8_mark_read_commands.py
+++ b/scripts/check_v3_6_8_mark_read_commands.py
@@ -25,9 +25,10 @@ REQUIRED_TOKENS = (
     "model: sonnet",      # routing per feedback_no_haiku.md
 )
 
-# Enforce canonical CLI dispatch pattern: 
-# Prose instructions are fragile; using a literal bash block with $ARGUMENTS 
+# Enforce canonical CLI dispatch pattern (PR #197 local convention):
+# Prose instructions are fragile; using a literal bash block with $ARGUMENTS
 # ensures deterministic argument parsing and shell-safe token handling.
+# This is a repo-local policy introduced by #197, not a §3.6 Step 7 spec rule.
 REQUIRED_BLOCK = "Implementation:\n```bash\npython3 scripts/ars_mark_read.py $ARGUMENTS"
 
 
@@ -59,7 +60,7 @@ def main(argv: list[str] | None = None) -> int:
         if REQUIRED_BLOCK not in body:
             errors.append(
                 f"commands/{cmd_name}: missing compliant 'Implementation: ```bash' block "
-                f"(spec §3.6 Step 7: must use canonical bash block with $ARGUMENTS)"
+                f"(PR #197 local convention: must use canonical bash block with $ARGUMENTS for deterministic argument parsing)"
             )
 
     if errors:


### PR DESCRIPTION
## Summary

Follow-up from PR #225 review. The `REQUIRED_BLOCK` lint check that PR #225 introduced is correct, but its error message and inline comment cited `spec §3.6 Step 7` as the source of the rule. The spec section actually prescribes file-creation, validation, and acceptance behavior only — it does not prescribe the bash-block invocation pattern. That pattern is a repo-local policy introduced by #197.

Two spots re-cited:
- Inline comment above `REQUIRED_BLOCK` constant
- Error message emitted when `REQUIRED_BLOCK` is missing from a command file

Enforcement is unchanged; only the source citation is corrected.

## Test plan

- [x] `python3 scripts/check_v3_6_8_mark_read_commands.py` → PASSED (2 commands scanned)
- [x] `pytest tests/test_mark_read_args.py -v` → 2 passed

[skip-closes-check] This PR does not close an issue; it is a citation-source correction flagged in the #225 approval review, not a deliverable tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)