### PR TITLE
chore(docs): redact personal environment topology from public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ docs/superpowers/
 # Python bytecode / pytest cache.
 __pycache__/
 
-# Private ROADMAP lives in claude-memory-sync (花花/roadmaps/), not this public repo
+# Private ROADMAP is intentionally gitignored and maintained outside this public repo
 ROADMAP.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -840,7 +840,7 @@ Reference: `feedback_codex_review_vs_resume_audit_scope.md`.
   writer/evaluator pair via contract-gated phase splits and Schema 13.1
   conditional gates. No new agent files; existing `draft_writer_agent` and
   `peer_reviewer_agent` gain per-phase sub-section instructions") lands in
-  the private ROADMAP.md (gitignored, lives in claude-memory-sync), not in
+  the private ROADMAP.md (gitignored, maintained outside this public repo), not in
   this repo PR.
 
 ## [3.6.7] - 2026-04-30

--- a/docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md
+++ b/docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md
@@ -5,7 +5,7 @@
 **Author:** Cheng-I Wu
 **Target versions:** v3.4.0 (compliance agent) → v3.5.0 (reading-check)
 **File path:** `docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md`
-**Supersedes:** the three-part roadmap saved in `花花/global/project_academic_research_skills.md` (2026-04-19 "下次優化的三項補強")
+**Supersedes:** the three-part roadmap saved in private planning notes (2026-04-19 "下次優化的三項補強")
 
 ---
 
@@ -568,7 +568,7 @@ compliance_agent is itself subject to calibration — reuses v3.2 `academic-pape
 ## 9. Open questions / deferred
 
 - Sixth-reviewer cross-model peer review remains in `planned` state (not v3.4 scope). v3.5.0 is a good moment to revisit.
-- Codex CLI port (roadmap from花花 memory 2026-04-19) stays out of scope for v3.4.
+- Codex CLI port (roadmap from private planning notes, 2026-04-19) stays out of scope for v3.4.
 - Downstream private-project SCR Loop upgrade to ARS v3.0+ stays separately tracked in private project memory.
 
 ## 10. References

--- a/docs/design/2026-04-22-ars-v3.7.3-reading-check-probe-design.md
+++ b/docs/design/2026-04-22-ars-v3.7.3-reading-check-probe-design.md
@@ -462,7 +462,7 @@ This is a public repo. Before `git push`:
 
 ### 6.5 ROADMAP update (memory-sync)
 
-After PR merges, update `~/Projects/claude-memory-sync/花花/roadmaps/academic-research-skills-ROADMAP.md` §3.7.3: mark shipped, cite v3.5.1, note that the original "sub-mode + soft-nudge" dual-track was collapsed to Mentor-only.
+After PR merges, update the private roadmap §3.7.3: mark shipped, cite v3.5.1, note that the original "sub-mode + soft-nudge" dual-track was collapsed to Mentor-only.
 
 ### 6.6 Post-merge verification
 
@@ -521,5 +521,5 @@ After PR merges, update `~/Projects/claude-memory-sync/花花/roadmaps/academic-
 - ARS ROADMAP §3.7.3 (2026-04-21): authoritative v3.7.3 spec after reshape from v3.4 design.
 - `docs/design/2026-04-20-v3.4-prisma-trAIce-raise-readcheck-design.md` §7.7, §8.2: original v3.5.0 plan (sub-mode + soft-nudge dual-track); partially superseded by this spec.
 - `shared/cross_model_verification.md`: `ARS_CROSS_MODEL` env-gating precedent.
-- `feedback_version_bump_sweep_checklist.md` (花花 memory): 7-site version bump map.
-- `project_ars_v3.6_execution_order.md` (花花 memory, 2026-04-22): execution order rationale (E → A → **B** → D) putting this spec as step B.
+- `feedback_version_bump_sweep_checklist.md` (private planning notes): 7-site version bump map.
+- `project_ars_v3.6_execution_order.md` (private planning notes, 2026-04-22): execution order rationale (E → A → **B** → D) putting this spec as step B.

--- a/docs/design/2026-04-23-ars-v3.6.2-sprint-contract-design.md
+++ b/docs/design/2026-04-23-ars-v3.6.2-sprint-contract-design.md
@@ -820,7 +820,7 @@ TDD-driven. See §7 for red-green discipline.
 
 ## 15. References
 
