### PR TITLE
docs: fix stale ACL AI policy URL

### DIFF
--- a/academic-paper/references/venue_disclosure_policies.md
+++ b/academic-paper/references/venue_disclosure_policies.md
@@ -79,8 +79,8 @@ If the venue is not listed here, the mode halts and asks the user to paste the c
 
 | Field | Value |
 |---|---|
-| Source URL | https://www.aclweb.org/portal/content/acl-policy-use-ai-writing-assistance |
-| Access date | 2026-04-09 |
+| Source URL | https://2023.aclweb.org/blog/ACL-2023-policy/ |
+| Access date | 2026-05-24 |
 | Policy summary | ACL requires a dedicated "Limitations" section and allows an optional "Use of AI Assistance" section. Authors must disclose substantive use of AI writing tools. Minor grammar/spell-check tools do not require disclosure. |
 | Required phrasing elements | Must name the tool. Must describe "the extent of use" — was it for drafting, editing, or brainstorming? ACL distinguishes between minor editing and substantive drafting. |
 | Preferred disclosure location | A dedicated **"Use of AI Assistance"** subsection, placed after "Limitations" and before "References" |


### PR DESCRIPTION
## Summary

- Replace the stale ACL AI-writing-assistance policy URL in `venue_disclosure_policies.md`.
- Update the ACL access date after verifying the replacement URL.

## Motivation

Fixes #230.

The previous ACL policy URL returns HTTP 404. The replacement points to the ACL 2023 program-chair policy post on AI writing assistance, which is the candidate canonical source identified in the issue.

## Verification

- Old URL: `https://www.aclweb.org/portal/content/acl-policy-use-ai-writing-assistance` -> HTTP 404
- New URL: `https://2023.aclweb.org/blog/ACL-2023-policy/` -> HTTP 200
- `git diff --check`
- `python3 scripts/check_spec_consistency.py`
- `python3 scripts/check_version_consistency.py`
- `python3 scripts/check_data_access_level.py`
- `python3 scripts/check_task_type.py`

## Risk

Docs-only URL anchor update. No agent behavior, schema, or runtime code changes.