### PR TITLE
docs: fix stale EMNLP disclosure policy URL

### DIFF
--- a/academic-paper/references/venue_disclosure_policies.md
+++ b/academic-paper/references/venue_disclosure_policies.md
@@ -94,8 +94,8 @@ If the venue is not listed here, the mode halts and asks the user to paste the c
 
 | Field | Value |
 |---|---|
-| Source URL | https://2026.emnlp.org/calls/main-conference-papers (follows ACL policy) |
-| Access date | 2026-04-09 |
+| Source URL | https://2026.emnlp.org/calls/main_conference_papers/ (follows ACL policy) |
+| Access date | 2026-05-23 |
 | Policy summary | EMNLP follows the ACL policy. Same requirements apply. |
 | Required phrasing elements | Same as ACL |
 | Preferred disclosure location | Same as ACL: **"Use of AI Assistance"** subsection |


### PR DESCRIPTION
## Summary

- Fix the stale EMNLP 2026 main conference papers URL in `venue_disclosure_policies.md`.
- Update the access date for the EMNLP policy source to 2026-05-23.

## Motivation

Closes #229.

The previous hyphenated URL returned HTTP 404. The canonical EMNLP 2026 call page uses `main_conference_papers/` and returns HTTP 200.

## Verification

```bash
curl -I -L --max-time 20 https://2026.emnlp.org/calls/main-conference-papers
# HTTP/2 404

curl -I -L --max-time 20 https://2026.emnlp.org/calls/main_conference_papers/
# HTTP/2 200

git diff --check
```

This is a docs-only broken-link fix and does not change agent behavior.
