### PR TITLE
[codex] add version-family citation reconciliation

### DIFF
--- a/academic-paper/SKILL.md
+++ b/academic-paper/SKILL.md
@@ -360,7 +360,7 @@ See `agents/intake_agent.md` for the complete field definitions of the Phase 0 c
 
 **Templates** (11 files in `templates/`): `imrad`, `literature_review`, `case_study`, `theoretical_paper`, `policy_brief`, `conference_paper`, `latex_article_template.tex`, `bilingual_abstract`, `credit_statement`, `funding_statement`, `revision_tracking` (4 status types).
 
-**Examples** (8 files in `examples/`): `imrad_hei_example`, `literature_review_example`, `plan_mode_guided_writing`, `chinese_paper_example`, `revision_mode_example`, `revision_recovery_example`, `clinical_citation_verification_checklist`, `clinical_epistemic_status_example`.
+**Examples** (9 files in `examples/`): `imrad_hei_example`, `literature_review_example`, `plan_mode_guided_writing`, `chinese_paper_example`, `revision_mode_example`, `revision_recovery_example`, `clinical_citation_verification_checklist`, `clinical_epistemic_status_example`, `version_family_reconciliation_example`.
 
 ---
 

--- a/academic-paper/agents/draft_writer_agent.md
+++ b/academic-paper/agents/draft_writer_agent.md
@@ -602,3 +602,29 @@ You MUST:
    NOT write the claim.
 
 You may not rely on linguistic plausibility for temporal claims. Temporal claims are arithmetic, not stylistic.
+
+## Citation Version-Family Check (Kong #258)
+
+When `phase2_investigation/version_records.yaml` is present, treat it as the sidecar source of truth for academic works with multiple concrete versions (for example, arXiv v1, conference proceedings, journal extension, technical report, dataset release). This check extends the Temporal Integrity Iron Rule; it does not replace the citation-faithfulness or claim-intent manifest rules.
+
+Before writing or revising any sentence that cites a slug belonging to a `version_family_id`, verify that all version-bound fields in the sentence come from the same `known_versions[]` record:
+
+- year
+- venue or source label
+- DOI, arXiv ID, or URL
+- quoted text / locator / anchor
+- explicit wording such as "preprint", "v1", "conference version", "proceedings version", or "journal extension"
+
+If these fields mix versions, do NOT silently smooth the prose. Surface an inline advisory for the caller:
+
+```text
+VERSION_INCONSISTENT_CITATION: citation metadata, locator, or quoted claim mixes multiple records in version_family_id=<id>. Select one version or explicitly separate the claims.
+```
+
+Safe patterns:
+
+- Cite the scholar-confirmed `primary_version_key` for general claims about the work.
+- Cite an arXiv/preprint version only when the sentence explicitly says the claim belongs to that preprint version.
+- Cite multiple versions in one sentence only when the sentence is explicitly comparing versions and each claim has its own locator.
+
+Do not mutate `literature_corpus[]` to store version-family state. The version family lives in `version_records.yaml`, produced by `timeline_extraction_agent`.

--- a/academic-paper/agents/formatter_agent.md
+++ b/academic-paper/agents/formatter_agent.md
@@ -310,6 +310,28 @@ When refusing, surface the unresolved markers to the user with their per-section
 
 **Contamination annotations (`CONTAMINATED-PREPRINT`, `CONTAMINATED-UNMATCHED`, `CONTAMINATED-PREPRINT+UNMATCHED`, `CONTAMINATED-COVERAGE-NOISE`, `CONTAMINATED-PARTIAL-UNMATCH`, `CONTAMINATED-TRIANGULATION-UNMATCHED`, `CONTAMINATED-PREPRINT+COVERAGE-NOISE`, `CONTAMINATED-PREPRINT+PARTIAL-UNMATCH`, `CONTAMINATED-PREPRINT+TRIANGULATION-UNMATCHED`) on `ok` or `LOW-WARN` markers DO NOT trigger refusal.** They are advisory per v3.5 Collaboration Depth Observer precedent + v3.7.3 R-L3-2-A + v3.9.0 R-L3-2-E — surface them in the output package's `provenance_summary.md`, but do not block the conversion. v3.9.0 adds 6 triangulation-tier suffixes (everything after the third entry); v3.7.3 added the first three. Refusal rules 1-10 (above) remain unchanged — no v3.9.0 marker triggers gate refusal.
 
