### PR TITLE
feat(citation): arXiv resolver + verification cache (#182 Delta 1+2 data layer)

### DIFF
--- a/academic-pipeline/references/adapters/overview.md
+++ b/academic-pipeline/references/adapters/overview.md
@@ -44,7 +44,7 @@ Refer to the [`literature_corpus_entry` schema](../../../shared/contracts/passpo
 | `adapter_name` | string | Optional. |
 | `adapter_version` | string | — |
 | `arxiv_id` | string | Optional arXiv identifier for arXiv-hosted works. |
-| `contamination_signals` | object | v3.7.3 + v3.9.0 contaminated-source advisory field (spec v3.7.3 §3.2 + v3.9.0 §3.4–§3.5). |
+| `contamination_signals` | object | v3.7.3 + v3.9.0 + v3.11 contaminated-source advisory field (spec v3.7.3 §3.2 + v3.9.0 §3.4–§3.5 + v3.11 #182 Delta 1). |
 | `contamination_signals_backfilled_at` | string | v3.7.3 backfill provenance (issue #105). |
 | `description_last_audit` | null \| string | v3.7.1 trust-chain field. |
 | `description_source` | string | v3.7.1 trust-chain field. |

--- a/commands/ars-cache-invalidate.md
+++ b/commands/ars-cache-invalidate.md
@@ -1,0 +1,17 @@
+---
+description: ARS /ars-cache-invalidate — drop cached verification entries for a citation key
+model: sonnet
+---
+
+Invalidate the persistent verification cache for one citation key, so the next pipeline run re-verifies it live against Crossref / OpenAlex / Semantic Scholar / arXiv instead of returning a stale cached verdict. Use this when a citation's metadata changed (e.g. a preprint gained a published DOI) or when a prior verification looks wrong.
+
+The cache (spec v3.11 #182 Delta 2) is a local SQLite store at `~/.cache/ars/verification.db` (override via `ARS_VERIFICATION_CACHE_PATH`), keyed by `(citation_key, resolver_name, query_form)` with a 90-day TTL. This command removes **every** cached entry for the named citation key (all four resolvers, all query forms); other citations are untouched. It is idempotent — invalidating a key with no cached rows succeeds as a no-op.
+
+To invalidate the **entire** cache at once (e.g. after a systemic resolver bug cached many false negatives), delete the database file directly: `rm ~/.cache/ars/verification.db`. It is recreated empty on the next run.
+
+Implementation:
+```bash
+python3 scripts/ars_cache_invalidate.py $ARGUMENTS
+```
+
+Mode reference: `docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md` §2 Delta 2.

--- a/deep-research/references/arxiv_api_protocol.md
+++ b/deep-research/references/arxiv_api_protocol.md
@@ -1,0 +1,77 @@
+# arXiv API Verification Protocol
+
+**Status**: v3.11 (#182 Delta 1)
+**Used by**: `bibliography_agent`, `scripts/contamination_signals.py` (`resolve_arxiv_unmatched`)
+**API base**: `http://export.arxiv.org/api/query`
+**Rate limit**: arXiv asks callers to pace requests ~3s apart (https://info.arxiv.org/help/api/tou.html). No polite-pool / higher-tier mechanism.
+**Polite email env var**: none (arXiv has no such convention)
+
+---
+
+## Purpose
+
+Adds a fourth bibliographic-index lookup to the cross-index triangulation surface (S2 + OpenAlex + Crossref + arXiv) per spec v3.11 #182 Delta 1. arXiv is the preprint registry of record — strongest coverage for CS / physics / math preprints carrying an arXiv ID. It complements the three published-literature indexes: a citation with a bogus arXiv ID that fails to resolve is positive non-existence evidence, while a published paper without an arXiv ID is legitimately `skipped` by this resolver (arXiv applicability is ID-gated, not a coverage gap).
+
+Mirrors the structure of `crossref_api_protocol.md` and `openalex_api_protocol.md`.
+
+## Response format
+
+Unlike the JSON siblings, the arXiv query API returns an **Atom 1.0 XML feed**. The client parses it with `xml.etree.ElementTree`; the Atom namespace is `{http://www.w3.org/2005/Atom}`. A match yields one or more `<entry>` elements; a miss yields a feed with **zero** `<entry>` elements (not a 404). Per-entry fields the client reads:
+
+- `<entry><title>` — paper title (arXiv inserts internal whitespace/newlines, which the client collapses to single spaces before similarity comparison).
+- `<entry><published>` — ISO-8601 timestamp; the leading 4 digits are the year (matching-year tiebreaker).
+
+## Query Patterns
+
+### Pattern 1: arXiv ID Lookup with Title Cross-Check (primary when an arXiv ID is available)
+
+```
+GET ?id_list={arxiv_id}
+```
+
+**Matching rule (mirrors the Crossref/S2 `DOI_MISMATCH` pattern):** ID lookup hits are gated by a 0.70 title cross-check (same SequenceMatcher threshold as the sibling clients). If the resolved entry's title is below threshold → ID_MISMATCH, return None, fall through to title search. An empty feed (non-existent ID) is a miss → None.
+
+### Pattern 2: Title Search (fallback when no arXiv ID or ID_MISMATCH)
+
+```
+GET ?search_query=ti:"{title}"&max_results=5
+```
+
+**Matching rule:** similarity >= 0.70. When multiple candidates pass, prefer the matching-year tiebreaker via a +0.05 score bonus (year read from `<published>`).
+
+## `arxiv_unmatched` derivation
+
+`true` if and only if:
+- arXiv ID present: ID lookup either returns an empty feed (miss), misses the title cross-check, AND title search returns no match meeting threshold; OR
+- arXiv ID absent: title search alone returns no match meeting threshold.
+
+The check fires only when `obtained_via != 'manual'`.
+
+Note: the unified `lookup_verified` summary (#182 Delta 4, a later batch) narrows the existence-gate `false` to **ID-keyed** unmatched — a title-only `arxiv_unmatched` with no resolvable ID is a coverage-gap signal, not fabrication evidence (C-V6(a)). This protocol's `arxiv_unmatched` boolean is the raw triangulation signal; the narrowing happens at the Delta 4 reducer, not here.
+
+## Degradation handling
+
+| Condition | Action |
+|---|---|
+| Empty feed (zero `<entry>`) | Treat as miss — caller falls through to title search / reports unmatched. NOT a degradation. |
+| HTTP 429 (rate limit) | Back off 2 seconds, retry up to 3 times. After exhaustion, raise `ArxivUnavailable`. Throttle anchor refreshed after each backoff. |
+| HTTP 5xx | Raise `ArxivUnavailable` immediately (no retry). |
+| Network timeout (30s default) / URLError | Raise `ArxivUnavailable`. |
+| Malformed XML body (truncated / unclosed mid-stream) | Raise `ArxivUnavailable` (the read/parse narrow-except translates `ET.ParseError`, `OSError`, `http.client.IncompleteRead`). A *complete* HTML error page is well-formed XML and parses to zero entries — a miss, not a degradation. |
+| `ArxivUnavailable` raised | Caller MUST omit `arxiv_unmatched` from the entry (absent != false). Other indexes proceed independently. |
+
+## arXiv-specific notes
+
+- **Applicability is ID-gated.** A citation with no arXiv ID is only checked by title search; the unified Delta 4 summary treats arXiv as `skipped` (not `unmatched`) for non-arXiv published work, so a journal article never picks up a spurious arXiv signal.
+- **No polite pool.** arXiv has no `mailto:`-in-User-Agent tier; pacing is the fixed ~3s min-interval, longer than the Crossref/OpenAlex sub-second intervals.
+- **XML, not JSON.** This is the one structural divergence from the sibling clients — the only place the response shape differs.
+
+## Client implementation
+
+See `scripts/arxiv_client.py`. Class `ArxivClient` exposes `arxiv_id_lookup(arxiv_id, expected_title)` and `title_search(title, year=None)`. Both return `dict | None` (the dict being a projected `{title, year}` view of one Atom `<entry>`). Both raise `ArxivUnavailable` on degradation per the table above.
+
+## Cross-references
+
+- Spec: `docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md` §2 Delta 1
+- Mirror template: `deep-research/references/crossref_api_protocol.md`
+- Sibling protocols: `deep-research/references/openalex_api_protocol.md`, `deep-research/references/semantic_scholar_api_protocol.md`

--- a/scripts/ars_cache_invalidate.py
+++ b/scripts/ars_cache_invalidate.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""/ars-cache-invalidate CLI — drop cached verification entries for a citation.
+
+Backs the `/ars-cache-invalidate <citation_key>` slash command (Delta 2,
+deliverable 6). Removes every cached resolver entry (all resolvers, all query
+forms) for the named citation_key so the next pipeline run re-verifies it live.
+Idempotent: invalidating a citation with no cached rows succeeds as a no-op.
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 2.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+try:
+    from verification_cache import VerificationCache
+except ImportError:
+    from scripts.verification_cache import VerificationCache
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ars-cache-invalidate",
+        description="Drop cached verification entries for a citation_key.",
+    )
+    parser.add_argument(
+        "citation_key",
+        help="The citation_key whose cached resolver entries to invalidate.",
+    )
+    args = parser.parse_args(argv)
+
+    cache = VerificationCache()
+    cache.invalidate(args.citation_key)
+    print(f"[ars-cache-invalidate] cleared cache for '{args.citation_key}'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/arxiv_client.py
+++ b/scripts/arxiv_client.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Minimal arXiv API client wrapper.
+
+Implements the lookup contract documented at
+`deep-research/references/arxiv_api_protocol.md`. arXiv-ID-first with
+title cross-check (ID_MISMATCH pattern), title-similarity fallback,
+429 -> 2s backoff x 3 retries, network/5xx -> ArxivUnavailable. Mirrors
+`crossref_client.py` / `openalex_client.py` structure.
+
+arXiv-specific differences from the Crossref/OpenAlex siblings:
+  - The query API returns Atom 1.0 XML, NOT JSON. `_get` parses with
+    `xml.etree.ElementTree`; the Atom namespace is
+    `{http://www.w3.org/2005/Atom}`.
+  - The exact-key endpoint is keyed by arXiv ID, not DOI:
+    `?id_list={id}` for ID lookup, `?search_query=ti:"{title}"` for the
+    title fallback. The base is `http://export.arxiv.org/api/query`.
+  - There is no polite-pool email convention. Rate-limit pacing is a
+    fixed min-interval; arXiv asks callers to wait ~3s between requests
+    (https://info.arxiv.org/help/api/tou.html), so `_ARXIV_MIN_INTERVAL`
+    is 3.0s.
+
+Delta 1 of docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md.
+"""
+from __future__ import annotations
+
+import http.client
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from typing import Any
+
+# Dual-path import: see openalex_client.py comment.
+try:
+    from _text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _similarity,
+    )
+except ImportError:
+    from scripts._text_similarity import (
+        _BACKOFF_SECONDS,
+        _MAX_RETRIES,
+        _TITLE_SIMILARITY_THRESHOLD,
+        _similarity,
+    )
+
+
+_API_BASE = "http://export.arxiv.org/api/query"
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+
+# arXiv API Terms of Use ask callers to pace requests ~3s apart.
+_ARXIV_MIN_INTERVAL = 3.0
+
+
+def _extract_title(entry: ET.Element) -> str:
+    """Atom <entry><title> text; arXiv collapses internal whitespace/newlines
+    in the title, so normalize runs of whitespace to single spaces."""
+    node = entry.find(f"{_ATOM_NS}title")
+    if node is None or node.text is None:
+        return ""
+    return " ".join(node.text.split())
+
+
+def _extract_year(entry: ET.Element) -> int | None:
+    """Atom <entry><published> is ISO-8601 (e.g. 2017-06-12T...); year is the
+    leading 4 digits. Returns None when absent or unparseable."""
+    node = entry.find(f"{_ATOM_NS}published")
+    if node is None or not node.text:
+        return None
+    head = node.text[:4]
+    return int(head) if head.isdigit() else None
+
+
+def _entry_to_dict(entry: ET.Element) -> dict[str, Any]:
+    """Project an Atom <entry> into the dict shape callers consume."""
+    return {"title": _extract_title(entry), "year": _extract_year(entry)}
+
+
+class ArxivUnavailable(Exception):
+    """arXiv API degraded -- caller MUST omit `arxiv_unmatched`."""
+
+
+class ArxivClient:
+    """Production lookup-by-(arxiv-id-with-cross-check-then-title) client.
+
+    Concurrency note: rate-limit pacing is per-instance.
+    """
+
+    def __init__(self) -> None:
+        self._min_interval = _ARXIV_MIN_INTERVAL
+        self._last_request_at: float | None = None
+        self._user_agent = "ARS-v3.11"
+
+    def _throttle(self) -> None:
+        if self._last_request_at is None:
+            return
+        # time.monotonic for elapsed measurement: NTP / manual clock
+        # adjustments can make time.time go backward (#128 §6). Aligns
+        # with crossref_client.py / semantic_scholar_client.py.
+        elapsed = time.monotonic() - self._last_request_at
+        if elapsed < self._min_interval:
+            time.sleep(self._min_interval - elapsed)
+
+    def _get(self, query: dict[str, str]) -> list[ET.Element]:
+        """GET the query endpoint and return the list of Atom <entry> elements
+        (empty list when the feed has none -- arXiv's miss shape)."""
+        url = _API_BASE
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+        req = urllib.request.Request(url, headers={"User-Agent": self._user_agent})
+
+        self._throttle()
+        self._last_request_at = time.monotonic()
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    # Wrap read + parse in a narrow except so transient socket
+                    # drops mid-stream and truncated / malformed bodies surface
+                    # as ArxivUnavailable -- honoring the per-API degradation
+                    # contract (one transient failure drops only arxiv_unmatched,
+                    # never aborts the backfill). Note: a *complete* non-Atom
+                    # body (e.g. a well-formed HTML error page served with 200)
+                    # parses fine and yields zero Atom entries -- that is a miss,
+                    # not a degradation; only genuinely malformed XML raises
+                    # ParseError here. Mirrors crossref_client.py's read/parse
+                    # except (ET.ParseError replaces JSONDecodeError).
+                    try:
+                        body = resp.read()
+                        root = ET.fromstring(body)
+                    except (
+                        OSError,
+                        http.client.HTTPException,
+                        ET.ParseError,
+                    ) as e:
+                        # http.client.HTTPException covers IncompleteRead
+                        # (truncated body) which inherits HTTPException, not
+                        # OSError. ET.ParseError replaces crossref's
+                        # JSONDecodeError for the XML payload.
+                        raise ArxivUnavailable(
+                            f"arXiv response read/parse failed: {e}"
+                        ) from e
+                    return root.findall(f"{_ATOM_NS}entry")
+            except urllib.error.HTTPError as e:
+                if e.code == 429 and attempt < _MAX_RETRIES:
+                    time.sleep(_BACKOFF_SECONDS)
+                    # Refresh throttle anchor after backoff so the next outer
+                    # _get call paces against actual wake time (mirrors
+                    # crossref_client.py).
+                    self._last_request_at = time.monotonic()
+                    continue
+                raise ArxivUnavailable(f"arXiv HTTP {e.code}: {e.reason}") from e
+            except (urllib.error.URLError, TimeoutError) as e:
+                raise ArxivUnavailable(f"arXiv network error: {e}") from e
+
+        raise ArxivUnavailable("arXiv rate limit exhausted after retries")
+
+    def arxiv_id_lookup(
+        self, arxiv_id: str, expected_title: str,
+    ) -> dict[str, Any] | None:
+        """arXiv ID lookup with mandatory 0.70 title cross-check.
+
+        Returns the projected entry dict if the ID resolves AND the title
+        cross-check passes; None on empty feed (miss) or ID_MISMATCH.
+        """
+        entries = self._get({"id_list": arxiv_id})
+        if not entries:  # non-existent ID -> empty feed
+            return None
+        entry = entries[0]
+        title = _extract_title(entry)
+        if _similarity(title, expected_title) >= _TITLE_SIMILARITY_THRESHOLD:
+            return _entry_to_dict(entry)
+        return None  # ID_MISMATCH
+
+    def title_search(
+        self, title: str, year: int | None = None,
+    ) -> dict[str, Any] | None:
+        """Title search with 0.70 similarity threshold + matching-year tiebreaker.
+
+        Returns the best matching projected entry dict, or None if no
+        candidate meets the threshold.
+        """
+        entries = self._get({"search_query": f'ti:"{title}"', "max_results": "5"})
+        scored = []
+        for cand in entries:
+            cand_title = _extract_title(cand)
+            sim = _similarity(cand_title, title)
+            if sim < _TITLE_SIMILARITY_THRESHOLD:
+                continue
+            year_match = year is not None and _extract_year(cand) == year
+            score = sim + (0.05 if year_match else 0.0)
+            scored.append((cand, score))
+        if not scored:
+            return None
+        scored.sort(key=lambda cand_score: -cand_score[1])
+        return _entry_to_dict(scored[0][0])

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -13,6 +13,14 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Protocol
 
+# Re-export ArxivUnavailable so callers (and tests) can reference it from the
+# signals module alongside the other resolver exceptions. Dual-path import
+# mirrors the client modules' own import guard.
+try:
+    from arxiv_client import ArxivUnavailable
+except ImportError:
+    from scripts.arxiv_client import ArxivUnavailable
+
 
 # 10-venue closed list per v3.7.3 spec §3.2 + schema description.
 # This list is intentionally redundant with the bibliography_agent's
@@ -125,6 +133,8 @@ def compute_preprint_signal(entry: Mapping[str, Any]) -> bool:
 def compute_ss_unmatched_signal(
     entry: Mapping[str, Any],
     client: SemanticScholarClient,
+    *,
+    cache=None,
 ) -> bool | None:
     """Signal 2 per v3.7.3 spec §3.2 Vector 2.
 
@@ -136,34 +146,124 @@ def compute_ss_unmatched_signal(
     Per spec emission rules, None means OMIT the field from the
     contamination_signals object (NOT set to False — that would imply
     "checked and found", which is not what happened).
+
+    cache: optional VerificationCache (spec §2 Delta 2). The S2 wrapper is the
+    resolver layer for S2 (its `lookup` is the lone entry-keyed client method),
+    so it shares the same `_cached_verdict` path as the other three resolvers.
+    A degradation returns None and is NEVER cached (absent != false): the
+    SemanticScholarUnavailable raised by `lookup` propagates out of `compute`
+    (uncached, since the put runs only on success) and is caught here to yield
+    None. cache=None is byte-equivalent to no caching.
     """
     if entry.get("obtained_via") == "manual":
         return None
     try:
-        result = client.lookup(entry)
+        return _cached_verdict(
+            cache=cache,
+            citation_key=entry.get("citation_key"),
+            resolver_name="semantic_scholar",
+            query_form=_query_form(
+                id_label="doi",
+                id_value=entry.get("doi"),
+                title=entry.get("title", ""),
+            ),
+            compute=lambda: (
+                not bool(client.lookup(entry).get("matched", False)),
+                None,
+            ),
+        )
     except SemanticScholarUnavailable:
-        return None
-    return not result.get("matched", False)
+        return None  # degradation → omit field, never cached
 
 
-def _resolve_by_doi_then_title(entry: Mapping[str, Any], client) -> bool | None:
-    """Shared body for resolve_openalex_unmatched / resolve_crossref_unmatched.
-    See those wrappers for the spec contract. Exception-type differentiation
-    stays at the wrapper — this helper never catches."""
-    if entry.get("obtained_via") == "manual":
-        return None
+def _query_form(*, id_label: str, id_value: str | None, title: str) -> str:
+    """Canonical cache query_form keying the WHOLE resolver attempt.
+
+    A resolver may try the exact ID, miss, then fall through to title search;
+    keying only on the ID would cache a title-hit verdict under the ID and
+    falsely imply the ID resolved. So the query_form captures both inputs of
+    the attempt: e.g. "doi:10.5/x|title:Attention...".
+    The cache key already namespaces by citation_key + resolver_name, so this
+    string never needs to disambiguate across citations or resolvers."""
+    return f"{id_label}:{id_value or ''}|title:{title}"
+
+
+def _cached_verdict(
+    *,
+    cache,
+    citation_key,
+    resolver_name: str,
+    query_form: str,
+    compute,
+) -> bool | None:
+    """Wrap a verdict computation with the persistent cache (spec §2 Delta 2).
+
+    `compute()` returns `(unmatched: bool, matched_by: str | None)`. On a cache
+    hit the network call is skipped and the stored verdict is returned. On a
+    miss the live `compute()` runs and the verdict is persisted (negatives
+    included, so repeat runs don't re-hammer the API). `cache=None` is
+    byte-equivalent to no caching. Degradation exceptions propagate from
+    `compute()` and are NEVER cached (the caller omits the field).
+    """
+    if cache is None:
+        unmatched, _ = compute()
+        return unmatched
+    cached = cache.get(citation_key, resolver_name, query_form)
+    if cached is not None and "matched" in cached:
+        return not cached["matched"]
+    # A row missing `matched` (written by an older/other tool) is treated as a
+    # miss — force a live recompute rather than KeyError for the 90-day TTL.
+    unmatched, matched_by = compute()
+    # query_form is the cache key, not part of the value — no need to echo it
+    # into the stored payload (nothing reads it back).
+    cache.put(
+        citation_key,
+        resolver_name,
+        query_form,
+        {"matched": not unmatched, "matched_by": matched_by},
+    )
+    return unmatched
+
+
+def _resolve_doi_then_title(entry: Mapping[str, Any], client) -> tuple[bool, str | None]:
+    """Run the DOI-then-title resolver flow, returning (unmatched, matched_by).
+    matched_by ∈ {'doi', 'title', None}. Exception-type differentiation stays
+    at the wrapper — this helper never catches."""
     title = entry.get("title", "")
     doi = entry.get("doi")
     if doi:
         hit = client.doi_lookup_with_title_check(doi, title)
         if hit is not None:
-            return False
+            return False, "doi"
         # DOI miss or MISMATCH — fall through to title search.
     hit = client.title_search(title)
-    return hit is None
+    if hit is not None:
+        return False, "title"
+    return True, None
 
 
-def resolve_openalex_unmatched(entry: Mapping[str, Any], client) -> bool | None:
+def _resolve_by_doi_then_title(
+    entry: Mapping[str, Any], client, *, resolver_name: str, cache=None,
+) -> bool | None:
+    """Shared body for resolve_openalex_unmatched / resolve_crossref_unmatched.
+    See those wrappers for the spec contract."""
+    if entry.get("obtained_via") == "manual":
+        return None
+    title = entry.get("title", "")
+    return _cached_verdict(
+        cache=cache,
+        citation_key=entry.get("citation_key"),
+        resolver_name=resolver_name,
+        query_form=_query_form(
+            id_label="doi", id_value=entry.get("doi"), title=title
+        ),
+        compute=lambda: _resolve_doi_then_title(entry, client),
+    )
+
+
+def resolve_openalex_unmatched(
+    entry: Mapping[str, Any], client, *, cache=None,
+) -> bool | None:
     """Compute openalex_unmatched per spec v3.9.0 §3.4.
 
     Mirrors resolve_semantic_scholar_unmatched semantics:
@@ -181,11 +281,18 @@ def resolve_openalex_unmatched(entry: Mapping[str, Any], client) -> bool | None:
 
     Raises:
         OpenAlexUnavailable: API degraded, caller must omit field per R-L3-2-C.
+
+    cache: optional VerificationCache (spec §2 Delta 2). cache=None is
+        byte-equivalent to no caching.
     """
-    return _resolve_by_doi_then_title(entry, client)
+    return _resolve_by_doi_then_title(
+        entry, client, resolver_name="openalex", cache=cache
+    )
 
 
-def resolve_crossref_unmatched(entry: Mapping[str, Any], client) -> bool | None:
+def resolve_crossref_unmatched(
+    entry: Mapping[str, Any], client, *, cache=None,
+) -> bool | None:
     """Compute crossref_unmatched per spec v3.9.0 §3.5.
 
     Mirrors resolve_openalex_unmatched / resolve_semantic_scholar_unmatched
@@ -196,13 +303,82 @@ def resolve_crossref_unmatched(entry: Mapping[str, Any], client) -> bool | None:
 
     Raises:
         CrossrefUnavailable: API degraded, caller must omit field per R-L3-2-C.
+
+    cache: optional VerificationCache (spec §2 Delta 2). cache=None is
+        byte-equivalent to no caching.
     """
-    return _resolve_by_doi_then_title(entry, client)
+    return _resolve_by_doi_then_title(
+        entry, client, resolver_name="crossref", cache=cache
+    )
+
+
+def _resolve_arxiv_id_then_title(
+    entry: Mapping[str, Any], client,
+) -> tuple[bool, str | None]:
+    """arXiv-specific resolver flow (ID-keyed, not DOI-keyed), returning
+    (unmatched, matched_by). matched_by ∈ {'arxiv', 'title', None}. Never
+    catches — exception differentiation stays at the wrapper."""
+    title = entry.get("title", "")
+    arxiv_id = entry.get("arxiv_id")
+    if arxiv_id:
+        hit = client.arxiv_id_lookup(arxiv_id, title)
+        if hit is not None:
+            return False, "arxiv"
+        # ID miss or MISMATCH — fall through to title search.
+    hit = client.title_search(title)
+    if hit is not None:
+        return False, "title"
+    return True, None
+
+
+def resolve_arxiv_unmatched(
+    entry: Mapping[str, Any], client, *, cache=None,
+) -> bool | None:
+    """Compute arxiv_unmatched per spec v3.11 #182 Delta 1.
+
+    Differs from resolve_crossref_unmatched / resolve_openalex_unmatched in
+    its exact-key channel: arXiv is keyed by `entry['arxiv_id']` (not 'doi'),
+    and the client's exact-key method is `arxiv_id_lookup` (not
+    `doi_lookup_with_title_check`). The title fallback is identical.
+
+    - Manual entry → return None (caller MUST omit field).
+    - arXiv ID present + ID hit (passes title cross-check) → return False.
+    - arXiv ID present + ID miss/MISMATCH → fall through to title search.
+    - arXiv ID absent → title search only.
+    - No hit anywhere → return True (unmatched).
+
+    Returns:
+        True: arXiv returned no match by ID (with title cross-check) or title.
+        False: arXiv found a match.
+        None: obtained_via='manual' → exempt, caller must omit field.
+
+    Raises:
+        ArxivUnavailable: API degraded, caller must omit field per R-L3-2-C.
+
+    cache: optional VerificationCache (spec §2 Delta 2). cache=None is
+        byte-equivalent to no caching.
+    """
+    if entry.get("obtained_via") == "manual":
+        return None
+    return _cached_verdict(
+        cache=cache,
+        citation_key=entry.get("citation_key"),
+        resolver_name="arxiv",
+        query_form=_query_form(
+            id_label="arxiv",
+            id_value=entry.get("arxiv_id"),
+            title=entry.get("title", ""),
+        ),
+        compute=lambda: _resolve_arxiv_id_then_title(entry, client),
+    )
 
 
 def build_signals_object(
     entry: Mapping[str, Any],
     client: SemanticScholarClient,
+    arxiv_client=None,
+    *,
+    cache=None,
 ) -> dict[str, bool]:
     """Construct the `contamination_signals` object for `entry`.
 
@@ -211,11 +387,25 @@ def build_signals_object(
         "computed and found clean" is distinct from "not computed")
       - Manual entry → omit `semantic_scholar_unmatched` field
       - API degradation → omit `semantic_scholar_unmatched` field
+
+    cache: optional VerificationCache (spec §2 Delta 2), threaded into both the
+    S2 and arXiv resolvers. cache=None is byte-equivalent to no caching.
     """
     obj: dict[str, bool] = {
         "preprint_post_llm_inflection": compute_preprint_signal(entry),
     }
-    ss = compute_ss_unmatched_signal(entry, client)
+    ss = compute_ss_unmatched_signal(entry, client, cache=cache)
     if ss is not None:
         obj["semantic_scholar_unmatched"] = ss
+    # v3.11 #182 Delta 1: arxiv signal is opt-in via an explicit client so the
+    # v3.7.3 caller (migrate_literature_corpus_to_v3_7_3) stays byte-equivalent
+    # (no client → no field). Manual exemption + API degradation both omit the
+    # field (resolve returns None / raises), matching the ss field's rules.
+    if arxiv_client is not None:
+        try:
+            ax = resolve_arxiv_unmatched(entry, arxiv_client, cache=cache)
+        except ArxivUnavailable:
+            ax = None
+        if ax is not None:
+            obj["arxiv_unmatched"] = ax
     return obj

--- a/scripts/test_ars_cache_invalidate.py
+++ b/scripts/test_ars_cache_invalidate.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Tests for the /ars-cache-invalidate CLI shim (Delta 2, deliverable 6).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 2.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def seeded_cache(tmp_path, monkeypatch):
+    """A VerificationCache with two citations cached across resolvers."""
+    from verification_cache import VerificationCache
+
+    db = tmp_path / "verification.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    c = VerificationCache()
+    c.put("smith2024", "crossref", "doi:10.5/x|title:T", {"matched": True})
+    c.put("smith2024", "arxiv", "arxiv:1.2|title:T", {"matched": False})
+    c.put("jones2024", "crossref", "doi:10.5/y|title:U", {"matched": True})
+    return c, db
+
+
+def test_invalidate_removes_named_citation(seeded_cache, monkeypatch):
+    from ars_cache_invalidate import main
+    from verification_cache import VerificationCache
+
+    cache, db = seeded_cache
+    rc = main(["smith2024"])
+    assert rc == 0
+
+    fresh = VerificationCache()  # reads same env path
+    assert fresh.get("smith2024", "crossref", "doi:10.5/x|title:T") is None
+    assert fresh.get("smith2024", "arxiv", "arxiv:1.2|title:T") is None
+    # Other citation untouched.
+    assert fresh.get("jones2024", "crossref", "doi:10.5/y|title:U") is not None
+
+
+def test_invalidate_unknown_citation_is_noop_success(seeded_cache):
+    from ars_cache_invalidate import main
+
+    rc = main(["never-cached"])
+    assert rc == 0  # idempotent no-op, not an error
+
+
+def test_missing_argument_is_usage_error(seeded_cache):
+    from ars_cache_invalidate import main
+
+    with pytest.raises(SystemExit):  # argparse exits on missing required arg
+        main([])

--- a/scripts/test_arxiv_client.py
+++ b/scripts/test_arxiv_client.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Tests for arXiv client per deep-research/references/arxiv_api_protocol.md.
+
+Mirrors test_crossref_client.py. arXiv API differs from Crossref in three
+ways the tests exercise: (1) the response is Atom XML, not JSON; (2) the
+exact-key lookup is by arXiv ID (`arxiv_id_lookup`), not DOI; (3) there is
+no polite-pool email — pacing is a fixed min-interval.
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 1.
+"""
+from __future__ import annotations
+
+import http.client
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _atom(entries: list[str]) -> bytes:
+    """Build an Atom feed body with the given <entry> blocks (raw XML strings)."""
+    body = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<feed xmlns="http://www.w3.org/2005/Atom">\n'
+        + "\n".join(entries)
+        + "\n</feed>"
+    )
+    return body.encode("utf-8")
+
+
+def _entry(title: str, arxiv_url: str = "http://arxiv.org/abs/1706.03762v5",
+           published: str = "2017-06-12T00:00:00Z") -> str:
+    return (
+        "<entry>"
+        f"<id>{arxiv_url}</id>"
+        f"<title>{title}</title>"
+        f"<published>{published}</published>"
+        "</entry>"
+    )
+
+
+def _mock_resp(body: bytes) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.read.return_value = body
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+    return mock_response
+
+
+def test_title_search_match_at_threshold():
+    """0.70 similarity threshold matches like the other clients."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([_entry("Attention Is All You Need")])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.title_search("Attention Is All You Need")
+
+    assert result is not None
+    assert result["title"] == "Attention Is All You Need"
+
+
+def test_title_search_no_match_below_threshold():
+    """No match if best candidate similarity < 0.70."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([_entry("Completely Unrelated Paper Title")])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.title_search("Attention Is All You Need")
+
+    assert result is None
+
+
+def test_title_search_empty_feed_returns_none():
+    """Zero <entry> elements (arXiv's empty-result shape) -> None."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.title_search("Attention Is All You Need")
+
+    assert result is None
+
+
+def test_arxiv_id_lookup_with_title_cross_check():
+    """ID hit MUST pass 0.70 title cross-check (ID_MISMATCH -> None)."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([_entry("Some Other Paper")])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.arxiv_id_lookup(
+            arxiv_id="1706.03762",
+            expected_title="Attention Is All You Need",
+        )
+
+    assert result is None  # ID_MISMATCH
+
+
+def test_arxiv_id_lookup_with_matching_title():
+    """ID hit + matching title -> success (returns the entry dict)."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([_entry("Attention Is All You Need")])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.arxiv_id_lookup(
+            arxiv_id="1706.03762",
+            expected_title="Attention Is All You Need",
+        )
+
+    assert result is not None
+    assert result["title"] == "Attention Is All You Need"
+
+
+def test_arxiv_id_lookup_empty_feed_is_miss():
+    """A non-existent arXiv ID returns an empty feed (no <entry>) -> None (miss)."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.arxiv_id_lookup(
+            arxiv_id="9999.99999",
+            expected_title="Anything",
+        )
+
+    assert result is None
+
+
+def test_arxiv_id_with_version_suffix_resolves():
+    """arXiv natively supports versioned IDs (1706.03762v5) in id_list — the
+    client passes the id through verbatim and a matching feed resolves."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([_entry("Attention Is All You Need")])
+    captured = {}
+
+    def mock_urlopen(req, *a, **k):
+        captured["url"] = req.full_url
+        return _mock_resp(body)
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        client = ArxivClient()
+        result = client.arxiv_id_lookup(
+            arxiv_id="1706.03762v5",
+            expected_title="Attention Is All You Need",
+        )
+
+    assert result is not None
+    assert "1706.03762v5" in captured["url"]  # passed through verbatim
+
+
+def test_arxiv_id_as_full_url_falls_through_to_title():
+    """If arxiv_id is a full URL (not a bare ID), id_list lookup won't match
+    and the client falls through to title search. Documents current behavior:
+    the client does NOT strip URLs — adapters are expected to emit bare IDs.
+    The fall-through still finds the paper via title, so it is not a hard miss."""
+    from arxiv_client import ArxivClient
+
+    # id_list lookup of a URL -> arXiv returns empty feed; title search hits.
+    id_feed = _atom([])
+    title_feed = _atom([_entry("Attention Is All You Need")])
+    responses = [_mock_resp(id_feed), _mock_resp(title_feed)]
+
+    def mock_urlopen(*a, **k):
+        return responses.pop(0)
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        client = ArxivClient()
+        id_hit = client.arxiv_id_lookup(
+            arxiv_id="https://arxiv.org/abs/1706.03762",
+            expected_title="Attention Is All You Need",
+        )
+        assert id_hit is None  # URL did not resolve as an exact id_list key
+        # The resolver wrapper would then fall through to title_search:
+        title_hit = client.title_search("Attention Is All You Need")
+        assert title_hit is not None
+
+
+def test_title_search_empty_title_is_miss_not_crash():
+    """An empty title produces a ti:"" query; the client must not crash and
+    returns None (no candidate meets the 0.70 threshold against "")."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([])  # arXiv returns no entries for an empty title query
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.title_search("")
+
+    assert result is None
+
+
+def test_title_search_prefers_matching_year():
+    """Two same-title candidates - matching publication year wins via 0.05 bonus."""
+    from arxiv_client import ArxivClient
+
+    body = _atom([
+        _entry("Attention Is All You Need", published="1999-01-01T00:00:00Z"),
+        _entry("Attention Is All You Need", published="2017-06-12T00:00:00Z"),
+    ])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        client = ArxivClient()
+        result = client.title_search("Attention Is All You Need", year=2017)
+
+    assert result is not None
+    assert result["year"] == 2017
+
+
+def test_429_triggers_2s_backoff_3_retries(monkeypatch):
+    """Per protocol: 429 -> 2s backoff x 3 retries -> raise ArxivUnavailable."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    call_count = [0]
+
+    def mock_urlopen(*args, **kwargs):
+        call_count[0] += 1
+        raise urllib.error.HTTPError(
+            url="http://export.arxiv.org/api/query",
+            code=429, msg="Too Many Requests", hdrs={}, fp=None,
+        )
+
+    sleeps = []
+    monkeypatch.setattr("arxiv_client.time.sleep", lambda s: sleeps.append(s))
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("anything")
+
+    assert call_count[0] == 4
+    assert sleeps == [2.0, 2.0, 2.0]
+
+
+def test_5xx_skips_immediately():
+    """Per protocol: 5xx -> no retry, raise ArxivUnavailable. call_count == 1."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    call_count = [0]
+
+    def mock_urlopen(*args, **kwargs):
+        call_count[0] += 1
+        raise urllib.error.HTTPError(
+            url="http://export.arxiv.org/api/query", code=503, msg="SU",
+            hdrs={}, fp=None,
+        )
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("anything")
+
+    assert call_count[0] == 1
+
+
+def test_network_error_raises_unavailable():
+    """URLError / TimeoutError -> ArxivUnavailable (degradation contract)."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    def mock_urlopen(*args, **kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("anything")
+
+
+def test_malformed_xml_body_raises_unavailable():
+    """resp.read() returns bytes that aren't well-formed XML (truncated body
+    mid-stream: an unclosed tag). Per the §3.7 degradation contract, translate
+    the ParseError to ArxivUnavailable. Mirrors crossref's
+    test_invalid_json_body_raises_unavailable.
+
+    Note: a *complete* HTML error page (`<html>...</html>`) is itself
+    well-formed XML and parses without error -- it just yields zero Atom
+    entries (a miss), not an exception. Only genuinely malformed bytes
+    (truncated/unclosed) trigger ParseError, which is what an interrupted
+    transfer actually produces."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    with patch("urllib.request.urlopen", return_value=_mock_resp(
+            b'<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>trunc')):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("any title")
+
+
+def test_oserror_during_read_raises_unavailable():
+    """urlopen succeeds, resp.read() raises OSError (socket drop mid-stream).
+    Translate to ArxivUnavailable. Mirrors crossref."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = OSError("socket dropped mid-read")
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("any title")
+
+
+def test_truncated_read_raises_unavailable():
+    """http.client.IncompleteRead = mid-stream socket drop (200 + truncated
+    body). Inherits HTTPException not OSError. Mirrors the crossref client."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    mock_response = MagicMock()
+    mock_response.read.side_effect = http.client.IncompleteRead(
+        partial=b"<feed>", expected=200
+    )
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("any title")
+
+
+def test_throttle_uses_monotonic_clock(monkeypatch):
+    """time.monotonic for elapsed measurement (NTP-safe), not time.time.
+    Aligns with crossref/openalex/S2 (#128 §6)."""
+    from arxiv_client import ArxivClient
+
+    monotonic_calls = []
+    time_calls = []
+
+    monkeypatch.setattr("arxiv_client.time.monotonic",
+                        lambda: (monotonic_calls.append(1), 100.0)[1])
+    monkeypatch.setattr("arxiv_client.time.time",
+                        lambda: (time_calls.append(1), 100.0)[1])
+
+    client = ArxivClient()
+    client._throttle()  # no prior request -> short-circuit
+    client._last_request_at = 90.0
+    client._throttle()
+
+    assert len(monotonic_calls) >= 1, "throttle must read time.monotonic"
+    assert len(time_calls) == 0, "throttle must NOT read time.time (NTP-unsafe)"

--- a/scripts/test_check_v3_6_8_frontmatter_trust_schema.py
+++ b/scripts/test_check_v3_6_8_frontmatter_trust_schema.py
@@ -482,6 +482,85 @@ def test_v3_10_venue_mutation_trusted_source_required_is_load_bearing(schema: di
     assert any(Draft202012Validator(schema).iter_errors(bad))
 
 
+# ---------- v3.11 #182 Delta 1: contamination_signals.arxiv_unmatched ----------
+
+
+def test_v3_11_contamination_signals_accepts_arxiv_unmatched(validator) -> None:
+    """arxiv_unmatched is an optional boolean alongside the v3.9.0 triplet."""
+    entry = _minimal_entry(
+        contamination_signals={"arxiv_unmatched": True}
+    )
+    assert list(validator.iter_errors(entry)) == [], (
+        "a non-manual entry carrying arxiv_unmatched must validate"
+    )
+
+
+def test_v3_11_contamination_signals_arxiv_unmatched_rejects_non_bool(
+    validator,
+) -> None:
+    """arxiv_unmatched is typed boolean; a string must fail."""
+    entry = _minimal_entry(
+        contamination_signals={"arxiv_unmatched": "yes"}
+    )
+    assert any(validator.iter_errors(entry)), (
+        "arxiv_unmatched must reject a non-boolean value"
+    )
+
+
+def test_v3_11_contamination_signals_keeps_additional_properties_false(
+    validator,
+) -> None:
+    """The contamination_signals object stays closed (no unknown signals)."""
+    entry = _minimal_entry(
+        contamination_signals={"made_up_signal": True}
+    )
+    assert any(validator.iter_errors(entry)), (
+        "contamination_signals must reject unknown fields "
+        "(additionalProperties: false)"
+    )
+
+
+def test_v3_11_manual_entry_with_arxiv_unmatched_fails(validator) -> None:
+    """The manual-entry not-rule extends to arxiv_unmatched: a manual entry
+    MUST NOT carry it (would surface CONTAMINATED-* on a user-vouched ref)."""
+    entry = _minimal_entry(
+        obtained_via="manual",
+        contamination_signals={"arxiv_unmatched": True},
+    )
+    assert any(validator.iter_errors(entry)), (
+        "a manual entry carrying arxiv_unmatched must FAIL the not-rule"
+    )
+
+
+def test_v3_11_manual_entry_not_rule_covers_v3_9_0_triplet(validator) -> None:
+    """Regression guard for the pre-existing v3.9.0 not-rule members — the
+    extension must not drop coverage of s2 / openalex / crossref."""
+    for field in (
+        "semantic_scholar_unmatched",
+        "openalex_unmatched",
+        "crossref_unmatched",
+    ):
+        entry = _minimal_entry(
+            obtained_via="manual",
+            contamination_signals={field: True},
+        )
+        assert any(validator.iter_errors(entry)), (
+            f"a manual entry carrying {field} must FAIL the not-rule"
+        )
+
+
+def test_v3_11_manual_entry_keeps_preprint_signal_allowed(validator) -> None:
+    """The not-rule covers the lookup fields only — a manual entry MAY still
+    carry preprint_post_llm_inflection (pure heuristic, not a lookup)."""
+    entry = _minimal_entry(
+        obtained_via="manual",
+        contamination_signals={"preprint_post_llm_inflection": True},
+    )
+    assert list(validator.iter_errors(entry)) == [], (
+        "a manual entry carrying only the preprint heuristic must validate"
+    )
+
+
 # ---------- Existing fixtures stay green ----------
 
 

--- a/scripts/test_contamination_signals.py
+++ b/scripts/test_contamination_signals.py
@@ -432,3 +432,363 @@ class ResolveCrossrefUnmatchedTest(unittest.TestCase):
         entry = {"title": "X", "doi": "10.5555/abc", "obtained_via": "folder-scan"}
         with self.assertRaises(CrossrefUnavailable):
             resolve_crossref_unmatched(entry, mock_client)
+
+
+# ============================================================================
+# v3.11 #182 Delta 1 — resolve_arxiv_unmatched
+# ============================================================================
+
+
+class ResolveArxivUnmatchedTest(unittest.TestCase):
+    """Tests for resolve_arxiv_unmatched per spec v3.11 #182 Delta 1.
+
+    Differs from the crossref/openalex resolvers: keyed by entry['arxiv_id']
+    (not 'doi'), and the client exact-key method is arxiv_id_lookup, not
+    doi_lookup_with_title_check."""
+
+    def test_match(self):
+        """arXiv hit via ID cross-check → False."""
+        from contamination_signals import resolve_arxiv_unmatched
+
+        mock_client = MagicMock()
+        mock_client.arxiv_id_lookup.return_value = {"title": "X", "year": 2017}
+
+        entry = {
+            "title": "X",
+            "arxiv_id": "1706.03762",
+            "obtained_via": "zotero-bbt-export",
+        }
+        result = resolve_arxiv_unmatched(entry, mock_client)
+        self.assertIs(result, False)
+
+    def test_no_match(self):
+        """arXiv no ID hit + no title hit → True."""
+        from contamination_signals import resolve_arxiv_unmatched
+
+        mock_client = MagicMock()
+        mock_client.arxiv_id_lookup.return_value = None
+        mock_client.title_search.return_value = None
+
+        entry = {
+            "title": "Nonexistent",
+            "arxiv_id": "9999.99999",
+            "obtained_via": "folder-scan",
+        }
+        result = resolve_arxiv_unmatched(entry, mock_client)
+        self.assertIs(result, True)
+
+    def test_manual_exempt(self):
+        """obtained_via='manual' → return None, no client calls."""
+        from contamination_signals import resolve_arxiv_unmatched
+
+        mock_client = MagicMock()
+        entry = {"title": "X", "arxiv_id": "1706.03762", "obtained_via": "manual"}
+        result = resolve_arxiv_unmatched(entry, mock_client)
+        self.assertIsNone(result)
+        mock_client.arxiv_id_lookup.assert_not_called()
+        mock_client.title_search.assert_not_called()
+
+    def test_arxiv_id_absent_falls_through_to_title(self):
+        """arXiv ID absent: title search alone, NO id lookup attempted."""
+        from contamination_signals import resolve_arxiv_unmatched
+
+        mock_client = MagicMock()
+        mock_client.title_search.return_value = {"title": "X", "year": 2017}
+
+        entry = {"title": "X", "obtained_via": "obsidian-vault"}  # no arxiv_id
+        result = resolve_arxiv_unmatched(entry, mock_client)
+        self.assertIs(result, False)
+        mock_client.arxiv_id_lookup.assert_not_called()
+
+    def test_arxiv_id_miss_falls_through_to_title(self):
+        """ID present but ID lookup misses → fall through to title search."""
+        from contamination_signals import resolve_arxiv_unmatched
+
+        mock_client = MagicMock()
+        mock_client.arxiv_id_lookup.return_value = None
+        mock_client.title_search.return_value = {"title": "X", "year": 2017}
+
+        entry = {"title": "X", "arxiv_id": "1706.03762", "obtained_via": "folder-scan"}
+        result = resolve_arxiv_unmatched(entry, mock_client)
+        self.assertIs(result, False)
+        mock_client.title_search.assert_called_once()
+
+    def test_api_down_raises(self):
+        """API degraded → re-raise ArxivUnavailable for caller to omit field."""
+        from contamination_signals import resolve_arxiv_unmatched
+        from arxiv_client import ArxivUnavailable
+
+        mock_client = MagicMock()
+        mock_client.arxiv_id_lookup.side_effect = ArxivUnavailable("down")
+
+        entry = {"title": "X", "arxiv_id": "1706.03762", "obtained_via": "folder-scan"}
+        with self.assertRaises(ArxivUnavailable):
+            resolve_arxiv_unmatched(entry, mock_client)
+
+
+# ============================================================================
+# v3.11 #182 Delta 1 — build_signals_object arxiv extension
+# ============================================================================
+
+
+class BuildSignalsArxivExtensionTest(unittest.TestCase):
+    """build_signals_object grows an optional arxiv_client keyword arg; when
+    omitted, behavior is byte-equivalent to the v3.7.3 caller (no arxiv field).
+    Per spec §2 Delta 1 'signal computation only' scope."""
+
+    def _entry(self, **overrides):
+        base = {"year": 2024, "venue": "arXiv", "obtained_via": "folder-scan"}
+        return base | overrides
+
+    def test_no_arxiv_client_omits_arxiv_field(self) -> None:
+        """Byte-equivalent v3.7.3 path: no arxiv_client → no arxiv_unmatched."""
+        ss = MagicMock()
+        ss.lookup.return_value = {"matched": True}
+        result = cs.build_signals_object(self._entry(), ss)
+        self.assertNotIn("arxiv_unmatched", result)
+
+    def test_arxiv_client_emits_arxiv_field(self) -> None:
+        """With arxiv_client, a non-manual entry emits arxiv_unmatched."""
+        ss = MagicMock()
+        ss.lookup.return_value = {"matched": True}
+        ax = MagicMock()
+        ax.arxiv_id_lookup.return_value = None
+        ax.title_search.return_value = None
+        result = cs.build_signals_object(
+            self._entry(arxiv_id="9999.99999"), ss, arxiv_client=ax
+        )
+        self.assertIs(result["arxiv_unmatched"], True)
+
+    def test_manual_entry_omits_arxiv_field_even_with_client(self) -> None:
+        """Manual entry: arxiv_unmatched omitted (not-rule), like the ss field."""
+        ss = MagicMock()
+        ax = MagicMock()
+        result = cs.build_signals_object(
+            self._entry(obtained_via="manual"), ss, arxiv_client=ax
+        )
+        self.assertNotIn("arxiv_unmatched", result)
+        ax.arxiv_id_lookup.assert_not_called()
+
+    def test_arxiv_api_down_omits_arxiv_field(self) -> None:
+        """arXiv API degradation → omit arxiv_unmatched (absent != false)."""
+        ss = MagicMock()
+        ss.lookup.return_value = {"matched": True}
+        ax = MagicMock()
+        ax.arxiv_id_lookup.side_effect = cs.ArxivUnavailable("5xx")
+        result = cs.build_signals_object(
+            self._entry(arxiv_id="1706.03762"), ss, arxiv_client=ax
+        )
+        self.assertNotIn("arxiv_unmatched", result)
+
+
+# ============================================================================
+# v3.11 #182 Delta 2 — resolver cache integration (wrapper layer)
+# ============================================================================
+
+
+class _FakeCache:
+    """Minimal in-memory stand-in for VerificationCache. Records get/put calls
+    so tests can assert hit/skip behavior without SQLite."""
+
+    def __init__(self, seed=None):
+        self._store = dict(seed or {})
+        self.get_calls = []
+        self.put_calls = []
+
+    def get(self, citation_key, resolver_name, query_form):
+        self.get_calls.append((citation_key, resolver_name, query_form))
+        return self._store.get((citation_key, resolver_name, query_form))
+
+    def put(self, citation_key, resolver_name, query_form, response):
+        self.put_calls.append((citation_key, resolver_name, query_form, response))
+        self._store[(citation_key, resolver_name, query_form)] = response
+
+
+class ResolveCrossrefCacheTest(unittest.TestCase):
+    """Cache integration is byte-equivalent when cache=None, consults the cache
+    before the network on hit, and populates on miss. Per spec §2 Delta 2."""
+
+    def _entry(self, **overrides):
+        base = {
+            "citation_key": "vaswani2017",
+            "title": "Attention Is All You Need",
+            "doi": "10.5555/abc",
+            "obtained_via": "folder-scan",
+        }
+        return base | overrides
+
+    def test_cache_none_is_byte_equivalent(self):
+        from contamination_signals import resolve_crossref_unmatched
+
+        client = MagicMock()
+        client.doi_lookup_with_title_check.return_value = {"title": ["X"]}
+        result = resolve_crossref_unmatched(self._entry(), client, cache=None)
+        self.assertIs(result, False)
+        client.doi_lookup_with_title_check.assert_called_once()
+
+    def test_cache_hit_skips_network(self):
+        from contamination_signals import resolve_crossref_unmatched
+
+        client = MagicMock()
+        qf = "doi:10.5555/abc|title:Attention Is All You Need"
+        cache = _FakeCache(seed={
+            ("vaswani2017", "crossref", qf): {"matched": True, "matched_by": "doi"}
+        })
+        result = resolve_crossref_unmatched(self._entry(), client, cache=cache)
+        self.assertIs(result, False)  # matched=True → unmatched=False
+        client.doi_lookup_with_title_check.assert_not_called()
+        client.title_search.assert_not_called()
+
+    def test_cache_miss_calls_network_and_populates(self):
+        from contamination_signals import resolve_crossref_unmatched
+
+        client = MagicMock()
+        client.doi_lookup_with_title_check.return_value = None
+        client.title_search.return_value = None  # unmatched
+        cache = _FakeCache()
+        result = resolve_crossref_unmatched(self._entry(), client, cache=cache)
+        self.assertIs(result, True)  # unmatched
+        self.assertEqual(len(cache.put_calls), 1)
+        # The negative verdict is cached (so repeat runs don't re-hammer API).
+        _, resolver, qf, response = cache.put_calls[0]
+        self.assertEqual(resolver, "crossref")
+        self.assertIs(response["matched"], False)
+
+    def test_malformed_cache_payload_treated_as_miss(self):
+        """A persistent on-disk cache row written by an older/other tool that
+        lacks the 'matched' key must be treated as a MISS (force live recompute),
+        not crash with KeyError for 90 days. Robustness guard."""
+        from contamination_signals import resolve_crossref_unmatched
+
+        client = MagicMock()
+        client.doi_lookup_with_title_check.return_value = {"title": ["X"]}  # match
+        qf = "doi:10.5555/abc|title:Attention Is All You Need"
+        cache = _FakeCache(seed={
+            ("vaswani2017", "crossref", qf): {"legacy": "no matched key"}
+        })
+        result = resolve_crossref_unmatched(self._entry(), client, cache=cache)
+        # Falls through to live call (which matched) → unmatched=False.
+        self.assertIs(result, False)
+        client.doi_lookup_with_title_check.assert_called_once()
+
+    def test_degradation_is_not_cached(self):
+        from contamination_signals import resolve_crossref_unmatched
+        from crossref_client import CrossrefUnavailable
+
+        client = MagicMock()
+        client.doi_lookup_with_title_check.side_effect = CrossrefUnavailable("down")
+        cache = _FakeCache()
+        with self.assertRaises(CrossrefUnavailable):
+            resolve_crossref_unmatched(self._entry(), client, cache=cache)
+        self.assertEqual(cache.put_calls, [])  # NEVER cache a degradation
+
+    def test_manual_entry_does_not_touch_cache(self):
+        from contamination_signals import resolve_crossref_unmatched
+
+        client = MagicMock()
+        cache = _FakeCache()
+        result = resolve_crossref_unmatched(
+            self._entry(obtained_via="manual"), client, cache=cache
+        )
+        self.assertIsNone(result)
+        self.assertEqual(cache.get_calls, [])
+        self.assertEqual(cache.put_calls, [])
+
+
+class ResolveArxivCacheTest(unittest.TestCase):
+    """Same cache contract for the arXiv resolver (ID-keyed query_form)."""
+
+    def _entry(self, **overrides):
+        base = {
+            "citation_key": "vaswani2017",
+            "title": "Attention Is All You Need",
+            "arxiv_id": "1706.03762",
+            "obtained_via": "folder-scan",
+        }
+        return base | overrides
+
+    def test_cache_hit_skips_network(self):
+        from contamination_signals import resolve_arxiv_unmatched
+
+        client = MagicMock()
+        qf = "arxiv:1706.03762|title:Attention Is All You Need"
+        cache = _FakeCache(seed={
+            ("vaswani2017", "arxiv", qf): {"matched": False, "matched_by": None}
+        })
+        result = resolve_arxiv_unmatched(self._entry(), client, cache=cache)
+        self.assertIs(result, True)  # matched=False → unmatched=True
+        client.arxiv_id_lookup.assert_not_called()
+
+    def test_cache_miss_populates(self):
+        from contamination_signals import resolve_arxiv_unmatched
+
+        client = MagicMock()
+        client.arxiv_id_lookup.return_value = {"title": "X", "year": 2017}
+        cache = _FakeCache()
+        result = resolve_arxiv_unmatched(self._entry(), client, cache=cache)
+        self.assertIs(result, False)  # matched
+        self.assertEqual(len(cache.put_calls), 1)
+        _, resolver, _, response = cache.put_calls[0]
+        self.assertEqual(resolver, "arxiv")
+        self.assertIs(response["matched"], True)
+
+
+class SemanticScholarCacheTest(unittest.TestCase):
+    """S2's wrapper is compute_ss_unmatched_signal (the lone client.lookup is
+    entry-keyed already). Cache integration lives at that wrapper, matching
+    Option A — the resolver_name is 'semantic_scholar'. Per spec §2 Delta 2
+    'the S2 lookup'."""
+
+    def _entry(self, **overrides):
+        base = {
+            "citation_key": "chen2024ai",
+            "title": "Test paper",
+            "doi": "10.1234/xyz",
+            "obtained_via": "folder-scan",
+        }
+        return base | overrides
+
+    def test_cache_none_byte_equivalent(self):
+        client = MagicMock()
+        client.lookup.return_value = {"matched": True}
+        self.assertFalse(cs.compute_ss_unmatched_signal(self._entry(), client, cache=None))
+        client.lookup.assert_called_once()
+
+    def test_cache_hit_skips_lookup(self):
+        client = MagicMock()
+        qf = "doi:10.1234/xyz|title:Test paper"
+        cache = _FakeCache(seed={
+            ("chen2024ai", "semantic_scholar", qf): {"matched": False, "matched_by": None}
+        })
+        result = cs.compute_ss_unmatched_signal(self._entry(), client, cache=cache)
+        self.assertTrue(result)  # matched=False → unmatched=True
+        client.lookup.assert_not_called()
+
+    def test_cache_miss_populates(self):
+        client = MagicMock()
+        client.lookup.return_value = {"matched": True}
+        cache = _FakeCache()
+        result = cs.compute_ss_unmatched_signal(self._entry(), client, cache=cache)
+        self.assertFalse(result)
+        self.assertEqual(len(cache.put_calls), 1)
+        _, resolver, _, response = cache.put_calls[0]
+        self.assertEqual(resolver, "semantic_scholar")
+        self.assertIs(response["matched"], True)
+
+    def test_manual_does_not_touch_cache(self):
+        client = MagicMock()
+        cache = _FakeCache()
+        result = cs.compute_ss_unmatched_signal(
+            self._entry(obtained_via="manual"), client, cache=cache
+        )
+        self.assertIsNone(result)
+        self.assertEqual(cache.get_calls, [])
+        self.assertEqual(cache.put_calls, [])
+
+    def test_degradation_not_cached(self):
+        client = MagicMock()
+        client.lookup.side_effect = cs.SemanticScholarUnavailable("5xx")
+        cache = _FakeCache()
+        result = cs.compute_ss_unmatched_signal(self._entry(), client, cache=cache)
+        self.assertIsNone(result)  # degradation → None (omit field)
+        self.assertEqual(cache.put_calls, [])  # never cache degradation

--- a/scripts/test_verification_cache.py
+++ b/scripts/test_verification_cache.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for the persistent verification cache (Delta 2).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 2.
+
+The cache is a local SQLite-backed store keyed by
+(citation_key, resolver_name, query_form). All tests point
+ARS_VERIFICATION_CACHE_PATH at a tmp file so no real ~/.cache/ars/ db is
+touched and runs are isolated.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture()
+def cache(tmp_path, monkeypatch):
+    from verification_cache import VerificationCache
+
+    db = tmp_path / "verification.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    return VerificationCache()
+
+
+def test_put_then_get_round_trip(cache):
+    cache.put("smith2024", "crossref", "10.5555/abc", {"matched": True})
+    got = cache.get("smith2024", "crossref", "10.5555/abc")
+    assert got is not None
+    assert got["matched"] is True
+
+
+def test_miss_returns_none(cache):
+    assert cache.get("nobody2024", "crossref", "10.5555/none") is None
+
+
+def test_distinct_resolvers_same_citation_are_independent(cache):
+    cache.put("smith2024", "crossref", "10.5555/abc", {"src": "cr"})
+    cache.put("smith2024", "arxiv", "1706.03762", {"src": "ax"})
+    assert cache.get("smith2024", "crossref", "10.5555/abc")["src"] == "cr"
+    assert cache.get("smith2024", "arxiv", "1706.03762")["src"] == "ax"
+
+
+def test_distinct_query_form_same_resolver_independent(cache):
+    cache.put("smith2024", "crossref", "10.5555/abc", {"via": "doi"})
+    cache.put("smith2024", "crossref", "smith attention 2024", {"via": "title"})
+    assert cache.get("smith2024", "crossref", "10.5555/abc")["via"] == "doi"
+    assert cache.get(
+        "smith2024", "crossref", "smith attention 2024"
+    )["via"] == "title"
+
+
+def test_put_overwrites_same_key(cache):
+    cache.put("smith2024", "crossref", "10.5555/abc", {"matched": False})
+    cache.put("smith2024", "crossref", "10.5555/abc", {"matched": True})
+    assert cache.get("smith2024", "crossref", "10.5555/abc")["matched"] is True
+
+
+def test_expired_entry_returns_none(tmp_path, monkeypatch):
+    """An entry older than the TTL (90 days) is a miss."""
+    from verification_cache import VerificationCache, _TTL_DAYS
+
+    db = tmp_path / "verification.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    c = VerificationCache()
+    c.put("old2020", "crossref", "10.5555/old", {"matched": True})
+
+    # Backdate the stored verification_timestamp past the TTL by writing
+    # directly to the underlying row.
+    stale = (
+        datetime.now(timezone.utc) - timedelta(days=_TTL_DAYS + 1)
+    ).isoformat()
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "UPDATE verification_cache SET verification_timestamp = ? "
+        "WHERE citation_key = ?",
+        (stale, "old2020"),
+    )
+    conn.commit()
+    conn.close()
+
+    assert c.get("old2020", "crossref", "10.5555/old") is None
+
+
+def test_fresh_entry_within_ttl_returns_value(tmp_path, monkeypatch):
+    from verification_cache import VerificationCache, _TTL_DAYS
+
+    db = tmp_path / "verification.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    c = VerificationCache()
+    c.put("recent2026", "arxiv", "2605.18661", {"matched": True})
+
+    fresh = (
+        datetime.now(timezone.utc) - timedelta(days=_TTL_DAYS - 1)
+    ).isoformat()
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "UPDATE verification_cache SET verification_timestamp = ? "
+        "WHERE citation_key = ?",
+        (fresh, "recent2026"),
+    )
+    conn.commit()
+    conn.close()
+
+    got = c.get("recent2026", "arxiv", "2605.18661")
+    assert got is not None and got["matched"] is True
+
+
+def test_invalidate_removes_all_resolvers_for_citation(cache):
+    cache.put("smith2024", "crossref", "10.5555/abc", {"src": "cr"})
+    cache.put("smith2024", "arxiv", "1706.03762", {"src": "ax"})
+    cache.put("jones2024", "crossref", "10.5555/xyz", {"src": "cr2"})
+
+    cache.invalidate("smith2024")
+
+    assert cache.get("smith2024", "crossref", "10.5555/abc") is None
+    assert cache.get("smith2024", "arxiv", "1706.03762") is None
+    # Other citations untouched.
+    assert cache.get("jones2024", "crossref", "10.5555/xyz")["src"] == "cr2"
+
+
+def test_invalidate_unknown_citation_is_noop(cache):
+    # Should not raise.
+    cache.invalidate("never-stored")
+
+
+def test_env_path_override_is_honored(tmp_path, monkeypatch):
+    from verification_cache import VerificationCache
+
+    db = tmp_path / "custom" / "mycache.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    c = VerificationCache()
+    c.put("k", "crossref", "q", {"v": 1})
+    assert db.exists(), "cache file must be created at the env-override path"
+
+
+def test_explicit_path_arg_overrides_env(tmp_path, monkeypatch):
+    from verification_cache import VerificationCache
+
+    env_db = tmp_path / "env.db"
+    arg_db = tmp_path / "arg.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(env_db))
+    c = VerificationCache(path=str(arg_db))
+    c.put("k", "crossref", "q", {"v": 1})
+    assert arg_db.exists()
+    assert not env_db.exists(), "explicit path arg must win over env var"
+
+
+def test_wal_mode_enabled(cache):
+    """SQLite WAL mode for single-writer-many-readers safety (spec Delta 2)."""
+    conn = sqlite3.connect(cache.path)
+    mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    conn.close()
+    assert mode.lower() == "wal"
+
+
+def test_response_roundtrips_nested_structure(cache):
+    """Resolver responses are arbitrary JSON-serializable dicts."""
+    payload = {
+        "matched": True,
+        "resolver_outcomes": {"crossref": {"status": "matched"}},
+        "title": "Attention Is All You Need",
+        "year": 2017,
+    }
+    cache.put("vaswani2017", "crossref", "10.5555/abc", payload)
+    assert cache.get("vaswani2017", "crossref", "10.5555/abc") == payload

--- a/scripts/verification_cache.py
+++ b/scripts/verification_cache.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Persistent verification cache for the bibliographic resolvers (Delta 2).
+
+A local SQLite-backed cache so the same paper cited across multiple drafts
+does not re-hit Crossref / OpenAlex / Semantic Scholar / arXiv every run.
+
+Cache key: (citation_key, resolver_name, query_form).
+  - resolver_name ∈ {crossref, openalex, semantic_scholar, arxiv}
+  - query_form is the canonical-form DOI / arXiv ID / title-query string the
+    resolver was keyed on (the caller passes whichever it used).
+Cache value: the resolver's structured response (any JSON-serializable dict)
+plus a verification_timestamp.
+
+TTL: entries older than 90 days are treated as a miss. The 90-day window is a
+guess pending empirical tuning (spec OQ-1, deferred).
+
+Concurrency: SQLite WAL mode (single-writer-many-readers). The audit pipeline
+is single-process; multi-user shared cache is out of scope (spec Delta 2).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 2.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# Spec OQ-1: 90-day window is a guess, deferred for empirical tuning.
+_TTL_DAYS = 90
+
+_DEFAULT_PATH = Path.home() / ".cache" / "ars" / "verification.db"
+_ENV_PATH = "ARS_VERIFICATION_CACHE_PATH"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS verification_cache (
+    citation_key           TEXT NOT NULL,
+    resolver_name          TEXT NOT NULL,
+    query_form             TEXT NOT NULL,
+    response_json          TEXT NOT NULL,
+    verification_timestamp TEXT NOT NULL,
+    PRIMARY KEY (citation_key, resolver_name, query_form)
+)
+"""
+
+
+def _resolve_path(path: str | None) -> Path:
+    """Explicit arg wins over the env override, which wins over the default."""
+    if path is not None:
+        return Path(path)
+    env = os.environ.get(_ENV_PATH)
+    if env:
+        return Path(env)
+    return _DEFAULT_PATH
+
+
+class VerificationCache:
+    """SQLite-backed (citation_key, resolver_name, query_form) → response cache.
+
+    Single-process use. Each method opens a short-lived connection so the
+    cache holds no long-lived file handle across pipeline stages.
+    """
+
+    def __init__(self, path: str | None = None) -> None:
+        self.path = str(_resolve_path(path))
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        # `closing(...) as conn, conn` — the outer ctx closes the handle, the
+        # inner (the connection itself) commits/rolls back. Honors the
+        # short-lived-connection contract (no leaked handle across stages).
+        with closing(self._connect()) as conn, conn:
+            conn.execute(_SCHEMA)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        # WAL: single-writer-many-readers safety (spec Delta 2). Persistent
+        # journal-mode pragma — set on every connection (cheap; no-op when
+        # already WAL).
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def get(
+        self, citation_key: str, resolver_name: str, query_form: str,
+    ) -> dict[str, Any] | None:
+        """Return the cached response, or None on miss / expired entry.
+
+        An entry whose verification_timestamp is older than the TTL is a
+        miss (the caller then makes the live call and re-populates).
+        """
+        with closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT response_json, verification_timestamp "
+                "FROM verification_cache "
+                "WHERE citation_key = ? AND resolver_name = ? AND query_form = ?",
+                (citation_key, resolver_name, query_form),
+            ).fetchone()
+        if row is None:
+            return None
+        response_json, ts = row
+        if self._is_expired(ts):
+            return None
+        return json.loads(response_json)
+
+    def put(
+        self,
+        citation_key: str,
+        resolver_name: str,
+        query_form: str,
+        response: dict[str, Any],
+    ) -> None:
+        """Store (or overwrite) the resolver response, stamping it now (UTC)."""
+        now = datetime.now(timezone.utc).isoformat()
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO verification_cache "
+                "(citation_key, resolver_name, query_form, response_json, "
+                " verification_timestamp) VALUES (?, ?, ?, ?, ?)",
+                (
+                    citation_key,
+                    resolver_name,
+                    query_form,
+                    json.dumps(response),
+                    now,
+                ),
+            )
+
+    def invalidate(self, citation_key: str) -> None:
+        """Drop every cached entry (all resolvers, all query forms) for a
+        citation. Backs the /ars-cache-invalidate command. No-op when the
+        citation has no cached rows."""
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                "DELETE FROM verification_cache WHERE citation_key = ?",
+                (citation_key,),
+            )
+
+    @staticmethod
+    def _is_expired(verification_timestamp: str) -> bool:
+        stored = datetime.fromisoformat(verification_timestamp)
+        return datetime.now(timezone.utc) - stored > timedelta(days=_TTL_DAYS)

--- a/shared/contracts/passport/literature_corpus_entry.schema.json
+++ b/shared/contracts/passport/literature_corpus_entry.schema.json
@@ -146,7 +146,7 @@
     "contamination_signals": {
       "type": "object",
       "additionalProperties": false,
-      "description": "v3.7.3 + v3.9.0 contaminated-source advisory field (spec v3.7.3 §3.2 + v3.9.0 §3.4–§3.5). Up to four optional boolean signals computed at ingest time by bibliography_agent: v3.7.3 Vector 1 (preprint_post_llm_inflection — heuristic), v3.7.3 Vector 2 (semantic_scholar_unmatched — S2 lookup), v3.9.0 (openalex_unmatched + crossref_unmatched — triangulation extension). Surfaces at cite-time finalizer as CONTAMINATED-... marker annotation suffix; advisory only — does NOT block emission. Absence of the object means signals were not computed (legacy entries or check skipped). Presence with all populated *_unmatched fields false means lookup-based contamination evidence is absent for the queried indexes; `preprint_post_llm_inflection: true` is an independent contamination signal that remains active regardless of lookup field values. Manual entries are exempt from the three lookup fields per spec v3.9.0 §3.1 not-rule but still carry preprint_post_llm_inflection (heuristic). External motivation: Zhao et al. arXiv:2605.07723 (2026-05) documents post-2024-mid hallucination inflection in preprint corpora and §3 cross-index triangulation as viable false-positive reduction.",
+      "description": "v3.7.3 + v3.9.0 + v3.11 contaminated-source advisory field (spec v3.7.3 §3.2 + v3.9.0 §3.4–§3.5 + v3.11 #182 Delta 1). Up to five optional boolean signals computed at ingest time by bibliography_agent: v3.7.3 Vector 1 (preprint_post_llm_inflection — heuristic), v3.7.3 Vector 2 (semantic_scholar_unmatched — S2 lookup), v3.9.0 (openalex_unmatched + crossref_unmatched — triangulation extension), v3.11 (arxiv_unmatched — four-index triangulation extension). Surfaces at cite-time finalizer as CONTAMINATED-... marker annotation suffix; advisory only — does NOT block emission. Absence of the object means signals were not computed (legacy entries or check skipped). Presence with all populated *_unmatched fields false means lookup-based contamination evidence is absent for the queried indexes; `preprint_post_llm_inflection: true` is an independent contamination signal that remains active regardless of lookup field values. Manual entries are exempt from the four lookup fields per spec v3.9.0 §3.1 + v3.11 not-rule but still carry preprint_post_llm_inflection (heuristic). External motivation: Zhao et al. arXiv:2605.07723 (2026-05) documents post-2024-mid hallucination inflection in preprint corpora and §3 cross-index triangulation as viable false-positive reduction.",
       "properties": {
         "preprint_post_llm_inflection": {
           "type": "boolean",
@@ -163,6 +163,10 @@
         "crossref_unmatched": {
           "type": "boolean",
           "description": "True when a Crossref API lookup (per references/crossref_api_protocol.md) returned no match by DOI (with title cross-check) or title. Mirrors semantic_scholar_unmatched semantics. The check fires only when obtained_via != 'manual'. Per spec v3.9.0 §3.5."
+        },
+        "arxiv_unmatched": {
+          "type": "boolean",
+          "description": "True when an arXiv API lookup (per references/arxiv_api_protocol.md) returned no match by arXiv ID (with title cross-check) or title. Mirrors semantic_scholar_unmatched / crossref_unmatched / openalex_unmatched semantics, extending the v3.9.0 triplet to a four-index triangulation. The check fires only when obtained_via != 'manual'. Per spec v3.11 #182 Delta 1. Note: this is the raw triangulation signal; the #182 Delta 4 unified summary narrows the existence-gate `false` to ID-keyed unmatched (a title-only arxiv_unmatched with no resolvable arXiv ID is a coverage-gap signal, not fabrication evidence, per C-V6(a))."
         }
       }
     },
@@ -301,7 +305,7 @@
       }
     },
     {
-      "description": "v3.9.0 spec §3.1 extends v3.7.3 §3.2 manual-entry exemption (codex round-3 F11 closure) symmetrically: when obtained_via='manual' the bibliography_agent SKIPS all three lookups (Semantic Scholar / OpenAlex / Crossref) and OMITS the three *_unmatched fields. The schema enforces this contract: a manual entry MUST NOT carry any of semantic_scholar_unmatched / openalex_unmatched / crossref_unmatched. Setting any to true on a manual entry would surface CONTAMINATED-* on a user-vouched reference. The asymmetry: preprint_post_llm_inflection IS still computed for manual entries (pure heuristic, no lookup) and is not in the exemption scope.",
+      "description": "v3.9.0 spec §3.1 extends v3.7.3 §3.2 manual-entry exemption (codex round-3 F11 closure) symmetrically; v3.11 #182 Delta 1 extends it further to arxiv_unmatched: when obtained_via='manual' the bibliography_agent SKIPS all four lookups (Semantic Scholar / OpenAlex / Crossref / arXiv) and OMITS the four *_unmatched fields. The schema enforces this contract: a manual entry MUST NOT carry any of semantic_scholar_unmatched / openalex_unmatched / crossref_unmatched / arxiv_unmatched. Setting any to true on a manual entry would surface CONTAMINATED-* on a user-vouched reference. The asymmetry: preprint_post_llm_inflection IS still computed for manual entries (pure heuristic, no lookup) and is not in the exemption scope.",
       "if": {
         "properties": {
           "obtained_via": {
@@ -331,6 +335,11 @@
                 {
                   "required": [
                     "crossref_unmatched"
+                  ]
+                },
+                {
+                  "required": [
+                    "arxiv_unmatched"
                   ]
                 }
               ]


### PR DESCRIPTION
## Scope

The **data-layer slice** of #182 v3.11 (scope anchored in #299). Token-rendering and policy layers (finalizer matrix `k=0..4`, formatter allowlist, `citation_existence` gate, the unified summary / verification_gate API) are **deferred to a later batch** — they share an advisory-rendering surface with Delta 4 and are best landed together.

## What's in

**Delta 1 — arXiv resolver**
- `scripts/arxiv_client.py` — `ArxivClient` mirroring the crossref/openalex clients, but parsing **Atom XML** (not JSON), keyed by **arXiv ID** (not DOI), with fixed ~3s pacing. `arxiv_id_lookup` + `title_search` + `ArxivUnavailable` degradation contract.
- `deep-research/references/arxiv_api_protocol.md` — the API protocol doc.
- `literature_corpus_entry.schema.json` — optional `contamination_signals.arxiv_unmatched` boolean + manual-entry not-rule extended to forbid it (the `anyOf` now covers all four lookups).
- `contamination_signals.py` — `resolve_arxiv_unmatched` + `build_signals_object` arxiv extension (**signal computation only**).

**Delta 2 — persistent verification cache**
- `scripts/verification_cache.py` — SQLite **WAL** cache keyed by `(citation_key, resolver_name, query_form)`, 90-day TTL, `get`/`put`/`invalidate`.
- `cache=` threaded through all four resolver wrappers via a shared `_cached_verdict` helper. `cache=None` is **byte-equivalent** to prior behavior (existing callers unchanged).
- `scripts/ars_cache_invalidate.py` + `commands/ars-cache-invalidate.md`.

## Correctness invariants (verified)

- **`cache=None` byte-equivalent** — existing client/migration tests unchanged and green.
- **query_form keys the whole attempt** (`id:X|title:Y`) so a title-hit verdict is never cached under a bare-id key (the id-miss-then-title-hit trap).
- **Degradation is never cached** — the `put` runs only after a successful compute; a raised `*Unavailable` bypasses it.
- **Malformed cached payload → treated as a miss** (force live recompute), not a 90-day `KeyError`.
- **Manual entries never touch the cache** and omit the `*_unmatched` field.

## Tests

Full suite: **1981 passed, 3 skipped**. New coverage: arXiv client (incl. version-suffix / URL fall-through / empty-title / XML-degradation edges), cache round-trip + TTL + WAL + env-override, resolver cache integration (hit/miss/degradation/manual/malformed-payload), schema validation + not-rule. Each constraint has a mutation-check confirming the test is non-trivial.

## Not closing #182

`[skip-closes-check]` — this is a data-layer slice; the gate/policy deliverables (Delta 3/4/5 + Delta 1's token rendering) remain. #182 stays open.