### PR TITLE
docs(SETUP): add Cowork enable-skill step + fix command-palette wording

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -327,6 +327,7 @@ See Anthropic's [Organize your tasks with Projects in Claude Cowork](https://sup
 3. In **Tasks**, use the left navigation panel and choose **Use an existing folder**.
 4. Select the local folder you want Cowork to work in. This creates a Cowork Project pointing at that folder.
 5. Restart Cowork after installing or updating the skill folders so the four skills register.
+6. Open **Customize → Skills**, find each of the four skills (`deep-research`, `academic-paper`, `academic-paper-reviewer`, `academic-pipeline`) under **Personal skills**, and turn on the toggle in the top-right of each skill's detail panel (it reads **Enabled** when on). A registered skill that is not enabled here will not appear in the `/` command palette and Claude will not invoke it.
 
 #### How Cowork invokes the skills
 
@@ -334,8 +335,8 @@ Claude uses each skill's `description` to judge relevance, as described in Anthr
 
 If description-based routing does not select the skill you want, Cowork also provides explicit UI surfaces described in Anthropic's [Cowork plugins documentation](https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork):
 
-- Type `/` in a Cowork Task to use the command palette and select an available skill.
-- Use the `+` capability picker to add a skill to the current Task.
+- Once a skill is enabled in **Customize → Skills** (step 6 above), type `/` in a Cowork Task to open the command palette and select it. Skills that are not enabled do not appear here.
+- Use the `+` capability picker to add an enabled skill to the current Task.
 
 ### Method 4: Use with claude.ai (web)
 

--- a/docs/SETUP.zh-TW.md
+++ b/docs/SETUP.zh-TW.md
@@ -327,6 +327,7 @@ cp -R ~/academic-research-skills/academic-pipeline ~/.claude/skills/academic-pip
 3. 在 **Tasks** 中使用左側導覽面板，選擇 **Use an existing folder**（使用既有資料夾）。
 4. 選取你希望 Cowork 在其中工作的本機資料夾。這會建立一個指向該資料夾的 Cowork Project。
 5. 安裝或更新 skill 資料夾後，請重啟 Cowork，讓四個 skills 註冊。
+6. 開啟 **Customize → Skills**，在 **Personal skills** 下找到四個 skill（`deep-research`、`academic-paper`、`academic-paper-reviewer`、`academic-pipeline`），把每個 skill 詳情面板右上角的 toggle 打開（開啟時會顯示 **Enabled**）。已註冊但未在此啟用的 skill 不會出現在 `/` command palette，Claude 也不會呼叫它。
 
 #### Cowork 如何呼叫 skills
 
@@ -334,8 +335,8 @@ Claude 會使用每個 skill 的 `description` 判斷相關性，方式如 Anthr
 
 若 description-based routing 沒有選到你想用的 skill，Cowork 也提供 Anthropic 的 [Cowork plugins documentation](https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork) 中說明的顯式 UI 入口：
 
-- 在 Cowork Task 中輸入 `/`，使用 command palette 並選取可用 skill。
-- 使用 `+` capability picker，把 skill 加入目前 Task。
+- 在 **Customize → Skills** 啟用 skill 後（上方步驟 6），在 Cowork Task 中輸入 `/` 開啟 command palette 並選取它。未啟用的 skill 不會出現在這裡。
+- 使用 `+` capability picker，把已啟用的 skill 加入目前 Task。
 
 ### 方法四：使用 claude.ai（網頁版）
 


### PR DESCRIPTION
## Problem

Discussion #306: a user followed Method 3 (Cowork), saw the correct
`~/.claude/skills/<name>/SKILL.md` path shape, restarted Desktop, but the
four skills never showed up in the `/` command palette.

## Root cause (verified by direct testing in Claude Desktop)

The symlink install **is** correct — Cowork reads `~/.claude/skills/` and the
four skills register (they appear in **Customize → Skills → Personal skills**).
But a registered skill is **not** usable until its per-skill toggle is turned on
there. Confirmed first-hand: with the toggle off a personal skill does not
appear in the `/` palette; turning it on (panel then reads **Enabled**) makes
it appear, and its Trigger is `Slash command + auto`.

Method 3 never documented this enable step, and the "type `/` and select an
available skill" line implied a freshly registered skill is selectable in the
palette without it.

## Changes

- **SETUP.md / SETUP.zh-TW.md Method 3**: add step 6 — enable each of the four
  skills in **Customize → Skills**.
- Fix the command-palette bullet to state a skill must be enabled first; skills
  that are not enabled do not appear in the palette.
- Both files kept in sync (step / H2 structure preserved).

Docs-only, no version bump. personal-boundary scan clean (0 violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)