### PR TITLE
docs: land Co-Scientist boundary docs (L1-L4)

### DIFF
--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -49,6 +49,8 @@ These reflect our policy intent. See the [CC BY-NC 4.0 license](https://creative
 
 **Failure modes are made visible, not hidden.** The 7-mode AI Research Failure Mode Checklist (v3.2) and Reviewer Calibration Mode exist so that users can see where the AI might be wrong — not so that the AI can claim it's always right. The v3.7.3 + v3.8 L3 claim-faithfulness gate adds per-citation locator anchors and an opt-in audit pass that verifies whether each cited source actually supports the claim made of it.
 
+**Boundaries are recorded, not improvised.** When adopting a capability from a published system would touch a load-bearing boundary — who ranks, what propagates, who writes state — the decision of whether and how to adopt it is written down as a design-lesson doc, so the same boundary is applied consistently later. The Co-Scientist (Gottweis et al. 2026) analysis is recorded in four such docs: hidden-ranking vs. advisory ranking ([L1](docs/design/2026-06-02-co-scientist-220-l1-hidden-ranking.md)), unapproved feedback propagation ([L2](docs/design/2026-06-02-co-scientist-221-l2-feedback-propagation.md)), which mechanisms transfer to ARS and which do not ([L3](docs/design/2026-06-02-co-scientist-222-l3-transfer-matrix.md)), and control-plane ownership — who may write, rank, or route ([L4](docs/design/2026-06-02-co-scientist-223-l4-control-plane-ownership.md)).
+
 ## Citing this tool
 
 If you use ARS in your research, please cite it:

--- a/docs/design/2026-06-02-co-scientist-220-l1-hidden-ranking.md
+++ b/docs/design/2026-06-02-co-scientist-220-l1-hidden-ranking.md
@@ -1,0 +1,101 @@
+# Co-Scientist L1 — hidden ranking is the red line, not Elo itself
+
+| | |
+|---|---|
+| **Status** | Design lesson — **NOT a proposed feature** |
+| **Issue** | [#220](https://github.com/Imbad0202/academic-research-skills/issues/220) |
+| **Parent epic** | [#219](https://github.com/Imbad0202/academic-research-skills/issues/219) — Co-Scientist implications for ARS |
+| **Paper anchor** | Gottweis et al. (2026), *Accelerating scientific discovery with Co-Scientist*, Nature. DOI [10.1038/s41586-026-10644-y](https://doi.org/10.1038/s41586-026-10644-y) |
+| **Verified** | 2026-06-02 — fully verified against the codebase (see Verification note) |
+
+This is a recorded boundary, not a roadmap item. It exists so that future work and
+reviews apply the same line consistently.
+
+## Anchor
+
+- **Paper**: Co-Scientist's Ranking agent (paper L1661–1685) uses Elo-based
+  tournaments with pairwise debate to rank hypotheses. Top-ranked candidates enter
+  multi-turn debate; lower-ranked candidates get single-turn comparisons. The agent
+  selects the top-K for downstream stages.
+- **ARS**: `POSITIONING.md` — "the human decides at every gate" (Design philosophy).
+  The 10-stage pipeline + mandatory user confirmation does not delegate selection
+  decisions to AI.
+
+## Problem
+
+A naive cross-walk would label "Elo + tournament" as fundamentally incompatible
+with ARS. That read is wrong.
+
+The real conflict is not the **algorithm** (Elo, pairwise comparison) but the
+**system behavior** (AI ranks → AI selects top-K → user sees only the survivors).
+The algorithm can be retained if the system behavior changes.
+
+## Boundary
+
+### Red line — DO NOT IMPLEMENT
+
+AI ranks N candidates → AI selects top-K based on its own scores → user sees only
+the survivors.
+
+This is hidden selection pressure. Even if the user nominally "approves" the
+survivors, their judgment is anchored on a filtered set whose filter criterion they
+cannot audit.
+
+### Yellow line — implementable with three conditions
+
+AI ranks N candidates → user sees ALL candidates → user picks → scores and
+reasoning are revealed. The ranking informs the design but does not pre-filter or
+pre-anchor what the user sees.
+
+Three conditions for the implementation to stay on the yellow line:
+
+1. **All candidates visible.** No silent culling. If N=10 candidates exist, all 10
+   reach the user.
+2. **Blinded presentation.** The AI's scores and rank labels are not shown
+   alongside the candidates up front (they would anchor the user to the AI's
+   ranking). Candidates carry anonymous identifiers (Option A, Option B, …); the
+   scores become available only after the user has formed an initial preference
+   (automatically or on request), and are never used as the default sort key or a
+   visible badge.
+3. **Randomized order.** First-position bias is well-documented. Presentation order
+   is randomized per session, not "top-scored first".
+
+### Green line — preferred default
+
+AI enumerates candidates without ranking. User reads, reasons, and ranks
+themselves.
+
+## Why this distinction matters
+
+The boundary is load-bearing because algorithm-level rejection ("no Elo, ever")
+loses useful primitives: pairwise comparison is a strong tool for surfacing
+trade-offs the user might miss, even when the user makes the final selection.
+Behavior-level rejection ("no hidden culling, ever") keeps the primitive while
+preserving the discipline.
+
+The reverse is equally true. Permitting "Elo in advisory mode" without the three
+conditions silently re-introduces the anchoring pressure, because score labels
+alone are sufficient to anchor user judgment.
+
+## Application — when this is invoked
+
+Any PR that introduces ranking, scoring, pairwise comparison, Elo, tournaments, or
+top-K selection of candidates is reviewed against the three yellow-line conditions
+above before merge. A change that lets the system narrow a candidate set the user
+never fully sees crosses the red line and is rejected regardless of how the scores
+are computed.
+
+The sibling docs build on this line:
+[L2](2026-06-02-co-scientist-221-l2-feedback-propagation.md) (feedback
+propagation), [L3](2026-06-02-co-scientist-222-l3-transfer-matrix.md) (mechanism
+transfer; its "all candidates visible" transfer conditions point here), and
+[L4](2026-06-02-co-scientist-223-l4-control-plane-ownership.md) (who may rank).
+
+## Verification note
+
+Verified against the codebase 2026-06-02. "The human decides at every gate" is
+present in `POSITIONING.md`; the 10-stage pipeline and mandatory user confirmation
+are real (`academic-pipeline/SKILL.md`). No Elo, tournament, top-K, or
+candidate-ranking mechanism exists in ARS today — so the claim "ARS has no hidden
+ranking" is a verified fact, not merely an aspiration. This doc therefore records a
+boundary for *future* work, not a description of an existing component.

--- a/docs/design/2026-06-02-co-scientist-221-l2-feedback-propagation.md
+++ b/docs/design/2026-06-02-co-scientist-221-l2-feedback-propagation.md
@@ -1,0 +1,104 @@
+# Co-Scientist L2 — unapproved feedback propagation is the red line, not feedback propagation itself
+
+| | |
+|---|---|
+| **Status** | Design lesson — **NOT a proposed feature** |
+| **Issue** | [#221](https://github.com/Imbad0202/academic-research-skills/issues/221) |
+| **Parent epic** | [#219](https://github.com/Imbad0202/academic-research-skills/issues/219) — Co-Scientist implications for ARS |
+| **Paper anchor** | Gottweis et al. (2026), *Accelerating scientific discovery with Co-Scientist*, Nature. DOI [10.1038/s41586-026-10644-y](https://doi.org/10.1038/s41586-026-10644-y) |
+| **Verified** | 2026-06-02 — fully verified against the codebase (see Verification note) |
+
+This is a recorded boundary, not a roadmap item.
+
+## Anchor
+
+- **Paper**: The Meta-review agent (paper L1498–1503, L1762–1775) "generates
+  feedback applicable to all agents, which is simply appended to their prompts in
+  the next iteration — a capability facilitated by the long-context search and
+  reasoning capabilities of the underlying Gemini models."
+- **ARS**: `POSITIONING.md` — "Failure modes are made visible, not hidden." The
+  7-mode AI Research Failure Mode Checklist (v3.2) and Reviewer Calibration Mode
+  exist so the user can see where the AI might be wrong.
+
+## Problem
+
+Co-Scientist's Meta-review agent enables learning across iterations without
+back-propagation: it observes patterns from a run's reviews and tournament debates,
+then appends synthesized feedback into the system prompts of other agents for
+subsequent iterations. The mechanism is elegant for the paper's hypothesis-
+generation paradigm.
+
+The same mechanism, imported into ARS unmodified, would silently mutate the
+behavior of downstream agents in ways the user cannot see. A user observing the
+output cannot tell whether a synthesis-stage agent is following its baseline prompt
+or operating under a meta-review patch derived from upstream stages. That is hidden
+behavior change, which conflicts with ARS positioning.
+
+The conflict is not feedback propagation itself. The conflict is **unapproved**
+feedback propagation.
+
+## Boundary
+
+### Red line — DO NOT IMPLEMENT
+
+An observer collects patterns from upstream stages → the system auto-appends
+synthesized feedback to a downstream agent's prompt → the user is not informed.
+
+This is invisible behavior change. The user's confidence in the downstream output
+assumes the baseline prompt is in effect, but the actual prompt has been mutated.
+
+### Yellow line — implementable with a user-approval gate
+
+An observer collects patterns from upstream stages → the system surfaces the
+patterns as an advisory artifact at the next checkpoint → the user reviews and
+approves (or rejects, or edits) → THEN the approved feedback is injected into the
+downstream agent's prompt.
+
+The user-approval gate is load-bearing. It is the difference between "AI helps the
+user calibrate the system" (yellow) and "AI silently calibrates the system" (red).
+
+### Green line — preferred default
+
+Observer surfaces patterns as an advisory artifact only. The user reads the
+artifact, optionally adjusts their own instructions in the next round, but no
+automatic prompt injection occurs.
+
+## Why this distinction matters
+
+The Co-Scientist paper presents the no-back-prop feedback loop as a strength: it
+scales learning without training, requires no fine-tuning, and operates within the
+same context window. All three are true.
+
+For ARS, the same property is a liability. Without the user-approval gate, a user
+cannot perform the integrity check that `POSITIONING.md` promises ("Failure modes
+are made visible"). The user's understanding of why a given output looks the way it
+does must remain reconstructible from the artifacts the user has seen.
+
+## Application — when this is invoked
+
+For any ARS feature that proposes cross-stage learning, observer agents, or feedback
+propagation, the design review must answer: does the propagated feedback reach a
+downstream agent's prompt without passing a user-visible approval checkpoint? If
+yes, it crosses the red line. A monotonic provenance flag carried forward unchanged
+(see Verification note) is not feedback propagation; an observer that *rewrites a
+downstream agent's instructions* is. The boundary is the prompt mutation, not the
+information flow.
+
+See [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md) for the
+visible-to-the-user principle this shares, and
+[L4](2026-06-02-co-scientist-223-l4-control-plane-ownership.md) for who may write
+state.
+
+## Verification note
+
+Verified against the codebase 2026-06-02. "Failure modes are made visible, not
+hidden" is present in `POSITIONING.md`; the 7-mode AI Research Failure Mode
+Checklist (v3.2) and Reviewer Calibration Mode both exist
+(`academic-pipeline/references/ai_research_failure_modes.md`,
+`academic-paper-reviewer/references/calibration_mode_protocol.md`). No mechanism in
+ARS auto-appends synthesized feedback into a downstream agent's prompt across
+iterations. The only cross-stage value carried forward is a monotonic `slr_lineage`
+provenance flag (it records that a run originated in a systematic-review context;
+it does not mutate any agent's prompt). So the claim "ARS does not silently
+propagate feedback" is a verified fact. This doc records a boundary for future
+work.

--- a/docs/design/2026-06-02-co-scientist-222-l3-transfer-matrix.md
+++ b/docs/design/2026-06-02-co-scientist-222-l3-transfer-matrix.md
@@ -1,0 +1,112 @@
+# Co-Scientist L3 — which mechanisms transfer to ARS QA, and which do not
+
+| | |
+|---|---|
+| **Status** | Design lesson — **NOT a proposed feature** |
+| **Issue** | [#222](https://github.com/Imbad0202/academic-research-skills/issues/222) |
+| **Parent epic** | [#219](https://github.com/Imbad0202/academic-research-skills/issues/219) — Co-Scientist implications for ARS |
+| **Paper anchor** | Gottweis et al. (2026), *Accelerating scientific discovery with Co-Scientist*, Nature. DOI [10.1038/s41586-026-10644-y](https://doi.org/10.1038/s41586-026-10644-y) |
+| **Verified** | 2026-06-02 — transfer matrix reconciled against the codebase; several originating bindings corrected (see Verification note) |
+
+This is a recorded boundary, not a roadmap item.
+
+## Anchor
+
+- **Paper**: A six-agent multi-agent system designed for *hypothesis generation* in
+  biomedicine, with continuous test-time compute scaling reported across 203
+  research goals.
+- **ARS**: `POSITIONING.md` — "a source-available academic research copilot
+  framework" with mandatory checkpoints, max 2 revision loops, and an explicit
+  non-claim of autonomy.
+
+## Problem
+
+Co-Scientist and ARS share the multi-agent shape but serve different epistemic
+roles. Co-Scientist generates novel hypotheses for experimental validation. ARS
+supports a human researcher through the research-to-publication workflow, with
+quality assurance as the load-bearing function.
+
+A naive "the paper has six agents, ARS should adopt the six-agent design" approach
+would silently change the role ARS plays in the user's research life. A naive "the
+paper and ARS are entirely different, nothing transfers" approach would miss
+genuinely useful primitives. This document records the boundary, mechanism by
+mechanism.
+
+> **The ARS-side cells below were re-derived from the current codebase (2026-06-02),
+> not copied from the originating issue.** Several of the issue's original bindings
+> projected Co-Scientist vocabulary onto ARS components that do not match. The
+> corrected mapping is what stands; the Verification note lists what changed.
+
+## The transferable mechanisms
+
+These can be adopted into ARS when re-framed for the human-leads workflow:
+
+| Co-Scientist mechanism | ARS analogue (verified) | Transfer condition |
+|---|---|---|
+| Enumeration of alternative hypotheses | **No current analogue.** ARS's `synthesis_agent` is a Phase-3 cross-source *integration* agent (it produces a Synthesis Report — literature matrix, themes, contradictions, gaps); it does not enumerate competing framings. | **Green-line candidate.** If candidate-framing enumeration is added, all candidates must reach the user with no hidden culling (see [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md)). |
+| Structured critique log (Reflection agent's deep verification review) | `source_verification_agent` produces a **Source Quality Matrix** (Source × Level / Venue / Author / Method / Currency / COI), grading the evidence hierarchy. | The matrix is for the user to read. A genuine extension would be a sub-assumption × evidence decomposition; that does not exist today and would be additive, not a relabeling of the quality matrix. |
+| Append-only correction / ADD-based variant | **No current analogue.** ARS has no competing-draft fork mechanism. | **Green-line candidate.** If an append-only competing-draft variant is ever added, it must be user-invoked with both drafts visible for A/B selection (per [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md)). This row records the *constraint*, not a commitment to build it. |
+| Observation review (does H explain long-tail observations?) | `devils_advocate_agent` critique at its post-analysis checkpoint (Checkpoint 2 of three). | The DA runs single-pass *per checkpoint*; multi-turn background self-play debate is rejected (see Non-transferable). Note: the DA has **three** mandatory checkpoints overall, not a single pass across the run. |
+| External grounding via web search + databases | `bibliography_agent` verification chain: Semantic Scholar (Tier 0) → DOI resolution (Tier 1) → WebSearch spot-check (Tier 2); contamination triangulation adds OpenAlex + Crossref (v3.9.0). | Verified and unverified sources are presented in separate columns with explicit source labels. (ARS does **not** have a "Semantic Scholar → PubMed/arXiv" search fallback; PubMed is a predatory-venue red-flag criterion and arXiv is a preprint-venue label, not search fallbacks.) |
+
+## The non-transferable mechanisms
+
+These conflict with ARS positioning at the paradigm level. Adoption would require
+changing ARS positioning, not just adapting the mechanism:
+
+| Co-Scientist mechanism | ARS conflict |
+|---|---|
+| Open-ended test-time compute scaling (paper L411 "no saturation observed") | Conflicts with `POSITIONING.md`: "Max 2 revision loops, after which remaining issues become 'Acknowledged Limitations' rather than being silently resolved." |
+| Autonomous selection of top-K hypotheses (Ranking agent's tournament outcome) | Conflicts with `POSITIONING.md`: "the human decides at every gate." See [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md). |
+| Hidden prompt patching via Meta-review feedback propagation | Conflicts with `POSITIONING.md`: "Failure modes are made visible, not hidden." See [L2](2026-06-02-co-scientist-221-l2-feedback-propagation.md). |
+| Domain expert contact identification (paper L1787–1792) | ARS does not identify or surface named individuals as contacts: it works from published sources, not from a directory of people to approach. Adopting this would add a person-targeting capability the framework deliberately does not have. |
+| Multi-turn self-play debate inside an agent for high-stakes evaluation | Conflicts with "Failure modes are made visible" — multi-turn background reasoning collapses into a summary that hides the reasoning trajectory. |
+| Wet-lab / AlphaFold-style domain-specific autonomous loops | Out of scope for a general academic workflow framework. |
+
+## The agents
+
+Mapping the paper's six agents to ARS equivalents (verified against the
+`deep-research/agents/` roster and `academic-pipeline/agents/`):
+
+| Paper agent | ARS equivalent? | Notes |
+|---|---|---|
+| Generation | Partial | `synthesis_agent` produces integrated findings (Phase 3), not candidate enumeration. Adopting enumeration would be a green-line addition (see [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md)). |
+| Reflection | Yes | `source_verification_agent`, `devils_advocate_agent`, `risk_of_bias_agent` (Cochrane RoB 2 / ROBINS-I). ARS's verification layer is strong; a sub-assumption × evidence decomposition is the genuine gap. |
+| Ranking | No, deliberately | No Elo / tournament / top-K mechanism exists. See [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md) for the red / yellow / green analysis. |
+| Proximity | Not adopted | Volume mismatch; ARS does not generate hundreds of candidates per goal. |
+| Evolution | Partial | revision-coach + draft re-entry exist. A competing-draft fork variant is a green-line candidate (above); replacing drafts in tournament fashion is rejected. |
+| Meta-review | Partial | v3.6.7 PATTERN PROTECTION blocks and the v3.5 `collaboration_depth_agent` (advisory-only). See [L2](2026-06-02-co-scientist-221-l2-feedback-propagation.md) for the user-approval-gate analysis. |
+
+## Application — when this is invoked
+
+When evaluating whether a Co-Scientist (or similar auto-research) mechanism belongs
+in ARS, consult this matrix to determine transferability. A mechanism in the
+non-transferable table requires a positioning change, not just an adapter. A
+"green-line candidate" cell states a constraint on *future* work, not a feature
+request — it does not authorize building the thing, only the shape it must
+take if built.
+
+## Verification note
+
+Verified against the codebase 2026-06-02. The originating issue's transfer matrix
+cited eight ARS internals; six did not match the codebase and are corrected here:
+
+- `synthesis_agent` "produces N candidate framings" → it is a Phase-3 integration
+  agent; no candidate enumeration. Recorded as a green-line candidate instead.
+- `source_verification_agent` "sub-assumption × evidence matrix" → real output is a
+  Source Quality Matrix; the sub-assumption decomposition is a non-existent
+  (additive) extension, not the current behavior.
+- `ARS_REVISION_FORK=1` → **no such flag exists anywhere in the repo.** The idea is
+  kept generically (append-only competing-draft variant) with no coined flag name.
+- `devils_advocate_agent` "single-pass critique only" → it runs three mandatory
+  checkpoints; the single-pass framing applies per-checkpoint, not across the run.
+- `bibliography_agent` "fallback to PubMed / arXiv" → the real chain is S2 → DOI →
+  WebSearch (+ OpenAlex / Crossref triangulation); PubMed/arXiv are not search
+  fallbacks.
+- `risk_of_bias_agent` "reflection layer" → the agent is real, but "reflection
+  layer" is not an ARS concept; it is folded into the Reflection-equivalent row
+  above without inventing the label.
+
+Verified and kept: the v3.6.7 PATTERN PROTECTION mechanism (shipped, CI-enforced)
+and `collaboration_depth_agent` (v3.5.0, advisory-only). This reconciliation is why
+the doc is trustworthy as a standalone reference.

--- a/docs/design/2026-06-02-co-scientist-223-l4-control-plane-ownership.md
+++ b/docs/design/2026-06-02-co-scientist-223-l4-control-plane-ownership.md
@@ -1,0 +1,144 @@
+# Co-Scientist L4 — control-plane ownership: who may write, rank, route
+
+| | |
+|---|---|
+| **Status** | Design lesson — **NOT a proposed feature** |
+| **Issue** | [#223](https://github.com/Imbad0202/academic-research-skills/issues/223) |
+| **Parent epic** | [#219](https://github.com/Imbad0202/academic-research-skills/issues/219) — Co-Scientist implications for ARS |
+| **Paper anchor** | Gottweis et al. (2026), *Accelerating scientific discovery with Co-Scientist*, Nature. DOI [10.1038/s41586-026-10644-y](https://doi.org/10.1038/s41586-026-10644-y) |
+| **Verified** | 2026-06-02 — verified against the codebase; two bindings corrected (see Verification note) |
+
+This is a recorded boundary, not a roadmap item.
+
+## Anchor
+
+- **Paper**: The Context Memory component (paper L1349–1354) "stores and retrieves
+  states of the agents and the system during the course of the computation"; the
+  Meta-review agent (paper L1498–1503) appends feedback into other agents' prompts;
+  the Supervisor agent routes work across the agent coalition.
+- **ARS**: the Material Passport, with `state_tracker_agent` as the writer of
+  pipeline state; per-stage checkpoint records; `pipeline_orchestrator_agent`-led
+  routing under user confirmation. `POSITIONING.md` — "the human decides at every
+  gate."
+
+## Problem
+
+Co-Scientist and ARS both have memory, both propagate information across agents,
+and both route work between stages. The mechanisms look similar from the outside,
+but they answer different questions:
+
+- Co-Scientist's memory is a *shared mutable context* that agents read from and
+  write to. The system optimizes for collective learning across the agent coalition.
+- ARS's Material Passport is an *authority ledger*. Single-writer discipline
+  (`state_tracker_agent`), append-only semantics, and audit-grade restart safety
+  are load-bearing properties.
+
+Importing a paper-derived mechanism without making the control-plane ownership
+explicit silently shifts ARS from authority-ledger to shared-mutable-context. The
+shift is invisible at the surface — the API looks the same — but the integrity
+guarantees change.
+
+## The three questions
+
+Every paper-derived mechanism proposal must explicitly answer these. **This document
+is their canonical reference.**
+
+### 1. Who may WRITE to state?
+
+ARS state writers:
+
+- Pipeline state (Material Passport): `state_tracker_agent` is the sole writer of
+  `pipeline_state`, `current_stage`, blocking flags, and materials. One narrow,
+  controlled exception exists and proves the rule: `collaboration_depth_agent` may
+  append only to its own `collaboration_depth_history[]` through a dedicated
+  append-only interface, and never touches pipeline state. The discipline is
+  "one writer per state region", not "literally one agent writes the whole
+  passport".
+- Checkpoint records: `pipeline_orchestrator_agent` after user confirmation.
+- INSIGHT Collection: produced in the **RESEARCH stage** (`deep-research`, socratic
+  mode — `socratic_mentor_agent` with the research-question and devil's-advocate
+  agents), under the Stage-1 user-confirmed scope. It is a research-stage deliverable,
+  not a write performed by `synthesis_agent`.
+
+A new mechanism must either route its writes through these existing writers, or
+declare a **new state region** with its own single writer and the same discipline
+(audit log, append-only semantics, restart-safety guarantees). It may not add a
+second writer to an existing region.
+
+### 2. Who may RANK candidates?
+
+Permitted shapes:
+
+- AI enumerates without ranking (green line — see
+  [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md)).
+- AI surfaces scores to the user as advisory information; the user picks (yellow
+  line, with L1's three conditions).
+
+Rejected shape:
+
+- AI ranks and the system selects top-K without showing the user the full set (red
+  line — hidden culling).
+
+### 3. Who may ROUTE to the next stage?
+
+ARS routing writers:
+
+- `pipeline_orchestrator_agent` computes the next stage from the pipeline
+  configuration and the Material Passport state.
+- The user confirms each transition at a checkpoint.
+- No agent unilaterally decides what stage runs next.
+
+A new mechanism must either route through the orchestrator, or document why a new
+routing primitive does not violate the user-confirmation invariant.
+
+## Why this distinction matters
+
+The Co-Scientist paper presents shared mutable context as a strength. Within its
+paradigm that is correct: hypothesis generation benefits from continuous information
+flow across agents.
+
+ARS's paradigm is different. The Material Passport's value comes precisely from its
+single-writer discipline. The same property the paper considers limiting (state
+cannot be freely mutated by every agent) is the property that makes ARS auditable.
+
+Without the three questions above, a paper-derived mechanism can preserve the
+surface API while silently undermining the discipline. The questions force the
+design to be explicit about control-plane ownership before implementation begins.
+
+## Application — when this is invoked
+
+Any mechanism that writes state, ranks candidates, or routes between stages must
+answer the three control-plane questions above. This document is their canonical
+reference: a design that cannot answer them has not established its control-plane
+ownership, and the boundary is unmet until it can.
+
+See [L1](2026-06-02-co-scientist-220-l1-hidden-ranking.md) (who may rank) and
+[L2](2026-06-02-co-scientist-221-l2-feedback-propagation.md) (who may mutate a
+downstream prompt).
+
+## Non-goals
+
+- Not a prohibition on cross-agent information flow. Information flow is fine; the
+  question is which agent has authority to mutate state, which to rank, which to
+  route.
+- Not a claim that Co-Scientist's shared-mutable-context design is wrong. It is the
+  right design for hypothesis generation at the volume the paper operates.
+
+## Verification note
+
+Verified against the codebase 2026-06-02. Two corrections relative to the
+originating issue:
+
+1. **Naming.** The writer agent is `state_tracker_agent` (the bare `state_tracker`
+   is its schema/role field name); the orchestrator is `pipeline_orchestrator_agent`.
+   The single-writer discipline itself is verified (`state_tracker_agent` is sole
+   writer of Material Passport state), as are orchestrator-written checkpoint records
+   and orchestrator-led routing.
+2. **INSIGHT Collection attribution.** The issue listed it as a `synthesis_agent`
+   write "after Stage 1". Verified incorrect — INSIGHT Collection is a deep-research
+   RESEARCH-stage artifact, and `synthesis_agent` is a Phase-3 integration agent that
+   does not produce it. The "who may WRITE" list above reflects the corrected
+   attribution.
+
+The substance of the boundary (single-writer authority ledger, orchestrator-led
+routing under user confirmation) stands; only these labels were tightened.


### PR DESCRIPTION
Lands the four Co-Scientist (Gottweis et al. 2026) design-lesson docs as permanent
references under `docs/design/`, plus one additive `POSITIONING.md` pointer.

These are **reference material, not proposed features**. Each records a red/yellow/green
boundary for *future* work and is reconciled against the current codebase — every
ARS-side binding was re-derived rather than transcribed from its originating issue.

## What lands

| Doc | Boundary |
|---|---|
| L1 (#220) | Hidden ranking is the red line, not Elo itself — three-condition yellow line for advisory ranking. |
| L2 (#221) | Unapproved feedback propagation is the red line — the user-approval gate. |
| L3 (#222) | Which Co-Scientist mechanisms transfer to ARS and which conflict at the positioning level. |
| L4 (#223) | Control-plane ownership — the write / rank / route questions a paper-derived mechanism must answer. |

`POSITIONING.md` gains a "Boundaries are recorded, not improvised" paragraph linking all four.

## Reconciliation note

The docs are **reconciled artifacts**, not issue-body mirrors. The originating issues
projected some vocabulary onto components that do not match the codebase; those bindings
were corrected, and each doc's Verification note records exactly what changed. Most
significant: L3 found six of eight originating bindings wrong or non-existent (including
a flag name that was never coined anywhere in the repo), and L4 corrected two agent-name
bindings plus one artifact misattribution.

Closing comments on #220–#223 record the per-issue specifics; #222 notes the 6/8
reconciliation and #223 notes that the paper-derived-template acceptance was deliberately
amended (the L4 doc is canonical; no separate template ships).

Closes #220
Closes #221
Closes #222
Closes #223
Refs #219
