### PR TITLE
ci(pytest): run full suite, broaden path filter

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,4 +55,8 @@ jobs:
       - name: Run test suite
         env:
           PYTHONPATH: .
+          # actions/checkout does not set origin/HEAD, so the v3.6.8
+          # pattern-protection lint cannot resolve the default branch via
+          # `git symbolic-ref`. Provide its documented env fallback.
+          GITHUB_DEFAULT_BRANCH: main
         run: pytest scripts/ tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,22 +3,26 @@ name: pytest
 on:
   pull_request:
     paths:
-      - 'scripts/adapters/**'
-      - 'scripts/check_literature_corpus_schema.py'
-      - 'scripts/check_corpus_consumer_protocol.py'
-      - 'scripts/sync_adapter_docs.py'
-      - 'shared/contracts/passport/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'shared/contracts/**'
+      - 'conftest.py'
+      - 'pyproject.toml'
+      - 'requirements-dev.txt'
+      - '.github/workflows/pytest.yml'
       - 'academic-pipeline/references/adapters/**'
       - 'academic-pipeline/references/literature_corpus_consumers.md'
       - 'deep-research/agents/bibliography_agent.md'
   push:
     branches: [main]
     paths:
-      - 'scripts/adapters/**'
-      - 'scripts/check_literature_corpus_schema.py'
-      - 'scripts/check_corpus_consumer_protocol.py'
-      - 'scripts/sync_adapter_docs.py'
-      - 'shared/contracts/passport/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'shared/contracts/**'
+      - 'conftest.py'
+      - 'pyproject.toml'
+      - 'requirements-dev.txt'
+      - '.github/workflows/pytest.yml'
       - 'academic-pipeline/references/adapters/**'
       - 'academic-pipeline/references/literature_corpus_consumers.md'
       - 'deep-research/agents/bibliography_agent.md'
@@ -48,7 +52,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt pytest
 
-      - name: Run adapter tests
+      - name: Run test suite
         env:
           PYTHONPATH: .
-        run: pytest scripts/adapters/tests/ -v
+        run: pytest scripts/ tests/


### PR DESCRIPTION
## Summary

The `pytest` workflow was named "pytest" but only ran the adapter test subset (`scripts/adapters/tests/`, ~10 files). The other ~1900 tests under `scripts/` and `tests/` never ran in CI, and the path filter only triggered on a narrow set of adapter-related paths.

This surfaced when #311 (test-helper relocation) moved 27 `scripts/test_*.py` imports and went fully green without CI running any of those tests — neither the trigger nor the run step covered them.

## Changes

- **Run step**: `pytest scripts/adapters/tests/ -v` → `pytest scripts/ tests/` (full suite, 1926 tests collected).
- **Path filter**: narrow adapter-only list → `scripts/**`, `tests/**`, `shared/contracts/**`, `conftest.py`, `pyproject.toml`, `requirements-dev.txt`, and the workflow file itself.

## Verification

- Clean pip-installed Python 3.11 venv (matches CI: only `requirements-dev.txt` + `pytest`): **1923 passed, 3 skipped**.
- `pytest scripts/ tests/` collects 1926 tests — identical to bare `pytest` (no tests dropped vs full collection).
- YAML parses; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[skip-closes-check] — CI hygiene fix, not tied to a specific feature issue.