### PR TITLE
fix(release): align plugin manifests to v3.10.0 + guard them in the version lint

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "academic-research-skills",
       "source": "./",
       "description": "4 skills + 35+ modes + Material Passport pipeline. Includes v3.6.7 cross-model audit gate and v3.6.8 generator-evaluator contract.",
-      "version": "3.7.0",
+      "version": "3.10.0",
       "license": "CC-BY-NC-4.0"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research-skills",
-  "version": "3.9.4.2",
+  "version": "3.10.0",
   "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 38-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.9.2 phase boundary fence (#133).",
   "author": {
     "name": "Cheng-I Wu",

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -8,12 +8,18 @@ Invariants enforced:
      "## [X.Y.Z]" entry in CHANGELOG.md.
   3. academic-pipeline version in the table equals the suite version (pipeline
      = orchestrator, by convention tracks the suite release).
+  4. The plugin manifests (.claude-plugin/plugin.json "version" and
+     .claude-plugin/marketplace.json plugins[].version) equal the suite version.
+     These are the repo's OUTWARD-FACING package metadata — a user updating the
+     plugin sees them — and were the one surface a v3.10.0 release-doc pass missed
+     because no lint covered them (marketplace had silently sat at 3.7.0).
 
 Runs from repo root by default; `--path` lets tests point at a fake tree.
 """
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -189,6 +195,64 @@ def check(root: Path) -> list[str]:
                 f"v{pipeline_in_table} but suite version is {suite_version!r} "
                 "(pipeline tracks the suite release)"
             )
+
+    # Invariant 4: plugin manifests track the suite version (outward-facing
+    # package metadata). Only checked when a suite version is known.
+    if suite_version is not None:
+        errors.extend(_check_plugin_manifests(root, suite_version))
+
+    return errors
+
+
+def _check_plugin_manifests(root: Path, suite_version: str) -> list[str]:
+    """Invariant 4: .claude-plugin/plugin.json "version" and every
+    .claude-plugin/marketplace.json plugins[].version equal the suite version.
+    Missing files / malformed JSON / missing version keys are surfaced, never
+    crash (a release lint must report drift, not blow up on it)."""
+    errors: list[str] = []
+
+    plugin_json = root / ".claude-plugin" / "plugin.json"
+    if not plugin_json.is_file():
+        errors.append(f"{plugin_json}: not found")
+    else:
+        try:
+            data = json.loads(plugin_json.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError) as exc:
+            errors.append(f"{plugin_json}: invalid JSON ({exc})")
+        else:
+            v = data.get("version")
+            if v is None:
+                errors.append(f"{plugin_json}: missing 'version' key")
+            elif str(v) != suite_version:
+                errors.append(
+                    f"{plugin_json}: version {str(v)!r} does not match suite "
+                    f"version {suite_version!r}"
+                )
+
+    marketplace = root / ".claude-plugin" / "marketplace.json"
+    if not marketplace.is_file():
+        errors.append(f"{marketplace}: not found")
+    else:
+        try:
+            data = json.loads(marketplace.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError) as exc:
+            errors.append(f"{marketplace}: invalid JSON ({exc})")
+        else:
+            plugins = data.get("plugins")
+            if not isinstance(plugins, list) or not plugins:
+                errors.append(f"{marketplace}: 'plugins' is missing or empty")
+            else:
+                for i, entry in enumerate(plugins):
+                    v = (entry or {}).get("version") if isinstance(entry, dict) else None
+                    if v is None:
+                        errors.append(
+                            f"{marketplace}: plugins[{i}] missing 'version' key"
+                        )
+                    elif str(v) != suite_version:
+                        errors.append(
+                            f"{marketplace}: plugins[{i}] version {str(v)!r} does "
+                            f"not match suite version {suite_version!r}"
+                        )
 
     return errors
 

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -80,6 +80,20 @@ def _write_changelog(
     )
 
 
+def _write_plugin_manifests(root: Path, version: str) -> None:
+    """Fixture .claude-plugin/{plugin,marketplace}.json at `version` (invariant 4)."""
+    import json
+    plugin_dir = root / ".claude-plugin"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps({"name": "fixture", "version": version}), encoding="utf-8"
+    )
+    (plugin_dir / "marketplace.json").write_text(
+        json.dumps({"name": "fixture", "plugins": [{"name": "fixture", "version": version}]}),
+        encoding="utf-8",
+    )
+
+
 def _write_aligned_fixture(root: Path) -> None:
     """Everything lines up — baseline for PASS cases and drift mutations."""
     skills = [
@@ -92,6 +106,7 @@ def _write_aligned_fixture(root: Path) -> None:
         _write_skill(root, name, ver)
     _write_claude_md(root, suite_version="3.5.0", table_rows=skills)
     _write_changelog(root, latest_version="3.5.0")
+    _write_plugin_manifests(root, "3.5.0")
 
 
 def _write_aligned_fixture_v351(root: Path) -> None:
@@ -106,6 +121,7 @@ def _write_aligned_fixture_v351(root: Path) -> None:
         _write_skill(root, name, ver)
     _write_claude_md(root, suite_version="3.5.1", table_rows=skills)
     _write_changelog(root, latest_version="3.5.1")
+    _write_plugin_manifests(root, "3.5.1")
 
 
 class TestVersionConsistency(unittest.TestCase):
@@ -153,6 +169,38 @@ class TestVersionConsistency(unittest.TestCase):
             self.assertIn("3.5.0", result.stdout)
             self.assertIn("3.4.0", result.stdout)
             self.assertIn("CHANGELOG", result.stdout)
+
+    def test_plugin_json_version_drift_fails(self) -> None:
+        """Invariant 4: .claude-plugin/plugin.json version != suite — must fail.
+        (Regression for the v3.10.0 release miss: plugin.json sat at the prior
+        version because no lint covered it.)"""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)  # suite 3.5.0
+            _write_plugin_manifests(root, "3.4.0")  # drift both manifests down
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("plugin.json", result.stdout)
+            self.assertIn("3.4.0", result.stdout)
+            self.assertIn("3.5.0", result.stdout)
+
+    def test_marketplace_version_drift_fails(self) -> None:
+        """Invariant 4: marketplace.json plugins[].version != suite — must fail.
+        (Regression for marketplace.json silently sitting at 3.7.0 for releases.)"""
+        import json
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)  # suite 3.5.0; plugin.json aligned at 3.5.0
+            # Drift ONLY marketplace, leaving plugin.json correct, to isolate it.
+            (root / ".claude-plugin" / "marketplace.json").write_text(
+                json.dumps({"name": "fixture",
+                            "plugins": [{"name": "fixture", "version": "3.7.0"}]}),
+                encoding="utf-8",
+            )
+            result = _run(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("marketplace.json", result.stdout)
+            self.assertIn("3.7.0", result.stdout)
 
     def test_pipeline_version_vs_suite_drift_fails(self) -> None:
         """academic-pipeline version in table must equal suite version."""


### PR DESCRIPTION
## Summary

Follow-up to the v3.10.0 release: the release-docs pass aligned CLAUDE.md / SKILL.md /
CHANGELOG / READMEs but **missed the two plugin manifests** — the repo's outward-facing
package metadata that a user sees when updating the plugin.

- `.claude-plugin/plugin.json` `version` sat at `3.9.4.2`
- `.claude-plugin/marketplace.json` `plugins[].version` had silently sat at `3.7.0` since v3.7.0

Both now read `3.10.0`.

## Root cause + the guard

No lint covered these surfaces: `check_version_consistency.py` only checked CLAUDE.md /
SKILL.md / CHANGELOG; `check_spec_consistency.py` ignores the plugin manifests. So
marketplace.json drifted across several releases unnoticed. This PR adds **invariant 4** to
`check_version_consistency.py` — both manifests' plugin version must equal the suite version —
with positive + negative unit tests (plugin.json drift and marketplace.json drift each fail
the lint). The blind spot is now closed.

## Why the tag isn't re-cut

The `v3.10.0` tag points at the release content and stays put. The manifest version string is
cosmetic metadata; this follow-up commit on main corrects it without a disruptive force-retag.

## Verification

- `check_version_consistency` (with new invariant 4) + `check_spec_consistency` pass.
- Full suite 1921 passed / 3 skipped (+2 invariant-4 tests).

`[skip-closes-check]` — release-hygiene follow-up; does not close a single tracked issue (it
corrects a metadata miss from the v3.10.0 release cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