+## Citation Version-Family Advisory (Kong #258)
+
+If `phase2_investigation/version_records.yaml` is present, run a final version-family consistency scan before emitting the output package. This is advisory, not a refusal rule.
+
+For each cited slug that joins a `version_family_id`, compare the rendered citation and nearby claim against the corresponding `known_versions[]` records:
+
+- rendered year
+- rendered venue / source label
+- DOI, arXiv ID, or URL
+- direct quotation locator or anchor
+- prose wording such as "preprint", "v1", "conference version", "proceedings", or "journal extension"
+
+Surface `VERSION_INCONSISTENT_CITATION` in `provenance_summary.md` when these fields mix concrete versions. Examples include a reference list entry rendered as proceedings while the quoted text locator points to arXiv v1, or a DOI for a journal extension paired with prose describing the conference version.
+
+Do not auto-standardize the reference. Do not rewrite the manuscript during formatting. Report the inconsistency and ask the scholar to choose one of these remediation paths:
+
+- standardize the citation to the scholar-confirmed `primary_version_key`
+- explicitly cite the preprint / proceedings / journal extension being quoted
+- split the sentence so each version-bound claim has its own citation and locator
+
+This advisory is separate from #127 strict triangulation policy: #127 asks whether a reference meets existence / venue policy; Kong #258 asks whether an existing work's citation metadata and quoted claim come from the same concrete version.
+
 ## Output Format
 
 ```markdown

--- a/academic-paper/examples/version_family_reconciliation_example.md
+++ b/academic-paper/examples/version_family_reconciliation_example.md
@@ -1,0 +1,89 @@
+# Version-Family Reconciliation Example (Kong #258)
+
+This example shows how ARS surfaces a citation-version mismatch without auto-correcting the manuscript.
+
+## Scenario
+
+The author wants to cite *Attention Is All You Need*. Their corpus contains two concrete versions:
+
+- arXiv preprint v1
+- NeurIPS 2017 proceedings record
+
+The scholar selects the proceedings record as the primary citable version, but the draft sentence quotes the arXiv v1 locator while the reference list renders proceedings metadata.
+
+## Sidecar
+
+`phase2_investigation/version_records.yaml`:
+
+```yaml
+schema_version: "1.0"
+version_records:
+  - version_family_id: attention-transformer-family
+    canonical_slug: vaswani2017
+    primary_version_key: attention-neurips-2017
+    discovery_status: user_confirmed
+    reconciliation_note: "Proceedings record selected as default citation; arXiv v1 can be cited explicitly for preprint-specific claims."
+    known_versions:
+      - version_key: attention-arxiv-v1
+        citation_key: vaswani2017-arxiv-v1
+        kind: arxiv_preprint
+        title: "Attention Is All You Need"
+        year: 2017
+        venue: "arXiv"
+        doi: null
+        arxiv_id: "1706.03762v1"
+        url: "https://arxiv.org/abs/1706.03762v1"
+        publication_date: {value: "2017-06", precision: month}
+        metadata_provenance: arxiv_api
+        source_locator: "arxiv:1706.03762v1"
+        claim_scope_note: "Use only for text verified against the v1 preprint."
+        notes: null
+      - version_key: attention-neurips-2017
+        citation_key: vaswani2017-neurips
+        kind: proceedings
+        title: "Attention Is All You Need"
+        year: 2017
+        venue: "NeurIPS 2017"
+        doi: null
+        arxiv_id: null
+        url: "https://papers.nips.cc/paper/7181-attention-is-all-you-need"
+        publication_date: {value: "2017", precision: year}
+        metadata_provenance: user_override
+        source_locator: "papers.nips.cc:7181"
+        claim_scope_note: "Use for proceedings metadata and the final citable record."
+        notes: null
+```
+
+## Problem Draft
+
+```markdown
+The preprint v1 states the Transformer architecture relies entirely on attention mechanisms (Vaswani et al., 2017).<!--ref:vaswani2017-neurips ok--><!--anchor:section:arxiv:1706.03762v1:sec3-->
+```
+
+The citation slug points to the proceedings record, but the prose and anchor point to arXiv v1.
+
+## Advisory
+
+```text
+VERSION_INCONSISTENT_CITATION: citation metadata, locator, or quoted claim mixes multiple records in version_family_id=attention-transformer-family. The rendered slug vaswani2017-neurips belongs to attention-neurips-2017, while the prose/anchor refers to attention-arxiv-v1. Select one version or explicitly separate the claims.
+```
+
+## Acceptable Fix A — Cite the Preprint Explicitly
+
+```markdown
+The arXiv v1 preprint states the Transformer architecture relies entirely on attention mechanisms (Vaswani et al., 2017).<!--ref:vaswani2017-arxiv-v1 ok--><!--anchor:section:arxiv:1706.03762v1:sec3-->
+```
+
+## Acceptable Fix B — Use the Proceedings Record
+
+```markdown
+The proceedings version presents the Transformer architecture as relying entirely on attention mechanisms (Vaswani et al., 2017).<!--ref:vaswani2017-neurips ok--><!--anchor:section:papers.nips.cc:7181:sec3-->
+```
+
+## Acceptable Fix C — Compare Versions Explicitly
+
+```markdown
+The arXiv v1 preprint and the NeurIPS proceedings version both frame the Transformer as an attention-only architecture, but the manuscript cites the proceedings version as the primary record (Vaswani et al., 2017).<!--ref:vaswani2017-arxiv-v1 ok--><!--anchor:section:arxiv:1706.03762v1:sec3--><!--ref:vaswani2017-neurips ok--><!--anchor:section:papers.nips.cc:7181:sec3-->
+```
+
+The important rule is that each version-bound claim has its own slug and locator. ARS does not decide which version is "better"; the scholar selects the version appropriate to the claim.

--- a/deep-research/agents/timeline_extraction_agent.md
+++ b/deep-research/agents/timeline_extraction_agent.md
@@ -7,7 +7,7 @@ description: "Extracts per-source temporal facts and citation provenance into Ph
 
 ## Role Definition
 
-You are the Timeline Extraction Agent. Your sole purpose is to materialise per-source temporal facts (publication date, effective-date range, supersession chain, known versions) and first-party citation provenance (Crossref `issued` date lookup + pdftotext cover-page first-line scan) into two sidecar artifacts that downstream Phase 4 → 5 verifiers consume deterministically.
+You are the Timeline Extraction Agent. Your sole purpose is to materialise per-source temporal facts (publication date, effective-date range, supersession chain, known versions), first-party citation provenance (Crossref `issued` date lookup + pdftotext cover-page first-line scan), and academic citation version-family records into sidecar artifacts that downstream Phase 4 → 5 verifiers consume deterministically.
 
 This is the load-bearing component of v3.9.4 temporal verification. `bibliography_agent` is read-only context (you read its annotated bibliography); the boundary defined by v3.9.2 phase-boundary spec is unchanged.
 
@@ -17,6 +17,7 @@ You are a single-phase agent assigned to **Phase 2 (Investigation)** — same ph
 
 - `phase2_investigation/timeline.yaml` (per-source / per-event temporal facts)
 - `phase2_investigation/citation_provenance.yaml` (per-citation first-party verification results — Crossref `issued` date lookup + pdftotext cover scan)
+- `phase2_investigation/version_records.yaml` (academic citation version-family evidence for preprint -> proceedings -> journal chains; Kong #258)
 
 You MUST NOT:
 
@@ -49,7 +50,7 @@ For every source in the corpus:
 
 1. Determine `published_date` (per Crossref or user override; precision required).
 2. Determine `effective_date_range` if the document is an institutional document with a defined governance period (user override usually; this CANNOT be inferred from publication date).
-3. Determine `supersedes` / `superseded_by` if the user has tagged related editions with shared `version_family_id` (user-declared only in v3.9.4 stub; v3.10 will add proactive title-similarity discovery).
+3. Determine `supersedes` / `superseded_by` if the user has tagged related editions with shared `version_family_id` (user-declared only in v3.9.4 stub; Kong #258 adds academic citation version-family candidate discovery in `version_records.yaml`, not corpus mutation).
 4. Determine `version_catalog_completeness` (user-declared; v3.9.4 records but does not act on `exhaustive`).
 5. Write the entry to `phase2_investigation/timeline.yaml`.
 
@@ -59,8 +60,40 @@ Events that are referenced in prose but have no corpus citation (e.g., "law was 
 
 Every date in `timeline.yaml` MUST carry `precision` ∈ {day, month, year, interval, unknown} and `provenance.method`. When `precision: unknown` AND `open_ended: false` (or absent), the verifier treats it as missing data. When `precision: unknown` AND `open_ended: true`, the verifier treats it as `+∞` (still in force; only valid for `effective_date_range.end`). No other date may carry `open_ended: true`. See spec §3.1 date shape table.
 
+## Academic Citation Version Discovery (Kong #258)
+
+For academic citation chains, write `phase2_investigation/version_records.yaml` using `shared/contracts/passport/version_records.schema.json`. This extends the v3.9.4 M5 `version_family_id` stub from institutional documents to scholarly works that appear as arXiv preprints, conference proceedings, journal extensions, reports, datasets, or book chapters.
+
+### What to detect
+
+For every corpus entry with a DOI, arXiv ID, title, or URL:
+
+1. Query Crossref and OpenAlex when DOI/title metadata is available.
+2. Query arXiv metadata when `arxiv_id` is present, preserving exact version suffixes such as `v1` / `v2`.
+3. Group records into a shared `version_family_id` only when the evidence indicates the same work, not merely a related topic.
+4. Emit each concrete version under `known_versions[]`, with `kind`, `title`, `year`, `venue`, identifiers, `metadata_provenance`, `source_locator`, and a `claim_scope_note`.
+5. Mark families as `candidate` or `needs_review` until the scholar confirms the primary citable record. Only `discovery_status: user_confirmed` should guide final citation standardization.
+
+### Sidecar discipline
+
+- Do NOT write `version_family_id`, `primary_version_key`, or version metadata into `literature_corpus_entry.schema.json` or any `literature_corpus[]` entry.
+- Do NOT modify `bibliography_agent.md` or the annotated bibliography. This agent owns candidate discovery.
+- Do NOT auto-correct citations. Surface candidate evidence and ask the scholar to select the primary version.
+- If metadata conflicts across resolvers, keep all candidate records and set `discovery_status: needs_review`.
+
+### Consumer contract
+
+Downstream `draft_writer_agent` and `formatter_agent` read `version_records.yaml` to surface `VERSION_INCONSISTENT_CITATION` when a citation mixes fields from multiple concrete versions in the same family. Examples:
+
+- reference list uses a proceedings venue/year but the quoted text locator points to arXiv v1
+- DOI belongs to a journal extension while the manuscript describes the conference version
+- the prose says "preprint v1" but the citation slug resolves to the scholar-confirmed proceedings record
+
+The warning is advisory. The scholar chooses whether to cite one version, cite multiple versions explicitly, or revise the claim.
+
 ## Output Schemas
 
 - `shared/contracts/passport/timeline.schema.json` (aggregate-level with `$defs`)
 - `shared/contracts/passport/citation_provenance.schema.json` (aggregate-level)
-- Both validated by `scripts/check_v3_9_4_temporal_verification.py` lint.
+- `shared/contracts/passport/version_records.schema.json` (aggregate-level academic citation version-family sidecar)
+- Temporal sidecars are validated by `scripts/check_v3_9_4_temporal_verification.py`; `version_records.schema.json` is covered by `scripts/test_version_records_schema.py`.

--- a/docs/design/2026-05-28-kong-258-version-family-reconciliation.md
+++ b/docs/design/2026-05-28-kong-258-version-family-reconciliation.md
@@ -1,0 +1,94 @@
+# Kong #258 — Academic Citation Version-Family Reconciliation
+
+**Status:** prompt + sidecar contract implementation
+**Date:** 2026-05-28
+**Issue:** #258
+**Scope:** Extend the v3.9.4 M5 version-family stub from institutional documents to academic citation chains such as arXiv preprint -> proceedings -> journal extension.
+
+## Boundary
+
+This patch is a faithfulness extension, not an autonomous correction layer.
+
+- `literature_corpus_entry.schema.json` remains unchanged. It is adapter-owned and `additionalProperties: false`.
+- `bibliography_agent.md` remains unchanged. Version discovery is owned by `timeline_extraction_agent`.
+- `version_records.yaml` records candidate evidence and user-confirmed choices. It does not auto-standardize the reference list.
+- `formatter_agent` and `draft_writer_agent` surface `VERSION_INCONSISTENT_CITATION` as an advisory, not a hard refusal.
+
+## Sidecar
+
+`phase2_investigation/version_records.yaml` is validated by
+`shared/contracts/passport/version_records.schema.json`.
+
+Minimal shape:
+
+```yaml
+schema_version: "1.0"
+version_records:
+  - version_family_id: attention-transformer-family
+    canonical_slug: vaswani2017
+    primary_version_key: attention-neurips-2017
+    discovery_status: user_confirmed
+    reconciliation_note: "Scholar selected proceedings as the primary citation."
+    known_versions:
+      - version_key: attention-arxiv-v1
+        citation_key: vaswani2017-arxiv-v1
+        kind: arxiv_preprint
+        title: "Attention Is All You Need"
+        year: 2017
+        venue: "arXiv"
+        doi: null
+        arxiv_id: "1706.03762v1"
+        url: "https://arxiv.org/abs/1706.03762v1"
+        publication_date: {value: "2017-06", precision: month}
+        metadata_provenance: arxiv_api
+        source_locator: "arxiv:1706.03762v1"
+        claim_scope_note: "Use only for claims verified against v1 text."
+      - version_key: attention-neurips-2017
+        citation_key: vaswani2017-neurips
+        kind: proceedings
+        title: "Attention Is All You Need"
+        year: 2017
+        venue: "NeurIPS 2017"
+        doi: null
+        arxiv_id: null
+        url: "https://papers.nips.cc/paper/7181-attention-is-all-you-need"
+        publication_date: {value: "2017", precision: year}
+        metadata_provenance: user_override
+        source_locator: "papers.nips.cc:7181"
+        claim_scope_note: "Use for proceedings metadata and final citable record."
+```
+
+## Producer Protocol
+
+`timeline_extraction_agent` writes candidate records from DOI/arXiv/title evidence:
+
+1. For DOI-bearing entries, query Crossref and OpenAlex metadata when available.
+2. For arXiv-bearing entries, query arXiv metadata for exact version IDs (`v1`, `v2`, etc.).
+3. Group candidate records into `version_family_id` families only when evidence indicates the same work, not merely similar topic.
+4. Mark the family `candidate` or `needs_review` until the scholar selects `primary_version_key`.
+5. When the scholar confirms the selected citable version, mark `discovery_status: user_confirmed`.
+
+## Consumer Protocol
+
+When a cited slug joins a version family, `draft_writer_agent` and `formatter_agent` verify that all version-bound fields in the emitted claim are from the same `known_versions[]` entry:
+
+- cited `year`
+- visible venue / source label
+- DOI, arXiv ID, URL
+- direct quotation or anchor locator
+- explicit version phrasing, such as "v1", "preprint", "conference version", or "journal extension"
+
+If the fields mix versions, emit:
+
+```text
+VERSION_INCONSISTENT_CITATION: citation metadata, locator, or quoted claim mixes multiple records in version_family_id=<id>. Select one version or explicitly separate the claims.
+```
+
+This warning is advisory. The scholar decides whether to cite the preprint, proceedings, journal extension, or multiple versions explicitly.
+
+## #127 Boundary
+
+#127 handles the v3.10 triangulation policy layer: strict modes, `venue_type`, and terminal blocking when a reference is unmatched across indexes. #258 is narrower: it assumes the work exists and asks whether the metadata and quoted claim come from the same concrete version. Do not merge the two concerns:
+
+- #127: "Does this reference meet policy for existence / venue classification?"
+- #258: "Which concrete version of this existing work supports this citation?"

--- a/scripts/test_check_v3_9_4_temporal_verification.py
+++ b/scripts/test_check_v3_9_4_temporal_verification.py
@@ -439,11 +439,12 @@ def test_timeline_extraction_agent_has_phase_boundary_block():
     assert "## Citation Provenance Protocol (v3.9.4)" in content
 
 
-def test_timeline_extraction_agent_lists_two_deliverables():
+def test_timeline_extraction_agent_lists_sidecar_deliverables():
     agent_path = REPO_ROOT / "deep-research/agents/timeline_extraction_agent.md"
     content = agent_path.read_text()
     assert "timeline.yaml" in content
     assert "citation_provenance.yaml" in content
+    assert "version_records.yaml" in content
 
 
 M3_IRON_RULE_MARKER = "## Temporal Integrity Iron Rule (v3.9.4)"

--- a/scripts/test_version_records_schema.py
+++ b/scripts/test_version_records_schema.py
@@ -1,0 +1,114 @@
+"""Tests for Kong #258 version_records sidecar schema."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS = REPO_ROOT / "shared/contracts/passport"
+
+
+def _schema(name: str) -> dict:
+    return json.loads((SCHEMAS / name).read_text())
+
+
+def _valid_version_records() -> dict:
+    return {
+        "schema_version": "1.0",
+        "version_records": [
+            {
+                "version_family_id": "attention-transformer-family",
+                "canonical_slug": "vaswani2017",
+                "primary_version_key": "attention-neurips-2017",
+                "discovery_status": "user_confirmed",
+                "reconciliation_note": "Scholar selected proceedings as the primary rendered citation.",
+                "known_versions": [
+                    {
+                        "version_key": "attention-arxiv-v1",
+                        "citation_key": "vaswani2017-arxiv-v1",
+                        "kind": "arxiv_preprint",
+                        "title": "Attention Is All You Need",
+                        "year": 2017,
+                        "venue": "arXiv",
+                        "doi": None,
+                        "arxiv_id": "1706.03762v1",
+                        "url": "https://arxiv.org/abs/1706.03762v1",
+                        "publication_date": {"value": "2017-06", "precision": "month"},
+                        "metadata_provenance": "arxiv_api",
+                        "source_locator": "arxiv:1706.03762v1",
+                        "claim_scope_note": "Use only for claims verified against the v1 preprint text.",
+                        "notes": None,
+                    },
+                    {
+                        "version_key": "attention-neurips-2017",
+                        "citation_key": "vaswani2017-neurips",
+                        "kind": "proceedings",
+                        "title": "Attention Is All You Need",
+                        "year": 2017,
+                        "venue": "NeurIPS 2017",
+                        "doi": None,
+                        "arxiv_id": None,
+                        "url": "https://papers.nips.cc/paper/7181-attention-is-all-you-need",
+                        "publication_date": {"value": "2017", "precision": "year"},
+                        "metadata_provenance": "user_override",
+                        "source_locator": "papers.nips.cc:7181",
+                        "claim_scope_note": "Use for proceedings metadata and final citable record.",
+                        "notes": None,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_version_records_schema_validates_canonical_example():
+    jsonschema.validate(_valid_version_records(), _schema("version_records.schema.json"))
+
+
+def test_version_records_rejects_unknown_top_level_field():
+    bad = _valid_version_records()
+    bad["literature_corpus_patch"] = []
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, _schema("version_records.schema.json"))
+
+
+def test_version_records_rejects_invalid_arxiv_id():
+    bad = _valid_version_records()
+    bad["version_records"][0]["known_versions"][0]["arxiv_id"] = "arXiv:1706.03762v1"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, _schema("version_records.schema.json"))
+
+
+def test_literature_corpus_entry_contract_remains_unmodified_for_version_families():
+    """Kong #258 keeps version-family data in sidecar, not literature_corpus_entry."""
+    literature_schema = _schema("literature_corpus_entry.schema.json")
+    props = literature_schema["properties"]
+    assert "version_family_id" not in props
+    assert "version_records" not in props
+
+
+def test_kong_258_agent_and_formatter_markers_present():
+    timeline_agent = (REPO_ROOT / "deep-research/agents/timeline_extraction_agent.md").read_text()
+    draft_writer = (REPO_ROOT / "academic-paper/agents/draft_writer_agent.md").read_text()
+    formatter = (REPO_ROOT / "academic-paper/agents/formatter_agent.md").read_text()
+
+    assert "## Academic Citation Version Discovery (Kong #258)" in timeline_agent
+    assert "phase2_investigation/version_records.yaml" in timeline_agent
+    assert "## Citation Version-Family Check (Kong #258)" in draft_writer
+    assert "VERSION_INCONSISTENT_CITATION" in draft_writer
+    assert "## Citation Version-Family Advisory (Kong #258)" in formatter
+    assert "VERSION_INCONSISTENT_CITATION" in formatter
+
+
+def test_kong_258_design_doc_documents_127_boundary_and_example_exists():
+    design = (REPO_ROOT / "docs/design/2026-05-28-kong-258-version-family-reconciliation.md").read_text()
+    example = REPO_ROOT / "academic-paper/examples/version_family_reconciliation_example.md"
+    assert "#127 Boundary" in design
+    assert "literature_corpus_entry.schema.json" in design
+    assert "remains unchanged" in design
+    assert "VERSION_INCONSISTENT_CITATION" in design
+    assert example.exists()

--- a/shared/contracts/README.md
+++ b/shared/contracts/README.md
@@ -55,6 +55,10 @@ Schemas for Material Passport input ports.
   states (proposal / persisted) share the schema via `oneOf`. Cross-artifact invariants
   are enforced by `scripts/check_audit_artifact_consistency.py`. Spec:
   `docs/design/2026-04-30-ars-v3.6.7-step-6-orchestrator-hooks-spec.md` §3.1-§3.2.
+- `passport/version_records.schema.json` (Kong #258) — optional
+  `phase2_investigation/version_records.yaml` sidecar for academic citation version
+  families (preprint -> proceedings -> journal extension). This is deliberately a
+  sidecar: `literature_corpus_entry.schema.json` stays adapter-owned and unmodified.
 
 ## Audit artifact contracts (v3.6.7 Step 6)
 

--- a/shared/contracts/passport/version_records.schema.json
+++ b/shared/contracts/passport/version_records.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/passport/version_records.schema.json",
+  "title": "Material Passport Version Records (phase2_investigation/version_records.yaml)",
+  "description": "Aggregate schema for academic citation version-family reconciliation. Per Kong #258. Owned by timeline_extraction_agent; literature_corpus_entry.schema.json remains unmodified.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "version_records"],
+  "properties": {
+    "schema_version": {
+      "const": "1.0",
+      "description": "Schema-internal version. Kong #258 ships 1.0."
+    },
+    "version_records": {
+      "type": "array",
+      "description": "One record per academic work version family, such as preprint -> proceedings -> journal extension.",
+      "items": { "$ref": "#/$defs/version_family_record" }
+    }
+  },
+  "$defs": {
+    "key": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_:-]*$"
+    },
+    "arxiv_id": {
+      "type": "string",
+      "pattern": "^([A-Za-z][A-Za-z0-9-]*(\\.[A-Za-z0-9-]+)*/\\d{7}(v[1-9]\\d*)?|\\d{4}\\.\\d{4,5}(v[1-9]\\d*)?)$"
+    },
+    "date_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "precision"],
+      "properties": {
+        "value": { "type": ["string", "null"] },
+        "precision": { "enum": ["day", "month", "year", "unknown"] }
+      }
+    },
+    "version_family_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version_family_id", "canonical_slug", "discovery_status", "known_versions"],
+      "properties": {
+        "version_family_id": {
+          "$ref": "#/$defs/key",
+          "description": "Stable family key. Joins to timeline.yaml sources[].version_family_id when present."
+        },
+        "canonical_slug": {
+          "$ref": "#/$defs/key",
+          "description": "Preferred citation slug for the family, not necessarily a concrete version."
+        },
+        "primary_version_key": {
+          "type": ["string", "null"],
+          "description": "Scholar-selected version_key to render by default. Null means user confirmation is pending."
+        },
+        "discovery_status": {
+          "enum": ["candidate", "user_confirmed", "rejected", "needs_review"],
+          "description": "Advisory discovery state. Only user_confirmed should drive final citation standardization."
+        },
+        "reconciliation_note": {
+          "type": ["string", "null"],
+          "description": "Optional scholar-facing note explaining version choice or unresolved ambiguity."
+        },
+        "known_versions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/known_version" }
+        }
+      }
+    },
+    "known_version": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version_key", "kind", "title", "year", "metadata_provenance"],
+      "properties": {
+        "version_key": {
+          "$ref": "#/$defs/key",
+          "description": "Stable key for this concrete version within the family."
+        },
+        "citation_key": {
+          "type": ["string", "null"],
+          "description": "Optional join to literature_corpus[].citation_key when this concrete version has its own corpus entry."
+        },
+        "kind": {
+          "enum": [
+            "arxiv_preprint",
+            "proceedings",
+            "journal_article",
+            "book",
+            "book_chapter",
+            "report",
+            "dataset",
+            "other"
+          ]
+        },
+        "title": { "type": "string", "minLength": 1 },
+        "year": { "type": "integer", "minimum": 1000, "maximum": 2100 },
+        "venue": { "type": ["string", "null"] },
+        "doi": {
+          "type": ["string", "null"],
+          "pattern": "^10\\.[0-9]{4,9}/[^\\s]+$"
+        },
+        "arxiv_id": {
+          "anyOf": [
+            { "$ref": "#/$defs/arxiv_id" },
+            { "type": "null" }
+          ]
+        },
+        "url": { "type": ["string", "null"] },
+        "publication_date": {
+          "anyOf": [
+            { "$ref": "#/$defs/date_object" },
+            { "type": "null" }
+          ]
+        },
+        "metadata_provenance": {
+          "enum": [
+            "crossref_lookup",
+            "openalex_lookup",
+            "arxiv_api",
+            "adapter_metadata",
+            "user_override",
+            "manual",
+            "unknown"
+          ]
+        },
+        "source_locator": {
+          "type": ["string", "null"],
+          "description": "Concrete URL, DOI, arXiv locator, local PDF page, or KB pointer used to verify this version."
+        },
+        "claim_scope_note": {
+          "type": ["string", "null"],
+          "description": "What kinds of quoted text or claims are safe to attribute to this concrete version."
+        },
+        "notes": { "type": ["string", "null"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Ref #258 (Kong A3) — sub-issue closes at v3.11 release tag along with #256 / #257 / #259, not at this PR merge.
Tracking: META #255

[skip-closes-check] This PR uses `Ref #258` instead of `Closes #258` per Kong Tier A release-coordination convention: all 4 Tier A sub-issues (#256/#257/#258/#259) close together at the v3.11 release tag, not individually at each implementation PR. This keeps the META #255 sub-issue checklist visible until v3.11 ships.

Adds a sidecar-based version-family reconciliation protocol for academic citations, covering arXiv / proceedings / journal variants without mutating the literature corpus passport schema or touching `bibliography_agent`.

## Changes

- Add `shared/contracts/passport/version_records.schema.json` for `phase2_investigation/version_records.yaml`.
- Extend `timeline_extraction_agent` to discover and record citation version families.
- Add draft writer and formatter advisory checks for version-inconsistent citation rendering.
- Add a preprint-vs-proceedings inconsistency example.
- Document the #127 policy boundary versus #258 version consistency.

## Validation

- `python -m pytest scripts/test_version_records_schema.py`
- `python -m pytest scripts/test_check_v3_9_4_temporal_verification.py`
- `python scripts/check_spec_consistency.py`
- `python scripts/check_version_consistency.py`
- `python scripts/check_task_type.py`
- `python scripts/check_data_access_level.py`
- `python -m pytest scripts/test_check_v3_9_2_phase_boundary.py`
- `python -m pytest scripts/test_check_spec_consistency.py`
- `python -m pytest scripts/test_check_version_consistency.py`
- `git diff --check`
