### PR TITLE
docs: sync academic-paper examples inventory in SKILL.md (7 files)

### DIFF
--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -360,7 +360,7 @@ See `agents/intake_agent.md` for the complete field definitions of the Phase 0 c
 
 **Templates** (11 files in `templates/`): `imrad`, `literature_review`, `case_study`, `theoretical_paper`, `policy_brief`, `conference_paper`, `latex_article_template.tex`, `bilingual_abstract`, `credit_statement`, `funding_statement`, `revision_tracking` (4 status types).
 
-**Examples** (6 files in `examples/`): `imrad_hei_example`, `literature_review_example`, `plan_mode_guided_writing`, `chinese_paper_example`, `revision_mode_example`, `clinical_citation_verification_checklist`.
+**Examples** (7 files in `examples/`): `imrad_hei_example`, `literature_review_example`, `plan_mode_guided_writing`, `chinese_paper_example`, `revision_mode_example`, `revision_recovery_example`, `clinical_citation_verification_checklist`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Bump `academic-paper/SKILL.md` examples inventory from 6 → 7 files
- Add `revision_recovery_example` (added in v4.0 commit 2dd7f27, never indexed)
- Order: basic IMRaD → lit-review → planning → chinese → revision → revision-recovery → clinical

## Why

SKILL.md line 363 has been silently drifting from `academic-paper/examples/` for two release cycles. Surfaced by codex review of #236 — directory had 7 `.md` files but inventory said 6 and omitted `revision_recovery_example`.

Not @2023Anita's fault — the gap pre-dated her PR; she synced inventory in the manner consistent with what she observed in the file, but the file was already 1 behind.

[skip-closes-check] Pure maintenance sync — no open issue tracks this drift (would be circular to file one for a 1-line follow-up). The originating signal is the codex review comment on #236, referenced above.

## Test plan

- [ ] `ls academic-paper/examples/*.md | wc -l` → 7
- [ ] grep `Examples` count in SKILL.md line 363 → 7
- [ ] inventory list contains both `revision_recovery_example` and `clinical_citation_verification_checklist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)