-- ROADMAP: `~/Projects/claude-memory-sync/花花/roadmaps/academic-research-skills-ROADMAP.md` §3.6.2
+- ROADMAP: private roadmap §3.6.2
 - Execution order memory: `project_ars_v3.6_execution_order.md` §4
 - Anthropic Labs (2026-03-24), *Harness Design for Long-Running Applications*, principle 3 (sprint contract)
 - `shared/compliance_report.schema.json` (Schema 12, pattern source)

--- a/docs/design/2026-04-27-ars-v3.6.5.2-claude-ai-method-4a-scope-implementation-brief.md
+++ b/docs/design/2026-04-27-ars-v3.6.5.2-claude-ai-method-4a-scope-implementation-brief.md
@@ -102,7 +102,7 @@ The drafter MAY paraphrase Anthropic's guidance but must cite the source for eve
 
 ## §4 — Public repo + Ruleset constraints
 
-`Imbad0202/academic-research-skills` is public with branch protection on main blocking direct commits (GH013). The drafter does not commit directly. Branch is `hotfix/v3.6.5.2-clarify-claude-ai-method-4a-scope` (already created and renamed locally on 花花 machine).
+`Imbad0202/academic-research-skills` is public with branch protection on main blocking direct commits (GH013). The drafter does not commit directly. Branch is `hotfix/v3.6.5.2-clarify-claude-ai-method-4a-scope` (already created and renamed locally on the maintainer's machine).
 
 PR is public-facing. The PR body must not reference internal terminology (no "blast radius", "Codex round-X", "atomic boundary", "home turf" as repo-internal jargon — though the user-facing rationale can describe Claude Code as the platform the suite was built for, which is plain English).
 

--- a/docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md
+++ b/docs/design/2026-04-27-ars-v3.6.6-generator-evaluator-contract-design.md
@@ -1358,7 +1358,7 @@ Four spec sub-sections (§3, §5, §6, §7) ran multi-round codex iterative revi
 | §7 spec body | 4 | r1 5 / r2 2 / r3 1 / r4 0 | 8 |
 | **Cumulative** | **19 rounds across 5 review streams** | — | **56** |
 
-Recurring lessons (recorded in `~/.claude/projects/-Users-imbad/memory/feedback_*.md` during the spec sprint):
+Recurring lessons (recorded in the maintainer's private memory during the spec sprint):
 
 - **Brief preflight saves spec-body rework**: §5 brief 6-round preflight surfaced design-level matrix that would have produced 5-10 spec-body rework rounds without it. Total work was 6 brief + 3 spec body = 9 rounds vs. estimated 15+ without preflight (per `feedback_brief_itself_needs_codex_review.md`).
 - **"Don't add a counter, change the rule" stop condition**: §5 brief r6 left only a P3 round-label issue — mechanical chase-the-tail. User explicitly stopped instead of running r7. The stop condition: when remaining findings are all label / wording polish that fail to surface real semantic drift, pin the content as "PASS" and ship (per `feedback_architectural_inflection_after_repeated_p1.md`).

--- a/docs/design/2026-05-14-ai-disclosure-impl-spec.md
+++ b/docs/design/2026-05-14-ai-disclosure-impl-spec.md
@@ -180,10 +180,10 @@ Hitting either trigger ⇒ stop and ask user whether to accept audit-trail-compl
 
 ## 8. Public-repo boundary discipline
 
-This is a public repository. Pre-push gates (per `~/.claude/CLAUDE.md` + `feedback_ars_public_repo_boundary.md`):
+This is a public repository. Pre-push gates:
 
-1. `grep -rn` for the private-org and private-project tokens enumerated in `~/.claude/personal-boundary/deny_list.yaml` — block on hit (Springer is **legal** anchor scope per Decision Doc §4.5 / §4.6).
-2. `python3 ~/.claude/personal-boundary/check_boundary.py --root . --quiet` — block on hit.
+1. `grep -rn` for the private-org and private-project tokens enumerated in the maintainer's local boundary deny list — block on hit (Springer is **legal** anchor scope per Decision Doc §4.5 / §4.6).
+2. Run the maintainer's local boundary-check script against the repo root — block on hit.
 3. `/codex review` + `/security-review` parallel: both must produce 0 P1/P2 before merge.
 
 ---

--- a/docs/design/2026-05-15-issue-103-claim-alignment-audit-decision.md
+++ b/docs/design/2026-05-15-issue-103-claim-alignment-audit-decision.md
@@ -187,4 +187,4 @@ Implementation-layer acceptance lives in the spec. The decision doc passes when:
 
 - **Spec:** `docs/design/2026-05-15-issue-103-claim-alignment-audit-spec.md` (implementation surface, schema, lint, TDD test cases — to be written after this doc passes codex round-1).
 - **Calibration protocol:** `academic-pipeline/references/claim_audit_calibration_protocol.md` (post-spec implementation).
-- **Memory anchor:** `~/.claude/projects/-Users-imbad/memory/project_ars_106_ai_disclosure_discovery.md` — lesson #22 to be added recording 8-OQ resolution pattern (compresses #106's three-stage to two-stage when issue body already contains frozen design).
+- **Memory anchor:** private maintainer memory (`project_ars_106_ai_disclosure_discovery`) — lesson #22 to be added recording 8-OQ resolution pattern (compresses #106's three-stage to two-stage when issue body already contains frozen design).

--- a/docs/design/2026-05-15-issue-103-claim-alignment-audit-spec.md
+++ b/docs/design/2026-05-15-issue-103-claim-alignment-audit-spec.md
@@ -800,8 +800,8 @@ This mirrors #105 → #115 split pattern (production module first, integration f
 
 After ship, update:
 
-- `~/.claude/projects/-Users-imbad/memory/project_ars_106_ai_disclosure_discovery.md` — lesson #22 (8-OQ compressed decision-doc pattern when issue body already has frozen design)
-- `~/.claude/projects/-Users-imbad/memory/feedback_codex_round_convergence_by_scope.md` — new memory if not exists, record "new tool + IO + new agent" data point
+- private maintainer memory (`project_ars_106_ai_disclosure_discovery`) — lesson #22 (8-OQ compressed decision-doc pattern when issue body already has frozen design)
+- private maintainer memory (`feedback_codex_round_convergence_by_scope`) — new memory if not exists, record "new tool + IO + new agent" data point
 - Consider new memory `feedback_audit_results_vs_audit_artifact_semantic_split.md` documenting D5 boundary
 
 ## 13. Implementation order (TDD-driven)

--- a/docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md
+++ b/docs/design/2026-05-18-ars-v3.9.2-phase-boundary-spec.md
@@ -296,7 +296,7 @@ File: `scripts/check_pipeline_integrity.py` (joins existing 28 `check_*.py` scri
 
 ### Phase 7: Security + PII + public-flip readiness (~1h)
 
-- `~/.claude/personal-boundary/check_boundary.py --root . --quiet`
+- Run the maintainer's local boundary-check script against the repo root
 - Per `feedback_public_flip_readiness_checklist.md` 12-item audit (ARS is public repo)
 - Per `feedback_ars_public_repo_boundary.md` — grep for hei-platform / Springer / HEEACT leakage in new files
 


### PR DESCRIPTION
## What

Replaces traces of the maintainer's private local environment with generic descriptions across design docs, `CHANGELOG.md`, and `.gitignore`.

These traces (private home-directory paths, a machine nickname, and private-repo names) carry zero value for a reader trying to understand how this repo is developed — they only expose the maintainer's local setup. The design rationale, decision logs, and development-process narrative that the design docs intentionally make public are **unchanged**.

## Scope

- 11 files, 17 lines, all 1:1 replacements
- private home-dir paths (local boundary-check script, local memory dir) → generic phrasing ("the maintainer's local boundary-check script", "private maintainer memory")
- a private roadmap repo reference → "private roadmap / maintained outside this public repo"
- a machine nickname → "the maintainer's machine"

## Deliberately kept

- All design content, rationale, and review-process narrative
- Internal memory **filenames** (they are development-process artifacts; only the private path/locator prefixes were removed)
- Bare mechanism mentions that carry no path
- The canonical public repo identifier

## Verification

- Re-ran the leak-pattern grep after editing: 0 hits
- Full diff reviewed: every change is a 1:1 textual replacement; no structural or content edits