### PR TITLE
feat(citation): #182 Delta 4+5 — verification summary + gate API (data layer) [skip-closes-check]

### DIFF
--- a/evals/gold/citation_extraction/README.md
+++ b/evals/gold/citation_extraction/README.md
@@ -1,6 +1,6 @@
 # Citation-Extraction Gold Subset (Phase 1a)
 
-50-tuple gold subset measuring the per-citation `lookup_verified` 3-class enum classification accuracy. Phase 1a shipped the data; **Phase 1b (#263) shipped the harness** (`scripts/run_evals.py`) — it now measures this gold set directly.
+51-tuple gold subset measuring the per-citation `lookup_verified` 3-class enum classification accuracy (50 original + one v3.11 by-design false-negative fixture, spec OQ-5 / C-V6(a)). Phase 1a shipped the data; **Phase 1b (#263) shipped the harness** (`scripts/run_evals.py`) — it now measures this gold set directly.
 
 Run it with:
 
@@ -8,7 +8,7 @@ Run it with:
 PYTHONPATH=. python -m scripts.run_evals --task citation_extraction
 ```
 
-The harness computes the predicted `lookup_verified` itself from each tuple's `resolver_outcomes.*.status` via the #182 Delta 4 reducer (`verification_gate.verify_citation` has not shipped yet; the reducer reconciles when it does). The metric is symmetric 3-class accuracy — `unresolvable` is never collapsed into `false`. Because `expected_outcomes.json` was authored by the same rule, a fresh run scores ~1.0.
+The harness computes the predicted `lookup_verified` from each tuple's `resolver_outcomes` via the #182 Delta 4 reducer `citation_verification_summary.reduce_lookup_verified` (the single source of truth). `verification_gate.verify_citation` (#182 Delta 5) runs the resolvers live and feeds the SAME reducer, so the harness and the shipped API agree by construction. The reducer uses the v3.11 narrowed-false definition (C-V6(a)): `false` requires an ID-keyed `unmatched` (`queried_by: id`); a title-only `unmatched` is a coverage gap and reduces to `unresolvable`, never `false`. The metric is symmetric 3-class accuracy — `unresolvable` is never collapsed into `false`. Because `expected_outcomes.json` was authored by the same rule, a fresh run scores ~1.0.
 
 ## Spec reference
 
@@ -26,7 +26,7 @@ The harness computes the predicted `lookup_verified` itself from each tuple's `r
 
 ## Threshold contract (v3.10.0 binding defaults)
 
-- Aggregate: `accuracy >= 0.90` across all 50 tuples
+- Aggregate: `accuracy >= 0.90` across all 51 tuples
 - Per-class: `accuracy >= 0.85` for each of `true` / `false` / `unresolvable`
 
 Changing these before v3.10.0 ship requires a spec amendment per #184 §3.1.1 / E-V2.
@@ -50,7 +50,7 @@ fuzzy-match false-positive path) is tracked in issue #250.
 
 ## Human expert verdicts
 
-10 of 50 tuples (20% per Delta 5) carry an optional `human_expert_verdict` field. The Phase 1b harness emits an `expert_concordance` row per class from these labeled tuples (agreement of the expert verdict vs `expected_outcomes.json`). The verdicts are advisory only — synthetic ground truth in `expected_outcomes.json` is the source of truth for CI gates per E-V3, and concordance never gates.
+11 tuples (the original 10 at 20% per Delta 5, plus the v3.11 by-design FN fixture) carry an optional `human_expert_verdict` field. The Phase 1b harness emits an `expert_concordance` row per class from these labeled tuples (agreement of the expert verdict vs `expected_outcomes.json`). The verdicts are advisory only — synthetic ground truth in `expected_outcomes.json` is the source of truth for CI gates per E-V3, and concordance never gates.
 
 ## Validator
 

--- a/evals/gold/citation_extraction/expected_outcomes.json
+++ b/evals/gold/citation_extraction/expected_outcomes.json
@@ -4,19 +4,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -25,19 +29,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -46,19 +54,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -67,19 +79,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -88,19 +104,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -109,19 +129,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -130,19 +154,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -151,19 +179,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -172,19 +204,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -193,19 +229,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -214,19 +254,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -235,19 +279,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -256,19 +304,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -277,19 +329,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -298,19 +354,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -319,19 +379,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -340,19 +404,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -361,19 +429,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -382,19 +454,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -403,19 +479,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -424,19 +504,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -445,19 +529,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -466,19 +554,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -487,19 +579,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -508,19 +604,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -529,19 +629,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -550,19 +654,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -571,19 +679,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -592,19 +704,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -613,19 +729,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "openalex": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "semantic_scholar": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "title"
       },
       "arxiv": {
         "status": "matched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       }
     }
   },
@@ -634,19 +754,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -655,19 +779,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -676,19 +804,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -697,19 +829,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -718,19 +854,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -739,19 +879,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -760,19 +904,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -781,19 +929,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -802,19 +954,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -823,19 +979,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -844,19 +1004,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "openalex": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "semantic_scholar": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -865,19 +1029,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "openalex": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "semantic_scholar": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -886,19 +1054,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "openalex": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "semantic_scholar": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -907,19 +1079,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "openalex": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "semantic_scholar": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -928,19 +1104,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "openalex": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "semantic_scholar": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -949,19 +1129,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -970,19 +1154,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -991,19 +1179,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -1012,19 +1204,23 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "openalex": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "semantic_scholar": {
         "status": "unmatched",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": "id"
       },
       "arxiv": {
         "status": "skipped",
-        "response_summary": null
+        "response_summary": null,
+        "queried_by": null
       }
     }
   },
@@ -1033,18 +1229,47 @@
     "resolver_outcomes": {
       "crossref": {
         "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "openalex": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "semantic_scholar": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "arxiv": {
+        "status": "skipped",
+        "response_summary": null,
+        "queried_by": null
+      }
+    }
+  },
+  "051-fabricated-title-only-no-identifier": {
+    "lookup_verified": "unresolvable",
+    "resolver_outcomes": {
+      "crossref": {
+        "status": "unmatched",
+        "queried_by": "title",
         "response_summary": null
       },
       "openalex": {
         "status": "unmatched",
+        "queried_by": "title",
         "response_summary": null
       },
       "semantic_scholar": {
         "status": "unmatched",
+        "queried_by": "title",
         "response_summary": null
       },
       "arxiv": {
         "status": "skipped",
+        "queried_by": null,
         "response_summary": null
       }
     }

--- a/evals/gold/citation_extraction/expected_outcomes.json
+++ b/evals/gold/citation_extraction/expected_outcomes.json
@@ -1273,5 +1273,30 @@
         "response_summary": null
       }
     }
+  },
+  "052-valid-unindexed-regional-paper": {
+    "lookup_verified": "unresolvable",
+    "resolver_outcomes": {
+      "crossref": {
+        "status": "unmatched",
+        "queried_by": "title",
+        "response_summary": null
+      },
+      "openalex": {
+        "status": "unmatched",
+        "queried_by": "title",
+        "response_summary": null
+      },
+      "semantic_scholar": {
+        "status": "unmatched",
+        "queried_by": "title",
+        "response_summary": null
+      },
+      "arxiv": {
+        "status": "skipped",
+        "queried_by": null,
+        "response_summary": null
+      }
+    }
   }
 }

--- a/evals/gold/citation_extraction/manifest.yaml
+++ b/evals/gold/citation_extraction/manifest.yaml
@@ -6,15 +6,18 @@ outcome_gradable: true
 description: |
   Phase 1 gold subset for #182 verification_gate.verify_citation.
   Measures the lookup_verified 3-class enum classification accuracy
-  across 51 hand-curated tuples (incl. one by-design false-negative
-  fixture per spec OQ-5 / C-V6(a): a no-identifier fabrication that
-  must stay unresolvable, never false).
+  across 52 hand-curated tuples. Two of them form the C-V6(a)
+  coverage-gap pair: a no-identifier fabrication (OQ-5 by-design
+  false-negative) and a legitimately-unindexed regional paper, both
+  of which must stay unresolvable, never false — proving the gate
+  treats fabrication and coverage-gap symmetrically when no resolvable
+  identifier exists.
 target:
   entrypoint: verification_gate.verify_citation
   predicted_field: lookup_verified
   expected_outcomes_path: expected_outcomes.json
   tuple_dir: tuples
-sample_n: 51
+sample_n: 52
 labels: ["true", "false", "unresolvable"]
 thresholds:
   aggregate:
@@ -42,5 +45,8 @@ tuple_distribution:
     n: 15
     expected_lookup_verified: "false"
   - kind: fabricated_title_only
+    n: 1
+    expected_lookup_verified: "unresolvable"
+  - kind: valid_unindexed
     n: 1
     expected_lookup_verified: "unresolvable"

--- a/evals/gold/citation_extraction/manifest.yaml
+++ b/evals/gold/citation_extraction/manifest.yaml
@@ -6,13 +6,15 @@ outcome_gradable: true
 description: |
   Phase 1 gold subset for #182 verification_gate.verify_citation.
   Measures the lookup_verified 3-class enum classification accuracy
-  across 50 hand-curated tuples.
+  across 51 hand-curated tuples (incl. one by-design false-negative
+  fixture per spec OQ-5 / C-V6(a): a no-identifier fabrication that
+  must stay unresolvable, never false).
 target:
   entrypoint: verification_gate.verify_citation
   predicted_field: lookup_verified
   expected_outcomes_path: expected_outcomes.json
   tuple_dir: tuples
-sample_n: 50
+sample_n: 51
 labels: ["true", "false", "unresolvable"]
 thresholds:
   aggregate:
@@ -39,3 +41,6 @@ tuple_distribution:
   - kind: fabricated
     n: 15
     expected_lookup_verified: "false"
+  - kind: fabricated_title_only
+    n: 1
+    expected_lookup_verified: "unresolvable"

--- a/evals/gold/citation_extraction/tuples/051-fabricated-title-only-no-identifier.json
+++ b/evals/gold/citation_extraction/tuples/051-fabricated-title-only-no-identifier.json
@@ -1,0 +1,27 @@
+{
+  "tuple_id": "051-fabricated-title-only-no-identifier",
+  "kind": "fabricated_title_only",
+  "corpus_entry": {
+    "citation_key": "Nakamura2024PhantomEthnographyTitleOnly",
+    "title": "Phantom Ethnography of Vanished Riverine Trade Guilds in Pre-Colonial Sarawak",
+    "authors": [
+      {"family": "Nakamura", "given": "K."},
+      {"family": "Abdullah", "given": "R."}
+    ],
+    "year": 2024,
+    "venue": "Journal of Regional Historical Ethnography",
+    "source_pointer": "shelf:regional-history/sarawak-trade-guilds",
+    "obtained_via": "folder-scan"
+  },
+  "arxiv_id": null,
+  "ref_slug": "nakamura-2024-phantom-ethnography",
+  "anchor": {"kind": "page", "value": "1"},
+  "human_expert_verdict": {
+    "verdict": "unresolvable",
+    "labeled_by": "ars-182-v3.11-by-design-fn-fixture",
+    "labeled_at": "2026-06-04T00:00:00Z",
+    "notes": "By-design false-negative fixture per spec OQ-5 / C-V6(a). This citation is FABRICATED (fabrication_intent=true) but carries NO DOI and NO arXiv ID — only a bogus title. With no resolvable identifier to key on, every resolver can only title-search, producing title-only unmatched (queried_by=title). The narrowed-false definition (C-V6(a)) classifies this as unresolvable, NOT false: a no-identifier fabrication is indistinguishable from a legitimately-unindexed regional/non-English paper, and the existence gate accepts this recall limit by design (the v3.8 claim-faithfulness audit + human review catch it instead). This fixture pins that the narrow does NOT promote a title-only unmatched to false even under a would-be strict policy."
+  },
+  "provenance_note": "Spec OQ-5 Acknowledged Limitation fixture. Mirrors the strict_articles_only coverage-gap carve-out: fabrication requires a falsifiable identifier, not mere absence-from-index.",
+  "fabrication_intent": true
+}

--- a/evals/gold/citation_extraction/tuples/052-valid-unindexed-regional-paper.json
+++ b/evals/gold/citation_extraction/tuples/052-valid-unindexed-regional-paper.json
@@ -1,0 +1,27 @@
+{
+  "tuple_id": "052-valid-unindexed-regional-paper",
+  "kind": "valid_unindexed",
+  "corpus_entry": {
+    "citation_key": "Sembiring2023AgroforestryKaroHighlands",
+    "title": "Smallholder Agroforestry Adaptation in the Karo Highlands of North Sumatra",
+    "authors": [
+      {"family": "Sembiring", "given": "T."},
+      {"family": "Ginting", "given": "M."}
+    ],
+    "year": 2023,
+    "venue": "Jurnal Penelitian Pertanian Regional",
+    "source_pointer": "shelf:regional-agronomy/karo-highlands-agroforestry",
+    "obtained_via": "folder-scan"
+  },
+  "arxiv_id": null,
+  "ref_slug": "sembiring-2023-agroforestry-karo",
+  "anchor": {"kind": "page", "value": "47"},
+  "human_expert_verdict": {
+    "verdict": "unresolvable",
+    "labeled_by": "ars-182-v3.11-coverage-gap-companion-fixture",
+    "labeled_at": "2026-06-04T00:00:00Z",
+    "notes": "Coverage-gap companion to the by-design FN fixture 051. This citation is GENUINE (fabrication_intent=false) — a real regional, non-English-indexed agronomy paper that simply is not in Crossref / OpenAlex / S2 / arXiv. It carries NO DOI and NO arXiv ID, so every resolver can only title-search, producing title-only unmatched (queried_by=title). The narrowed-false definition (C-V6(a)) classifies this as unresolvable, exactly as it classifies the no-identifier fabrication 051. Together 051+052 prove the gate's SYMMETRIC treatment of coverage gaps: a no-identifier fabrication and a legitimately-unindexed paper are indistinguishable to the existence gate, which is precisely why C-V6(a) narrows false to require an ID-keyed unmatched. If the gate ever promoted title-only unmatched to false, THIS genuine paper would be false-blocked."
+  },
+  "provenance_note": "Spec C-V6(a) symmetry fixture. Pairs with 051: same resolver shape (all title-only unmatched), same verdict (unresolvable), opposite fabrication_intent. Demonstrates the narrow protects real unindexed scholarship, not only that it tolerates a recall limit.",
+  "fabrication_intent": false
+}

--- a/scripts/check_evals_gold_set.py
+++ b/scripts/check_evals_gold_set.py
@@ -21,10 +21,17 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator
 
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+from citation_verification_summary import (  # noqa: E402
+    reduce_lookup_verified as _reduce_lookup_verified,
+)
+
 LABEL_ENUM = {"true", "false", "unresolvable"}
 QUERIED_BY_ENUM = {"id", "title", None}
 KIND_ENUM = {"valid_doi", "valid_arxiv", "manual_exempt", "fabricated",
-             "fabricated_title_only"}
+             "fabricated_title_only", "valid_unindexed"}
 RESOLVER_NAMES = ("crossref", "openalex", "semantic_scholar", "arxiv")
 STATUS_ENUM = {"matched", "unmatched", "unreachable", "skipped"}
 
@@ -186,6 +193,12 @@ def validate(root: Path) -> list[str]:
 
     # I9: resolver_outcomes has all four resolver keys with valid status enum
     # + valid queried_by enum (v3.11 #182 Delta 4 / C-V6(a)).
+    # I9b: every gold label must be REPRODUCIBLE by the shipped reducer (the
+    # single source of truth, C-V6(a) narrowed-false). Rather than hand-rolling
+    # the false condition here (which would drift from the reducer if C-V6(a) is
+    # ever amended), recompute each label via reduce_lookup_verified and assert
+    # it matches — pinning the gold to the reducer, not a parallel copy of its
+    # logic. Both share a single pass over expected.items().
     for tid, outcome in expected.items():
         ros = outcome.get("resolver_outcomes", {})
         for resolver in RESOLVER_NAMES:
@@ -206,22 +219,14 @@ def validate(root: Path) -> list[str]:
                     f"not in {{'id', 'title', null}}"
                 )
 
-    # I9b: narrowed-false invariant (C-V6(a)) — a `false`-labeled tuple MUST
-    # carry at least one ID-keyed unmatched (status=unmatched, queried_by=id).
-    # A title-only-only fabrication must be labeled `unresolvable`, not `false`.
-    for tid, outcome in expected.items():
-        if outcome.get("lookup_verified") != "false":
-            continue
-        ros = outcome.get("resolver_outcomes", {})
-        has_id_keyed_unmatched = any(
-            (r or {}).get("status") == "unmatched" and (r or {}).get("queried_by") == "id"
-            for r in ros.values()
-        )
-        if not has_id_keyed_unmatched:
+        recomputed = _reduce_lookup_verified(ros)
+        declared = outcome.get("lookup_verified")
+        if recomputed != declared:
             errors.append(
-                f"I9b: {tid} labeled lookup_verified=false but has no ID-keyed "
-                f"unmatched (C-V6(a): false requires a provably-bogus DOI/arXiv ID; "
-                f"a title-only unmatched must be labeled unresolvable)"
+                f"I9b: {tid} lookup_verified={declared!r} but the shipped reducer "
+                f"computes {recomputed!r} from its resolver_outcomes "
+                f"(gold label must match the single-source-of-truth reducer; "
+                f"C-V6(a) narrowed-false: false needs an ID-keyed unmatched)"
             )
 
     # I10: per-tuple corpus_entry validates against literature_corpus_entry.schema.json

--- a/scripts/check_evals_gold_set.py
+++ b/scripts/check_evals_gold_set.py
@@ -22,7 +22,9 @@ import yaml
 from jsonschema import Draft202012Validator
 
 LABEL_ENUM = {"true", "false", "unresolvable"}
-KIND_ENUM = {"valid_doi", "valid_arxiv", "manual_exempt", "fabricated"}
+QUERIED_BY_ENUM = {"id", "title", None}
+KIND_ENUM = {"valid_doi", "valid_arxiv", "manual_exempt", "fabricated",
+             "fabricated_title_only"}
 RESOLVER_NAMES = ("crossref", "openalex", "semantic_scholar", "arxiv")
 STATUS_ENUM = {"matched", "unmatched", "unreachable", "skipped"}
 
@@ -170,16 +172,20 @@ def validate(root: Path) -> list[str]:
             if arxiv_id:
                 errors.append(f"I6: {stem}.json kind={kind!r} but arxiv_id={arxiv_id!r} present (must be null)")
 
-    # I7: fabrication_intent <-> kind == "fabricated"
+    # I7: fabrication_intent <-> kind is a fabrication kind. Both `fabricated`
+    # (ID-keyed → false) and `fabricated_title_only` (no identifier → unresolvable,
+    # the C-V6(a) by-design FN fixture) are fabrications and MUST carry the marker.
+    fabrication_kinds = {"fabricated", "fabricated_title_only"}
     for stem, tup in tuples_by_id.items():
         kind = tup.get("kind")
         marker = tup.get("fabrication_intent")
-        if kind == "fabricated" and marker is not True:
-            errors.append(f"I7: {stem}.json kind=fabricated but fabrication_intent={marker!r} (must be true)")
-        if kind != "fabricated" and marker is True:
+        if kind in fabrication_kinds and marker is not True:
+            errors.append(f"I7: {stem}.json kind={kind!r} but fabrication_intent={marker!r} (must be true)")
+        if kind not in fabrication_kinds and marker is True:
             errors.append(f"I7: {stem}.json kind={kind!r} but fabrication_intent=true (must be false)")
 
     # I9: resolver_outcomes has all four resolver keys with valid status enum
+    # + valid queried_by enum (v3.11 #182 Delta 4 / C-V6(a)).
     for tid, outcome in expected.items():
         ros = outcome.get("resolver_outcomes", {})
         for resolver in RESOLVER_NAMES:
@@ -193,6 +199,30 @@ def validate(root: Path) -> list[str]:
                     f"I9: {tid} resolver_outcomes.{resolver}.status={status!r} "
                     f"not in {sorted(STATUS_ENUM)}"
                 )
+            queried_by = entry.get("queried_by")
+            if queried_by not in QUERIED_BY_ENUM:
+                errors.append(
+                    f"I9: {tid} resolver_outcomes.{resolver}.queried_by={queried_by!r} "
+                    f"not in {{'id', 'title', null}}"
+                )
+
+    # I9b: narrowed-false invariant (C-V6(a)) — a `false`-labeled tuple MUST
+    # carry at least one ID-keyed unmatched (status=unmatched, queried_by=id).
+    # A title-only-only fabrication must be labeled `unresolvable`, not `false`.
+    for tid, outcome in expected.items():
+        if outcome.get("lookup_verified") != "false":
+            continue
+        ros = outcome.get("resolver_outcomes", {})
+        has_id_keyed_unmatched = any(
+            (r or {}).get("status") == "unmatched" and (r or {}).get("queried_by") == "id"
+            for r in ros.values()
+        )
+        if not has_id_keyed_unmatched:
+            errors.append(
+                f"I9b: {tid} labeled lookup_verified=false but has no ID-keyed "
+                f"unmatched (C-V6(a): false requires a provably-bogus DOI/arXiv ID; "
+                f"a title-only unmatched must be labeled unresolvable)"
+            )
 
     # I10: per-tuple corpus_entry validates against literature_corpus_entry.schema.json
     for stem, tup in tuples_by_id.items():

--- a/scripts/citation_verification_summary.py
+++ b/scripts/citation_verification_summary.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Citation verification summary reducer (Delta 4) — SINGLE SOURCE OF TRUTH.
+
+Reduces per-resolver outcomes to the 3-class `lookup_verified` value using the
+v3.11 narrowed-false definition (C-V6(a)): `false` requires at least one
+ID-keyed unmatched (a DOI/arXiv ID that provably fails to resolve = fabrication
+evidence); a title-only unmatched (no resolvable identifier to key on) is a
+coverage gap and reduces to `unresolvable`, never `false`.
+
+run_evals.py imports `reduce_lookup_verified` from here; there is exactly one
+reducer implementation in the repo (the old un-narrowed copy in run_evals.py
+was removed when this landed).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md
+§2 Delta 4 + §0(4a) + INVARIANT C-V6(a).
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+STATUS_MATCHED = "matched"
+STATUS_UNMATCHED = "unmatched"
+STATUS_UNREACHABLE = "unreachable"
+STATUS_SKIPPED = "skipped"
+
+QUERIED_BY_ID = "id"
+
+CITATION_LABELS = ("true", "false", "unresolvable")
+
+
+def reduce_lookup_verified(resolver_outcomes: Mapping[str, Any]) -> str:
+    """Reduce per-resolver outcomes to a 3-class lookup_verified value.
+
+    Each value in `resolver_outcomes` is a dict with at least `status`, and
+    (for unmatched rows) `queried_by` ∈ {'id', 'title', None}.
+
+    Rules (symmetric 3-class; `unresolvable` is NEVER collapsed into `false`):
+
+    * `skipped` outcomes are EXCLUDED from classification (resolver
+      applicability / policy, not adjudication). "applicable" = not skipped.
+    * `true` iff >=1 applicable resolver is `matched` (matched WINS — true even
+      if another applicable resolver is `unmatched`).
+    * `false` (v3.11 narrowed, C-V6(a)) iff NO applicable resolver is `matched`
+      AND >=1 applicable resolver is an **ID-keyed** `unmatched`
+      (status=unmatched AND queried_by='id'). A bogus DOI/arXiv ID that
+      provably fails to resolve is fabrication evidence. Anti-fabrication bias:
+      one ID-keyed unmatched stands even alongside an `unreachable` (a transient
+      outage does not cancel positive non-existence evidence).
+    * `unresolvable` otherwise — every applicable resolver `unreachable` (total
+      outage), OR every resolver `skipped` (empty adjudicating set, manual
+      exempt), OR the only negative signals are title-only `unmatched`
+      (queried_by != 'id' — no resolvable identifier to key on = coverage gap,
+      the real-but-unindexed paper; C-V6(a)/(f) + OQ-5 by-design FN).
+    """
+    outcomes = [v or {} for v in resolver_outcomes.values()]
+    applicable = [o for o in outcomes if o.get("status") != STATUS_SKIPPED]
+
+    if any(o.get("status") == STATUS_MATCHED for o in applicable):
+        return "true"
+
+    id_keyed_unmatched = any(
+        o.get("status") == STATUS_UNMATCHED and o.get("queried_by") == QUERIED_BY_ID
+        for o in applicable
+    )
+    if id_keyed_unmatched:
+        return "false"
+
+    return "unresolvable"

--- a/scripts/citation_verification_summary.py
+++ b/scripts/citation_verification_summary.py
@@ -11,6 +11,19 @@ run_evals.py imports `reduce_lookup_verified` from here; there is exactly one
 reducer implementation in the repo (the old un-narrowed copy in run_evals.py
 was removed when this landed).
 
+OQ-5 recall limit (user-facing surfacing deferred). The narrowed-false rule
+means a fabricated citation that carries NO resolvable identifier (no DOI /
+arXiv ID, only a bogus title) reduces to `unresolvable`, NOT `false`, so the
+citation-existence gate does not block it — it is indistinguishable from a
+legitimately unindexed (regional / non-English / pre-digital) paper. This is an
+accepted recall limit, caught instead by the v3.8 claim-faithfulness audit +
+human review. The user-facing explanation of this limit (in docs/ARCHITECTURE.md
+and the user guide) and the policy that consumes this verdict
+(`terminal_policies.citation_existence`, enum {advisory, strict}) both land with
+the Delta 3 / C-V6 policy batch — this data-layer batch only computes the
+verdict; it does not gate on it. Gold fixtures 051 (FN) + 052 (legit-unindexed)
+pin the symmetric treatment.
+
 Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md
 §2 Delta 4 + §0(4a) + INVARIANT C-V6(a).
 """
@@ -24,8 +37,6 @@ STATUS_UNREACHABLE = "unreachable"
 STATUS_SKIPPED = "skipped"
 
 QUERIED_BY_ID = "id"
-
-CITATION_LABELS = ("true", "false", "unresolvable")
 
 
 def reduce_lookup_verified(resolver_outcomes: Mapping[str, Any]) -> str:

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -172,11 +172,20 @@ def compute_ss_unmatched_signal(
             compute=lambda: (
                 not bool(client.lookup(entry).get("matched", False)),
                 None,
-                "id" if entry.get("doi") else "title",
+                queried_by_for(entry, id_field="doi"),
             ),
         )
     except SemanticScholarUnavailable:
         return None  # degradation → omit field, never cached
+
+
+def queried_by_for(entry: Mapping[str, Any], *, id_field: str) -> str:
+    """The C-V6(a) queried_by value for an entry: 'id' when the entry carries the
+    resolver's exact identifier (so an ID-keyed lookup is attempted), else
+    'title'. The SINGLE definition of this rule — all resolver paths (DOI-keyed,
+    arXiv-keyed, and S2's entry-keyed lookup) derive queried_by through here so
+    the narrowed-false signal can never drift across layers."""
+    return "id" if entry.get(id_field) else "title"
 
 
 def _query_form(*, id_label: str, id_value: str | None, title: str) -> str:
@@ -251,7 +260,7 @@ def _resolve_doi_then_title(
     catches."""
     title = entry.get("title", "")
     doi = entry.get("doi")
-    queried_by = "id" if doi else "title"
+    queried_by = queried_by_for(entry, id_field="doi")
     if doi:
         hit = client.doi_lookup_with_title_check(doi, title)
         if hit is not None:
@@ -343,7 +352,7 @@ def _resolve_arxiv_id_then_title(
     exception differentiation stays at the wrapper."""
     title = entry.get("title", "")
     arxiv_id = entry.get("arxiv_id")
-    queried_by = "id" if arxiv_id else "title"
+    queried_by = queried_by_for(entry, id_field="arxiv_id")
     if arxiv_id:
         hit = client.arxiv_id_lookup(arxiv_id, title)
         if hit is not None:

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -167,9 +167,12 @@ def compute_ss_unmatched_signal(
                 id_value=entry.get("doi"),
                 title=entry.get("title", ""),
             ),
+            # S2's lookup() does DOI-first then title internally, so queried_by
+            # follows the same has-an-id rule as the other resolvers (C-V6(a)).
             compute=lambda: (
                 not bool(client.lookup(entry).get("matched", False)),
                 None,
+                "id" if entry.get("doi") else "title",
             ),
         )
     except SemanticScholarUnavailable:
@@ -198,48 +201,66 @@ def _cached_verdict(
 ) -> bool | None:
     """Wrap a verdict computation with the persistent cache (spec §2 Delta 2).
 
-    `compute()` returns `(unmatched: bool, matched_by: str | None)`. On a cache
-    hit the network call is skipped and the stored verdict is returned. On a
-    miss the live `compute()` runs and the verdict is persisted (negatives
-    included, so repeat runs don't re-hammer the API). `cache=None` is
-    byte-equivalent to no caching. Degradation exceptions propagate from
-    `compute()` and are NEVER cached (the caller omits the field).
+    `compute()` returns `(unmatched: bool, matched_by: str | None,
+    queried_by: str)`. On a cache hit the network call is skipped and the stored
+    verdict is returned. On a miss the live `compute()` runs and the verdict is
+    persisted (negatives included, so repeat runs don't re-hammer the API).
+    `cache=None` is byte-equivalent to no caching. Degradation exceptions
+    propagate from `compute()` and are NEVER cached (the caller omits the field).
+
+    The stored payload carries `matched_by` + `queried_by` so a cached negative
+    keeps the C-V6(a) ID-keyed signal the narrowed-false reducer needs.
     """
     if cache is None:
-        unmatched, _ = compute()
+        unmatched, _, _ = compute()
         return unmatched
     cached = cache.get(citation_key, resolver_name, query_form)
     if cached is not None and "matched" in cached:
         return not cached["matched"]
     # A row missing `matched` (written by an older/other tool) is treated as a
     # miss — force a live recompute rather than KeyError for the 90-day TTL.
-    unmatched, matched_by = compute()
+    unmatched, matched_by, queried_by = compute()
     # query_form is the cache key, not part of the value — no need to echo it
     # into the stored payload (nothing reads it back).
     cache.put(
         citation_key,
         resolver_name,
         query_form,
-        {"matched": not unmatched, "matched_by": matched_by},
+        {"matched": not unmatched, "matched_by": matched_by,
+         "queried_by": queried_by},
     )
     return unmatched
 
 
-def _resolve_doi_then_title(entry: Mapping[str, Any], client) -> tuple[bool, str | None]:
-    """Run the DOI-then-title resolver flow, returning (unmatched, matched_by).
-    matched_by ∈ {'doi', 'title', None}. Exception-type differentiation stays
-    at the wrapper — this helper never catches."""
+def _resolve_doi_then_title(
+    entry: Mapping[str, Any], client,
+) -> tuple[bool, str | None, str]:
+    """Run the DOI-then-title resolver flow, returning
+    (unmatched, matched_by, queried_by).
+
+    matched_by ∈ {'doi', 'title', None}: which channel produced a match.
+    queried_by ∈ {'id', 'title'}: what the resolver ACTUALLY queried by —
+      'id' when a DOI was present (so an exact-key lookup was attempted, even
+      if it then fell through to title), 'title' when no DOI was available to
+      key on. This is the C-V6(a) signal: an `unmatched` with queried_by='id'
+      is fabrication evidence (a provably-bogus identifier); queried_by='title'
+      is a coverage gap (reduce to unresolvable, not false). It reflects
+      execution, not entry shape — see #182 Delta 4 / C-V6(a).
+
+    Exception-type differentiation stays at the wrapper — this helper never
+    catches."""
     title = entry.get("title", "")
     doi = entry.get("doi")
+    queried_by = "id" if doi else "title"
     if doi:
         hit = client.doi_lookup_with_title_check(doi, title)
         if hit is not None:
-            return False, "doi"
+            return False, "doi", queried_by
         # DOI miss or MISMATCH — fall through to title search.
     hit = client.title_search(title)
     if hit is not None:
-        return False, "title"
-    return True, None
+        return False, "title", queried_by
+    return True, None, queried_by
 
 
 def _resolve_by_doi_then_title(
@@ -314,21 +335,24 @@ def resolve_crossref_unmatched(
 
 def _resolve_arxiv_id_then_title(
     entry: Mapping[str, Any], client,
-) -> tuple[bool, str | None]:
+) -> tuple[bool, str | None, str]:
     """arXiv-specific resolver flow (ID-keyed, not DOI-keyed), returning
-    (unmatched, matched_by). matched_by ∈ {'arxiv', 'title', None}. Never
-    catches — exception differentiation stays at the wrapper."""
+    (unmatched, matched_by, queried_by). matched_by ∈ {'arxiv', 'title', None};
+    queried_by ∈ {'id', 'title'} per the C-V6(a) signal (see
+    _resolve_doi_then_title). 'id' when an arXiv ID was present. Never catches —
+    exception differentiation stays at the wrapper."""
     title = entry.get("title", "")
     arxiv_id = entry.get("arxiv_id")
+    queried_by = "id" if arxiv_id else "title"
     if arxiv_id:
         hit = client.arxiv_id_lookup(arxiv_id, title)
         if hit is not None:
-            return False, "arxiv"
+            return False, "arxiv", queried_by
         # ID miss or MISMATCH — fall through to title search.
     hit = client.title_search(title)
     if hit is not None:
-        return False, "title"
-    return True, None
+        return False, "title", queried_by
+    return True, None, queried_by
 
 
 def resolve_arxiv_unmatched(

--- a/scripts/fixtures/check_evals_gold_set/clean/expected_outcomes.json
+++ b/scripts/fixtures/check_evals_gold_set/clean/expected_outcomes.json
@@ -2,28 +2,76 @@
   "001-valid-doi-test": {
     "lookup_verified": "true",
     "resolver_outcomes": {
-      "crossref": { "status": "matched", "response_summary": null },
-      "openalex": { "status": "matched", "response_summary": null },
-      "semantic_scholar": { "status": "matched", "response_summary": null },
-      "arxiv": { "status": "skipped", "response_summary": null }
+      "crossref": {
+        "status": "matched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "openalex": {
+        "status": "matched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "semantic_scholar": {
+        "status": "matched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "arxiv": {
+        "status": "skipped",
+        "response_summary": null,
+        "queried_by": null
+      }
     }
   },
   "002-valid-arxiv-test": {
     "lookup_verified": "true",
     "resolver_outcomes": {
-      "crossref": { "status": "unmatched", "response_summary": null },
-      "openalex": { "status": "unmatched", "response_summary": null },
-      "semantic_scholar": { "status": "unmatched", "response_summary": null },
-      "arxiv": { "status": "matched", "response_summary": null }
+      "crossref": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "title"
+      },
+      "openalex": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "title"
+      },
+      "semantic_scholar": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "title"
+      },
+      "arxiv": {
+        "status": "matched",
+        "response_summary": null,
+        "queried_by": "id"
+      }
     }
   },
   "003-fabricated-test": {
     "lookup_verified": "false",
     "resolver_outcomes": {
-      "crossref": { "status": "unmatched", "response_summary": null },
-      "openalex": { "status": "unmatched", "response_summary": null },
-      "semantic_scholar": { "status": "unmatched", "response_summary": null },
-      "arxiv": { "status": "skipped", "response_summary": null }
+      "crossref": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "openalex": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "semantic_scholar": {
+        "status": "unmatched",
+        "response_summary": null,
+        "queried_by": "id"
+      },
+      "arxiv": {
+        "status": "skipped",
+        "response_summary": null,
+        "queried_by": null
+      }
     }
   }
 }

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -7,11 +7,11 @@ each task, and emits a report shaped by ``shared/evals_lift_report.schema.json``
 Per-task measurement dispatch:
 
 * ``citation_extraction`` (outcome-gradable) — the harness computes the predicted
-  ``lookup_verified`` 3-class enum ITSELF from each tuple's
-  ``resolver_outcomes.*.status`` via the #182 Delta 4 reducer (see
-  ``reduce_lookup_verified``). It does NOT call ``verification_gate.verify_citation``
-  because that API has not shipped yet (#182 Delta 5). When that module lands,
-  reconcile the reducer against it.
+  ``lookup_verified`` 3-class enum from each tuple's ``resolver_outcomes`` via the
+  shipped #182 Delta 4 reducer ``citation_verification_summary.reduce_lookup_verified``
+  (the SINGLE source of truth — re-exported here for back-compat). The reducer uses
+  the v3.11 narrowed-false definition (C-V6(a)): ``false`` requires an ID-keyed
+  unmatched, never a title-only one.
 * ``rq_framing_patterns`` (advisory-calibration) — dispatches to the existing
   ``scripts.check_rq_framing_patterns`` runner and adapts its FNR / FPR /
   balanced-accuracy output into the per-task lift-report shape.
@@ -64,38 +64,17 @@ CITATION_LABELS = ("true", "false", "unresolvable")
 
 
 # ---------------------------------------------------------------------------
-# #182 Delta 4 reducer
+# #182 Delta 4 reducer — single source of truth lives in
+# citation_verification_summary.py. Re-exported here so existing callers
+# (and tests) that import run_evals.reduce_lookup_verified keep working.
+# The reducer uses the v3.11 narrowed-false definition (C-V6(a)): `false`
+# requires an ID-keyed unmatched (resolver_outcomes[r].queried_by == "id"),
+# never a title-only unmatched.
 # ---------------------------------------------------------------------------
-def reduce_lookup_verified(resolver_outcomes: dict[str, Any]) -> str:
-    """Reduce per-resolver statuses to a 3-class ``lookup_verified`` value.
-
-    reducer mirrors #182 Delta 4; reconcile when verification_gate.verify_citation ships.
-
-    Rules (symmetric 3-class; ``unresolvable`` is NEVER collapsed into ``false``):
-
-    * ``skipped`` outcomes are EXCLUDED from classification (resolver
-      applicability / policy, not adjudication). "Applicable" = not skipped.
-    * ``true``  iff at least one applicable resolver returned ``matched``
-      (matched WINS — true even if another applicable resolver is ``unmatched``).
-    * ``false`` iff at least one applicable resolver returned ``unmatched`` AND
-      no applicable resolver returned ``matched`` (anti-fabrication bias:
-      3 unmatched + 1 unreachable -> false).
-    * ``unresolvable`` iff every applicable resolver is ``unreachable`` (total
-      outage) with no matched/unmatched — OR — every resolver is ``skipped``
-      (empty adjudicating set; manual-entry exempt). Both default to
-      ``unresolvable``.
-    """
-    statuses = [
-        (entry or {}).get("status")
-        for entry in resolver_outcomes.values()
-    ]
-    applicable = [s for s in statuses if s != STATUS_SKIPPED]
-
-    if any(s == STATUS_MATCHED for s in applicable):
-        return "true"
-    if any(s == STATUS_UNMATCHED for s in applicable):
-        return "false"
-    return "unresolvable"
+try:
+    from citation_verification_summary import reduce_lookup_verified
+except ImportError:
+    from scripts.citation_verification_summary import reduce_lookup_verified
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -114,8 +114,11 @@ def _accuracy(correct: int, total: int) -> float:
 def measure_citation_extraction(task_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
     """Self-reduce every tuple's resolver_outcomes and score vs expected_outcomes.
 
-    The predicted label is computed by ``reduce_lookup_verified`` (not by calling
-    the not-yet-shipped ``verification_gate.verify_citation``).
+    The predicted label is computed by ``reduce_lookup_verified`` directly from
+    each tuple's pre-recorded ``resolver_outcomes`` (no live network in CI).
+    ``verification_gate.verify_citation`` (#182 Delta 5) runs the resolvers live
+    and feeds the SAME reducer, so the harness and the shipped API agree by
+    construction — they share one reducer (the single source of truth).
     """
     target = manifest.get("target", {})
     expected_path = task_dir / target.get("expected_outcomes_path", "expected_outcomes.json")
@@ -408,8 +411,10 @@ def build_report(task_names: list[str], gold_root: Path = GOLD_ROOT) -> dict[str
     per_task = [run_task(name, gold_root) for name in task_names]
     caveats = [
         "Synthetic gold set; expert_concordance is advisory and never gates (E-V3).",
-        "citation_extraction predicted labels are computed by the local #182 "
-        "Delta 4 reducer, not by verification_gate.verify_citation (not yet shipped).",
+        "citation_extraction predicted labels are computed by the #182 Delta 4 "
+        "reducer (the single source of truth) from each tuple's pre-recorded "
+        "resolver_outcomes; verification_gate.verify_citation feeds the same "
+        "reducer live, so harness and API agree by construction.",
     ]
     pending = [t["task_name"] for t in per_task if t.get("status") != "measured"]
     if pending:

--- a/scripts/test_check_evals_gold_set.py
+++ b/scripts/test_check_evals_gold_set.py
@@ -184,6 +184,32 @@ def test_i9_invalid_status_enum_caught(tmp_path):
     assert any("I9" in e for e in errors), f"I9 not caught; errors: {errors}"
 
 
+def test_i9_invalid_queried_by_enum_caught(tmp_path):
+    """I9: queried_by outside {id, title, null} caught (v3.11 Delta 4)."""
+    target = _copy_clean(tmp_path)
+    exp = json.loads((target / "expected_outcomes.json").read_text(encoding="utf-8"))
+    exp["001-valid-doi-test"]["resolver_outcomes"]["crossref"]["queried_by"] = "doi"
+    (target / "expected_outcomes.json").write_text(json.dumps(exp))
+    errors = check_evals_gold_set.validate(target)
+    assert any("I9" in e for e in errors), f"I9 not caught; errors: {errors}"
+
+
+def test_i9b_false_with_only_title_only_unmatched_caught(tmp_path):
+    """I9b (C-V6(a)): a `false`-labeled tuple whose unmatched are all title-only
+    (queried_by != id) is a mislabel — narrowed-false requires an ID-keyed
+    unmatched. The validator must catch it (a title-only fabrication should be
+    labeled unresolvable)."""
+    target = _copy_clean(tmp_path)
+    exp = json.loads((target / "expected_outcomes.json").read_text(encoding="utf-8"))
+    # 003-fabricated-test is labeled false; flip its unmatched to title-only.
+    for r in exp["003-fabricated-test"]["resolver_outcomes"].values():
+        if r["status"] == "unmatched":
+            r["queried_by"] = "title"
+    (target / "expected_outcomes.json").write_text(json.dumps(exp))
+    errors = check_evals_gold_set.validate(target)
+    assert any("I9b" in e for e in errors), f"I9b not caught; errors: {errors}"
+
+
 def test_i10_authors_string_shorthand_caught(tmp_path):
     """I10: corpus_entry.authors as string array (CSL-JSON shorthand) caught.
 

--- a/scripts/test_citation_verification_summary.py
+++ b/scripts/test_citation_verification_summary.py
@@ -40,6 +40,8 @@ def validator(schema):
 
 
 def _entry(**overrides):
+    # Production-shaped: all four resolver keys present (the summary contract is
+    # fully-populated; absent != skipped). crossref matched, the rest skipped.
     base = {
         "citation_key": "vaswani2017",
         "ref_slug": "vaswani-2017-attention",
@@ -49,10 +51,24 @@ def _entry(**overrides):
         "resolver_outcomes": {
             "crossref": {"status": "matched", "queried_by": "id",
                          "response_summary": None},
+            "openalex": {"status": "skipped", "queried_by": None,
+                         "response_summary": None},
+            "semantic_scholar": {"status": "skipped", "queried_by": None,
+                                 "response_summary": None},
+            "arxiv": {"status": "skipped", "queried_by": None,
+                      "response_summary": None},
         },
     }
     base.update(overrides)
     return base
+
+
+def _full_ro(**overrides):
+    """All four resolver keys, default skipped/null; override individual ones."""
+    ro = {r: {"status": "skipped", "queried_by": None, "response_summary": None}
+          for r in ("crossref", "openalex", "semantic_scholar", "arxiv")}
+    ro.update(overrides)
+    return ro
 
 
 # ---------- Schema self-consistency ----------
@@ -87,23 +103,29 @@ def test_verification_timestamp_never_null(validator):
 
 
 def test_resolver_outcome_status_enum(validator):
-    for s in ("matched", "unmatched", "unreachable", "skipped"):
-        e = _entry(resolver_outcomes={"crossref": {
-            "status": s, "queried_by": "id", "response_summary": None}})
+    # status enum exercised with a coherent queried_by per status (ran→id,
+    # skipped/unreachable→null), against the full four-resolver shape.
+    for s, q in (("matched", "id"), ("unmatched", "id"),
+                 ("unreachable", None), ("skipped", None)):
+        e = _entry(lookup_verified="true", resolver_outcomes=_full_ro(
+            crossref={"status": s, "queried_by": q, "response_summary": None}))
         assert list(validator.iter_errors(e)) == [], s
-    bad = _entry(resolver_outcomes={"crossref": {
-        "status": "bogus", "queried_by": "id", "response_summary": None}})
+    bad = _entry(resolver_outcomes=_full_ro(crossref={
+        "status": "bogus", "queried_by": "id", "response_summary": None}))
     assert any(validator.iter_errors(bad))
 
 
 def test_resolver_outcome_queried_by_enum(validator):
-    """queried_by ∈ {id, title, null} — the C-V6(a) ID-keyed signal."""
-    for q in ("id", "title", None):
-        e = _entry(resolver_outcomes={"crossref": {
-            "status": "unmatched", "queried_by": q, "response_summary": None}})
+    """queried_by ∈ {id, title, null} — the C-V6(a) ID-keyed signal. (Status is
+    'unmatched' so id/title are both coherent; null is rejected by the
+    status-dependent rule, covered separately.)"""
+    for q in ("id", "title"):
+        e = _entry(lookup_verified="false", resolver_outcomes=_full_ro(
+            crossref={"status": "unmatched", "queried_by": q,
+                      "response_summary": None}))
         assert list(validator.iter_errors(e)) == [], repr(q)
-    bad = _entry(resolver_outcomes={"crossref": {
-        "status": "unmatched", "queried_by": "doi", "response_summary": None}})
+    bad = _entry(resolver_outcomes=_full_ro(crossref={
+        "status": "unmatched", "queried_by": "doi", "response_summary": None}))
     assert any(validator.iter_errors(bad)), "queried_by must reject 'doi' (use 'id')"
 
 
@@ -111,6 +133,60 @@ def test_resolver_outcomes_closed_to_four_resolvers(validator):
     bad = _entry(resolver_outcomes={"scopus": {
         "status": "matched", "queried_by": "id", "response_summary": None}})
     assert any(validator.iter_errors(bad)), "unknown resolver must be rejected"
+
+
+def test_resolver_outcomes_requires_all_four_resolver_keys(validator):
+    """The summary contract is fully-populated: all four resolver keys must be
+    present (each carrying its own status, incl. 'skipped'), so a consumer never
+    has to disambiguate 'absent key' from 'resolver did not run'. A partial
+    resolver_outcomes object is a contract violation."""
+    bad = _entry(resolver_outcomes={"crossref": {
+        "status": "matched", "queried_by": "id", "response_summary": None}})
+    assert any(validator.iter_errors(bad)), "must require all 4 resolver keys"
+
+
+def test_resolver_outcome_requires_queried_by(validator):
+    """queried_by is the load-bearing C-V6(a) signal; making it optional lets a
+    producer emit an ambiguous unmatched that silently reduces to unresolvable
+    instead of false. It must be required (value may be null for skipped /
+    pure-unreachable)."""
+    bad_ro = {r: {"status": "skipped", "queried_by": None,
+                  "response_summary": None}
+              for r in ("crossref", "openalex", "semantic_scholar", "arxiv")}
+    # drop queried_by from one outcome
+    del bad_ro["crossref"]["queried_by"]
+    bad = _entry(lookup_verified="unresolvable", resolver_outcomes=bad_ro)
+    assert any(validator.iter_errors(bad)), "queried_by must be required"
+
+
+def test_matched_and_unmatched_require_non_null_queried_by(validator):
+    """status ∈ {matched, unmatched} demands queried_by ∈ {id, title} — a ran
+    resolver always knows what it keyed on. queried_by=null with a ran status is
+    the exact ambiguity the narrowed-false reducer can be fooled by."""
+    bad = _entry(lookup_verified="false", resolver_outcomes=_full_ro(
+        crossref={"status": "unmatched", "queried_by": None,
+                  "response_summary": None}))
+    assert any(validator.iter_errors(bad)), \
+        "unmatched with queried_by=null must be rejected"
+    good = _entry(lookup_verified="false", resolver_outcomes=_full_ro(
+        crossref={"status": "unmatched", "queried_by": "id",
+                  "response_summary": None}))
+    assert list(validator.iter_errors(good)) == []
+
+
+def test_skipped_and_unreachable_require_null_queried_by(validator):
+    """status ∈ {skipped, unreachable} → no meaningful query completed →
+    queried_by MUST be null. A skipped row claiming queried_by=id is incoherent."""
+    bad = _entry(lookup_verified="unresolvable", resolver_outcomes=_full_ro(
+        crossref={"status": "skipped", "queried_by": "id",
+                  "response_summary": None}))
+    assert any(validator.iter_errors(bad)), \
+        "skipped with queried_by=id must be rejected"
+    bad2 = _entry(lookup_verified="unresolvable", resolver_outcomes=_full_ro(
+        crossref={"status": "unreachable", "queried_by": "title",
+                  "response_summary": None}))
+    assert any(validator.iter_errors(bad2)), \
+        "unreachable with non-null queried_by must be rejected"
 
 
 def test_resolver_outcome_object_is_closed(validator):
@@ -245,3 +321,21 @@ def test_reduce_by_design_false_negative_no_id_bogus_title():
 def test_reduce_empty_outcomes_is_unresolvable():
     from citation_verification_summary import reduce_lookup_verified
     assert reduce_lookup_verified({}) == "unresolvable"
+
+
+def test_reduce_legacy_unmatched_missing_queried_by_is_unresolvable():
+    """Defensive: a legacy/partial outcome with status=unmatched but NO
+    queried_by key must NOT be treated as ID-keyed. It safely reduces to
+    unresolvable (the reducer keys on queried_by=='id', so a missing key is
+    fail-safe-toward-not-false, never false). The schema now forbids this shape,
+    but the reducer stays robust to upstream data drift."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(
+        {"crossref": {"status": "unmatched"}}) == "unresolvable"
+
+
+def test_reduce_none_valued_outcome_is_ignored():
+    """A None resolver value (v or {} guard) must not crash and must not be
+    treated as evidence; with only a None outcome → unresolvable."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified({"crossref": None}) == "unresolvable"

--- a/scripts/test_citation_verification_summary.py
+++ b/scripts/test_citation_verification_summary.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Tests for citation_verification_summary — schema + reducer (Delta 4).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 4
++ §0(4a) / INVARIANT C-V6(a) (narrowed-false).
+
+This file covers BOTH the JSON-Schema (this section) and the Python reducer
+(the ReduceLookupVerified section). The reducer is the single source of truth
+for lookup_verified; run_evals.py imports it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+SCHEMA_PATH = (
+    REPO_ROOT / "shared" / "contracts" / "passport"
+    / "citation_verification_summary.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def schema():
+    with SCHEMA_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def validator(schema):
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _entry(**overrides):
+    base = {
+        "citation_key": "vaswani2017",
+        "ref_slug": "vaswani-2017-attention",
+        "lookup_verified": "true",
+        "anchor_present": True,
+        "verification_timestamp": "2026-06-04T12:00:00Z",
+        "resolver_outcomes": {
+            "crossref": {"status": "matched", "queried_by": "id",
+                         "response_summary": None},
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------- Schema self-consistency ----------
+
+
+def test_schema_is_valid_draft_2020_12(schema):
+    Draft202012Validator.check_schema(schema)
+
+
+def test_minimal_valid_entry(validator):
+    assert list(validator.iter_errors(_entry())) == []
+
+
+def test_lookup_verified_enum_is_three_class(validator):
+    for v in ("true", "false", "unresolvable"):
+        assert list(validator.iter_errors(_entry(lookup_verified=v))) == [], v
+    assert any(validator.iter_errors(_entry(lookup_verified="maybe")))
+    # The string "true" not a boolean — guard against boolean coercion.
+    assert any(validator.iter_errors(_entry(lookup_verified=True)))
+
+
+def test_required_fields_enforced(validator):
+    for field in ("citation_key", "ref_slug", "lookup_verified",
+                  "anchor_present", "verification_timestamp", "resolver_outcomes"):
+        bad = _entry()
+        del bad[field]
+        assert any(validator.iter_errors(bad)), f"{field} must be required"
+
+
+def test_verification_timestamp_never_null(validator):
+    assert any(validator.iter_errors(_entry(verification_timestamp=None)))
+
+
+def test_resolver_outcome_status_enum(validator):
+    for s in ("matched", "unmatched", "unreachable", "skipped"):
+        e = _entry(resolver_outcomes={"crossref": {
+            "status": s, "queried_by": "id", "response_summary": None}})
+        assert list(validator.iter_errors(e)) == [], s
+    bad = _entry(resolver_outcomes={"crossref": {
+        "status": "bogus", "queried_by": "id", "response_summary": None}})
+    assert any(validator.iter_errors(bad))
+
+
+def test_resolver_outcome_queried_by_enum(validator):
+    """queried_by ∈ {id, title, null} — the C-V6(a) ID-keyed signal."""
+    for q in ("id", "title", None):
+        e = _entry(resolver_outcomes={"crossref": {
+            "status": "unmatched", "queried_by": q, "response_summary": None}})
+        assert list(validator.iter_errors(e)) == [], repr(q)
+    bad = _entry(resolver_outcomes={"crossref": {
+        "status": "unmatched", "queried_by": "doi", "response_summary": None}})
+    assert any(validator.iter_errors(bad)), "queried_by must reject 'doi' (use 'id')"
+
+
+def test_resolver_outcomes_closed_to_four_resolvers(validator):
+    bad = _entry(resolver_outcomes={"scopus": {
+        "status": "matched", "queried_by": "id", "response_summary": None}})
+    assert any(validator.iter_errors(bad)), "unknown resolver must be rejected"
+
+
+def test_resolver_outcome_object_is_closed(validator):
+    bad = _entry(resolver_outcomes={"crossref": {
+        "status": "matched", "queried_by": "id", "response_summary": None,
+        "extra": 1}})
+    assert any(validator.iter_errors(bad))
+
+
+def test_top_level_additional_properties_false(validator):
+    assert any(validator.iter_errors(_entry(surprise="x")))
+
+
+# ---------- reduce_lookup_verified (single source of truth, C-V6(a)) ----------
+
+
+def _ro(**resolvers):
+    """Build a resolver_outcomes dict. Each kwarg value is a (status, queried_by)
+    tuple, or a bare status string (queried_by defaults to None)."""
+    out = {}
+    for name, v in resolvers.items():
+        if isinstance(v, tuple):
+            status, queried_by = v
+        else:
+            status, queried_by = v, None
+        out[name] = {"status": status, "queried_by": queried_by,
+                     "response_summary": None}
+    return out
+
+
+def test_reduce_matched_wins_true():
+    from citation_verification_summary import reduce_lookup_verified
+    # matched WINS even when another applicable resolver is unmatched.
+    assert reduce_lookup_verified(_ro(
+        crossref=("matched", "id"),
+        openalex=("unmatched", "id"),
+    )) == "true"
+
+
+def test_reduce_id_keyed_unmatched_is_false():
+    from citation_verification_summary import reduce_lookup_verified
+    # ID-keyed unmatched, no matched → false (fabrication evidence, C-V6(a)).
+    assert reduce_lookup_verified(_ro(
+        crossref=("unmatched", "id"),
+        openalex=("unmatched", "id"),
+    )) == "false"
+
+
+def test_reduce_title_only_unmatched_is_unresolvable_NOT_false():
+    """THE narrowed-false case (C-V6(a)): only title-only unmatched (no
+    resolvable ID) → unresolvable, never false. The real-but-unindexed paper."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref=("unmatched", "title"),
+        openalex=("unmatched", "title"),
+    )) == "unresolvable"
+
+
+def test_reduce_mixed_id_and_title_unmatched_is_false():
+    """At least one ID-keyed unmatched → false, even if others are title-only."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref=("unmatched", "id"),
+        openalex=("unmatched", "title"),
+    )) == "false"
+
+
+def test_reduce_anti_fabrication_bias_id_unmatched_plus_unreachable():
+    """3 ID-keyed unmatched + 1 unreachable → false (one outage doesn't cancel
+    positive non-existence evidence). Spec Delta 4 anti-fabrication bias."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref=("unmatched", "id"),
+        openalex=("unmatched", "id"),
+        semantic_scholar=("unmatched", "id"),
+        arxiv="unreachable",
+    )) == "false"
+
+
+def test_reduce_title_unmatched_plus_unreachable_is_unresolvable():
+    """Partial outage whose only unmatched are title-only → unresolvable, not
+    false (C-V6(a) / OQ-4 amendment)."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref=("unmatched", "title"),
+        openalex="unreachable",
+    )) == "unresolvable"
+
+
+def test_reduce_all_unreachable_is_unresolvable():
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref="unreachable",
+        openalex="unreachable",
+    )) == "unresolvable"
+
+
+def test_reduce_all_skipped_is_unresolvable():
+    """Manual entry: all resolvers skipped → empty adjudicating set →
+    unresolvable."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref="skipped",
+        openalex="skipped",
+        semantic_scholar="skipped",
+        arxiv="skipped",
+    )) == "unresolvable"
+
+
+def test_reduce_skipped_excluded_matched_still_true():
+    """skipped is excluded from classification; a matched among skips → true."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref=("matched", "id"),
+        arxiv="skipped",  # arXiv skipped on a non-arXiv citation
+    )) == "true"
+
+
+def test_reduce_by_design_false_negative_no_id_bogus_title():
+    """OQ-5 by-design FN: a fabricated citation with NO DOI/arXiv ID and only a
+    bogus title resolves to unresolvable, NOT false — the acknowledged recall
+    limit (a no-identifier fabrication is caught by the v3.8 audit + human
+    review, not the existence gate). MUST stay unresolvable."""
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified(_ro(
+        crossref=("unmatched", "title"),
+        openalex=("unmatched", "title"),
+        semantic_scholar=("unmatched", "title"),
+    )) == "unresolvable"
+
+
+def test_reduce_empty_outcomes_is_unresolvable():
+    from citation_verification_summary import reduce_lookup_verified
+    assert reduce_lookup_verified({}) == "unresolvable"

--- a/scripts/test_contamination_signals.py
+++ b/scripts/test_contamination_signals.py
@@ -792,3 +792,95 @@ class SemanticScholarCacheTest(unittest.TestCase):
         result = cs.compute_ss_unmatched_signal(self._entry(), client, cache=cache)
         self.assertIsNone(result)  # degradation → None (omit field)
         self.assertEqual(cache.put_calls, [])  # never cache degradation
+
+
+# ============================================================================
+# v3.11 #182 Delta 4 — queried_by retrofit (the ID-keyed-unmatched signal that
+# the narrowed-false reducer C-V6(a) needs). The internal resolver-flow helpers
+# return (unmatched, matched_by, queried_by) where queried_by records what the
+# resolver ACTUALLY queried by, so a title-only unmatched is distinguishable
+# from an ID-keyed unmatched at reduce time.
+# ============================================================================
+
+
+class ResolveDoiThenTitleQueriedByTest(unittest.TestCase):
+    """_resolve_doi_then_title now returns (unmatched, matched_by, queried_by).
+    queried_by ∈ {'id', 'title'} for unmatched; mirrors matched_by for matched."""
+
+    def test_doi_match_queried_by_id(self):
+        client = MagicMock()
+        client.doi_lookup_with_title_check.return_value = {"title": ["X"]}
+        unmatched, matched_by, queried_by = cs._resolve_doi_then_title(
+            {"title": "X", "doi": "10.5/x"}, client
+        )
+        self.assertIs(unmatched, False)
+        self.assertEqual(matched_by, "doi")
+        self.assertEqual(queried_by, "id")
+
+    def test_doi_present_but_unmatched_queried_by_id(self):
+        """DOI present, ID lookup miss, title miss → unmatched, queried_by='id'
+        (an ID lookup WAS attempted — this is ID-keyed unmatched, C-V6(a))."""
+        client = MagicMock()
+        client.doi_lookup_with_title_check.return_value = None
+        client.title_search.return_value = None
+        unmatched, matched_by, queried_by = cs._resolve_doi_then_title(
+            {"title": "Ghost", "doi": "10.5/fake"}, client
+        )
+        self.assertIs(unmatched, True)
+        self.assertIsNone(matched_by)
+        self.assertEqual(queried_by, "id")
+
+    def test_no_doi_unmatched_queried_by_title(self):
+        """No DOI to key on → title-only search → unmatched, queried_by='title'
+        (NOT id-keyed — coverage gap, must reduce to unresolvable not false)."""
+        client = MagicMock()
+        client.title_search.return_value = None
+        unmatched, matched_by, queried_by = cs._resolve_doi_then_title(
+            {"title": "Unindexed regional paper"}, client  # no doi
+        )
+        self.assertIs(unmatched, True)
+        self.assertIsNone(matched_by)
+        self.assertEqual(queried_by, "title")
+
+    def test_no_doi_title_match_queried_by_title(self):
+        client = MagicMock()
+        client.title_search.return_value = {"title": ["X"]}
+        unmatched, matched_by, queried_by = cs._resolve_doi_then_title(
+            {"title": "X"}, client  # no doi
+        )
+        self.assertIs(unmatched, False)
+        self.assertEqual(matched_by, "title")
+        self.assertEqual(queried_by, "title")
+
+
+class ResolveArxivQueriedByTest(unittest.TestCase):
+    """_resolve_arxiv_id_then_title queried_by uses arxiv_id presence."""
+
+    def test_arxiv_id_present_unmatched_queried_by_id(self):
+        client = MagicMock()
+        client.arxiv_id_lookup.return_value = None
+        client.title_search.return_value = None
+        unmatched, matched_by, queried_by = cs._resolve_arxiv_id_then_title(
+            {"title": "Ghost", "arxiv_id": "9999.99999"}, client
+        )
+        self.assertIs(unmatched, True)
+        self.assertEqual(queried_by, "id")
+
+    def test_no_arxiv_id_unmatched_queried_by_title(self):
+        client = MagicMock()
+        client.title_search.return_value = None
+        unmatched, matched_by, queried_by = cs._resolve_arxiv_id_then_title(
+            {"title": "Unindexed"}, client  # no arxiv_id
+        )
+        self.assertIs(unmatched, True)
+        self.assertEqual(queried_by, "title")
+
+    def test_arxiv_id_match_queried_by_id(self):
+        client = MagicMock()
+        client.arxiv_id_lookup.return_value = {"title": "X", "year": 2017}
+        unmatched, matched_by, queried_by = cs._resolve_arxiv_id_then_title(
+            {"title": "X", "arxiv_id": "1706.03762"}, client
+        )
+        self.assertIs(unmatched, False)
+        self.assertEqual(matched_by, "arxiv")
+        self.assertEqual(queried_by, "id")

--- a/scripts/test_evals_citation_extraction.py
+++ b/scripts/test_evals_citation_extraction.py
@@ -1,7 +1,9 @@
-"""Tests for the citation_extraction self-reducer + full 50-tuple gold-set run.
+"""Tests for the citation_extraction self-reducer + full gold-set run.
 
 Pins the #182 Delta 4 reducer branches and the end-to-end accuracy against the
-shipped gold set (which was authored by the same rule -> ~1.0 accuracy).
+shipped gold set (which was authored by the same rule -> ~1.0 accuracy). The
+reducer uses the v3.11 narrowed-false definition (C-V6(a)): `false` requires an
+ID-keyed unmatched (queried_by=id), never a title-only one.
 """
 from __future__ import annotations
 
@@ -17,11 +19,21 @@ CITATION_DIR = REPO_ROOT / "evals" / "gold" / "citation_extraction"
 
 
 def _ro(crossref="skipped", openalex="skipped", semantic_scholar="skipped", arxiv="skipped"):
+    """Each arg is a status string or (status, queried_by) tuple. A bare
+    `unmatched` defaults queried_by='id' (the ID-keyed = false-producing case)
+    so existing branch pins keep their intent under the narrowed-false reducer."""
+    def cell(v):
+        if isinstance(v, tuple):
+            status, queried_by = v
+        else:
+            status = v
+            queried_by = "id" if status == "unmatched" else None
+        return {"status": status, "queried_by": queried_by, "response_summary": None}
     return {
-        "crossref": {"status": crossref, "response_summary": None},
-        "openalex": {"status": openalex, "response_summary": None},
-        "semantic_scholar": {"status": semantic_scholar, "response_summary": None},
-        "arxiv": {"status": arxiv, "response_summary": None},
+        "crossref": cell(crossref),
+        "openalex": cell(openalex),
+        "semantic_scholar": cell(semantic_scholar),
+        "arxiv": cell(arxiv),
     }
 
 
@@ -53,11 +65,21 @@ def test_reducer_unmatched_no_matched_false():
 
 
 def test_reducer_partial_outage_unmatched_plus_unreachable_false():
-    # Anti-fabrication bias: >=1 unmatched & 0 matched -> false even with outage.
+    # Anti-fabrication bias: >=1 ID-keyed unmatched & 0 matched -> false even
+    # with outage.
     assert run_evals.reduce_lookup_verified(
         _ro(crossref="unmatched", openalex="unmatched",
             semantic_scholar="unmatched", arxiv="unreachable")
     ) == "false"
+
+
+def test_reducer_title_only_unmatched_unresolvable_NOT_false():
+    # v3.11 narrowed-false (C-V6(a)): title-only unmatched (no resolvable ID)
+    # is a coverage gap -> unresolvable, never false.
+    assert run_evals.reduce_lookup_verified(
+        _ro(crossref=("unmatched", "title"), openalex=("unmatched", "title"),
+            semantic_scholar=("unmatched", "title"))
+    ) == "unresolvable"
 
 
 def test_reducer_all_skipped_unresolvable():
@@ -82,12 +104,13 @@ def test_reducer_unresolvable_never_collapsed_into_false():
 
 
 # ---------------------------------------------------------------------------
-# Full 50-tuple gold-set run
+# Full 52-tuple gold-set run (50 + the C-V6(a) coverage-gap pair: 1 by-design
+# FN fixture per spec OQ-5 + 1 legit-unindexed companion).
 # ---------------------------------------------------------------------------
 def test_full_gold_set_runs_at_high_accuracy():
     result = run_evals.run_task("citation_extraction")
     assert result["status"] == "measured"
-    assert result["sample_n"] == 50
+    assert result["sample_n"] == 52
     # Authored by the same reducer rule -> expect ~1.0 accuracy.
     assert result["aggregate_metric"]["value"] == pytest.approx(1.0)
     assert result["aggregate_metric"]["passed"] is True
@@ -98,15 +121,17 @@ def test_full_gold_set_per_class_all_pass():
     by_class = {pc["class_name"]: pc for pc in result["per_class"]}
     for cls in ("true", "false", "unresolvable"):
         assert by_class[cls]["passed"] is True, cls
-    # Distribution: 30 true (20 doi + 10 arxiv), 15 false, 5 unresolvable.
+    # Distribution: 30 true (20 doi + 10 arxiv), 15 false (all ID-keyed),
+    # 7 unresolvable (5 manual_exempt + the C-V6(a) coverage-gap pair:
+    # 1 fabricated_title_only FN fixture + 1 valid_unindexed companion).
     assert by_class["true"]["support"] == 30
     assert by_class["false"]["support"] == 15
-    assert by_class["unresolvable"]["support"] == 5
+    assert by_class["unresolvable"]["support"] == 7
 
 
 def test_full_gold_set_reducer_matches_every_expected_label():
     # Independent recompute: the reducer over each tuple's resolver_outcomes
-    # must reproduce expected_outcomes' lookup_verified for all 50 tuples.
+    # must reproduce expected_outcomes' lookup_verified for all tuples.
     expected = json.loads((CITATION_DIR / "expected_outcomes.json").read_text(encoding="utf-8"))
     for tid, outcome in expected.items():
         predicted = run_evals.reduce_lookup_verified(outcome["resolver_outcomes"])
@@ -114,8 +139,10 @@ def test_full_gold_set_reducer_matches_every_expected_label():
 
 
 def test_expert_concordance_present_for_labeled_subset():
-    # 10 of 50 tuples carry human_expert_verdict; concordance is advisory.
+    # 12 tuples carry human_expert_verdict (10 original + the C-V6(a)
+    # coverage-gap pair: FN fixture 051 + valid_unindexed companion 052);
+    # concordance is advisory.
     result = run_evals.run_task("citation_extraction")
     conc = result.get("expert_concordance", [])
     total_labeled = sum(c["labeled_count"] for c in conc)
-    assert total_labeled == 10
+    assert total_labeled == 12

--- a/scripts/test_run_evals.py
+++ b/scripts/test_run_evals.py
@@ -75,13 +75,22 @@ def _citation_manifest(task_name="citation_extraction"):
 
 
 def _ro(crossref=None, openalex=None, semantic_scholar=None, arxiv=None):
-    def cell(status):
-        return {"status": status, "response_summary": None}
+    """Build resolver_outcomes. Each arg is a status string, or a
+    (status, queried_by) tuple. A bare 'unmatched' string defaults
+    queried_by='id' so it stays an ID-keyed (false-producing) unmatched under
+    the v3.11 narrowed-false reducer — the prior un-narrowed default semantics."""
+    def cell(v):
+        if isinstance(v, tuple):
+            status, queried_by = v
+        else:
+            status = v or "skipped"
+            queried_by = "id" if status == "unmatched" else None
+        return {"status": status, "queried_by": queried_by, "response_summary": None}
     return {
-        "crossref": cell(crossref or "skipped"),
-        "openalex": cell(openalex or "skipped"),
-        "semantic_scholar": cell(semantic_scholar or "skipped"),
-        "arxiv": cell(arxiv or "skipped"),
+        "crossref": cell(crossref),
+        "openalex": cell(openalex),
+        "semantic_scholar": cell(semantic_scholar),
+        "arxiv": cell(arxiv),
     }
 
 

--- a/scripts/test_verification_gate.py
+++ b/scripts/test_verification_gate.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Tests for the verification_gate API (Delta 5).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 5.
+
+verify_citation composes the four resolvers, maps each resolver's execution to a
+{status, queried_by} outcome, derives lookup_verified via the Delta 4 reducer
+(narrowed-false, C-V6(a)), reads anchor_present, and stamps verification_timestamp.
+Clients are dependency-injected so tests run without network.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _entry(**overrides):
+    # Production-shaped corpus entry: NO anchor field (the v3.7.3 anchor lives in
+    # writer prose, joined by ref_slug — passed to verify_citation as an explicit
+    # `anchor` param, never read off the corpus entry).
+    base = {
+        "citation_key": "vaswani2017",
+        "ref_slug": "vaswani-2017-attention",
+        "title": "Attention Is All You Need",
+        "doi": "10.5555/abc",
+        "obtained_via": "folder-scan",
+    }
+    base.update(overrides)
+    return base
+
+
+_PAGE_ANCHOR = {"kind": "page", "value": "1"}
+
+
+def _clients(*, crossref=None, openalex=None, semantic_scholar=None, arxiv=None):
+    """Build a clients dict of MagicMocks. Pass a configured mock per resolver,
+    or None to get a default (all lookups miss)."""
+    def default():
+        m = MagicMock()
+        m.doi_lookup_with_title_check.return_value = None
+        m.title_search.return_value = None
+        m.arxiv_id_lookup.return_value = None
+        m.lookup.return_value = {"matched": False}
+        return m
+    return {
+        "crossref": crossref or default(),
+        "openalex": openalex or default(),
+        "semantic_scholar": semantic_scholar or default(),
+        "arxiv": arxiv or default(),
+    }
+
+
+# ---------- verify_citation ----------
+
+
+def test_matched_yields_true_and_id_queried():
+    from verification_gate import verify_citation
+
+    cr = MagicMock()
+    cr.doi_lookup_with_title_check.return_value = {"title": ["X"]}  # match
+    outcome = verify_citation(_entry(), _clients(crossref=cr))
+
+    assert outcome["lookup_verified"] == "true"
+    assert outcome["resolver_outcomes"]["crossref"]["status"] == "matched"
+    assert outcome["resolver_outcomes"]["crossref"]["queried_by"] == "id"
+
+
+def test_id_keyed_unmatched_yields_false():
+    from verification_gate import verify_citation
+    # All resolvers miss; entry has a DOI → ID-keyed unmatched → false.
+    outcome = verify_citation(_entry(), _clients())
+    assert outcome["lookup_verified"] == "false"
+    assert outcome["resolver_outcomes"]["crossref"]["queried_by"] == "id"
+
+
+def test_title_only_unmatched_yields_unresolvable():
+    from verification_gate import verify_citation
+    # No DOI → title-only unmatched everywhere → unresolvable (C-V6(a)).
+    outcome = verify_citation(_entry(doi=None), _clients())
+    assert outcome["lookup_verified"] == "unresolvable"
+    assert outcome["resolver_outcomes"]["crossref"]["queried_by"] == "title"
+
+
+def test_resolver_outage_is_unreachable():
+    from verification_gate import verify_citation
+    from crossref_client import CrossrefUnavailable
+
+    cr = MagicMock()
+    cr.doi_lookup_with_title_check.side_effect = CrossrefUnavailable("down")
+    # other three also miss (id-keyed) → false stands (anti-fabrication bias).
+    outcome = verify_citation(_entry(), _clients(crossref=cr))
+    assert outcome["resolver_outcomes"]["crossref"]["status"] == "unreachable"
+    assert outcome["resolver_outcomes"]["crossref"]["queried_by"] is None
+    assert outcome["lookup_verified"] == "false"
+
+
+def test_all_unreachable_is_unresolvable():
+    from verification_gate import verify_citation
+    from crossref_client import CrossrefUnavailable
+    from openalex_client import OpenAlexUnavailable
+    from arxiv_client import ArxivUnavailable
+    from contamination_signals import SemanticScholarUnavailable
+
+    cr = MagicMock(); cr.doi_lookup_with_title_check.side_effect = CrossrefUnavailable("x")
+    oa = MagicMock(); oa.doi_lookup_with_title_check.side_effect = OpenAlexUnavailable("x")
+    s2 = MagicMock(); s2.lookup.side_effect = SemanticScholarUnavailable("x")
+    ax = MagicMock(); ax.arxiv_id_lookup.side_effect = ArxivUnavailable("x")
+    outcome = verify_citation(
+        _entry(arxiv_id="1706.03762"),
+        _clients(crossref=cr, openalex=oa, semantic_scholar=s2, arxiv=ax),
+    )
+    assert outcome["lookup_verified"] == "unresolvable"
+    for r in ("crossref", "openalex", "semantic_scholar", "arxiv"):
+        assert outcome["resolver_outcomes"][r]["status"] == "unreachable"
+
+
+def test_manual_entry_all_skipped_unresolvable():
+    from verification_gate import verify_citation
+    outcome = verify_citation(_entry(obtained_via="manual"), _clients())
+    assert outcome["lookup_verified"] == "unresolvable"
+    for r in ("crossref", "openalex", "semantic_scholar", "arxiv"):
+        assert outcome["resolver_outcomes"][r]["status"] == "skipped"
+
+
+def test_arxiv_skipped_on_non_arxiv_citation():
+    from verification_gate import verify_citation
+    cr = MagicMock(); cr.doi_lookup_with_title_check.return_value = {"title": ["X"]}
+    outcome = verify_citation(_entry(), _clients(crossref=cr))  # no arxiv_id
+    assert outcome["resolver_outcomes"]["arxiv"]["status"] == "skipped"
+
+
+def test_anchor_present_true_for_page_kind():
+    from verification_gate import verify_citation
+    # anchor is an EXPLICIT param (prose-sourced, joined by ref_slug upstream).
+    outcome = verify_citation(_entry(), _clients(), anchor=_PAGE_ANCHOR)
+    assert outcome["anchor_present"] is True
+
+
+def test_anchor_present_false_for_none_kind():
+    from verification_gate import verify_citation
+    outcome = verify_citation(
+        _entry(), _clients(), anchor={"kind": "none", "value": None})
+    assert outcome["anchor_present"] is False
+
+
+def test_anchor_present_false_when_anchor_omitted():
+    from verification_gate import verify_citation
+    # No anchor param (the prose join found no anchor for this ref_slug) → False.
+    outcome = verify_citation(_entry(), _clients())
+    assert outcome["anchor_present"] is False
+
+
+def test_anchor_is_not_read_off_the_corpus_entry():
+    """Anti-regression for the latent shape mismatch: even if a corpus entry
+    erroneously carries an 'anchor' key, it MUST be ignored — anchor_present
+    derives ONLY from the explicit param. This pins that we don't silently
+    resurrect the entry.get('anchor') path (the anchor lives in writer prose,
+    not in literature_corpus)."""
+    from verification_gate import verify_citation
+    e = _entry(anchor={"kind": "page", "value": "99"})  # decoy on the entry
+    outcome = verify_citation(e, _clients())  # no anchor param
+    assert outcome["anchor_present"] is False
+
+
+def test_outcome_carries_keys_and_timestamp():
+    from verification_gate import verify_citation
+    outcome = verify_citation(_entry(), _clients())
+    assert outcome["citation_key"] == "vaswani2017"
+    assert outcome["ref_slug"] == "vaswani-2017-attention"
+    assert outcome["verification_timestamp"]  # never null/empty
+
+
+def test_outcome_validates_against_summary_schema():
+    """The outcome must validate against citation_verification_summary.schema."""
+    import json
+    from jsonschema import Draft202012Validator
+    from verification_gate import verify_citation
+
+    schema = json.loads((
+        REPO_ROOT / "shared" / "contracts" / "passport"
+        / "citation_verification_summary.schema.json"
+    ).read_text(encoding="utf-8"))
+    outcome = verify_citation(_entry(), _clients())
+    errors = list(Draft202012Validator(schema).iter_errors(outcome))
+    assert errors == [], f"outcome must validate: {errors}"
+
+
+# ---------- verify_passport ----------
+
+
+def test_verify_passport_runs_each_entry():
+    from verification_gate import verify_passport
+
+    cr = MagicMock(); cr.doi_lookup_with_title_check.return_value = {"title": ["X"]}
+    passport = {
+        "literature_corpus": [
+            _entry(citation_key="a", ref_slug="slug-a"),
+            _entry(citation_key="b", ref_slug="slug-b", doi=None),
+        ]
+    }
+    outcomes = verify_passport(passport, clients=_clients(crossref=cr))
+    assert len(outcomes) == 2
+    assert {o["citation_key"] for o in outcomes} == {"a", "b"}
+
+
+def test_verify_passport_joins_anchors_by_ref_slug():
+    """verify_passport performs the prose-marker join: a {ref_slug: anchor} map
+    is threaded so each entry's anchor_present reflects ITS ref_slug's anchor.
+    Entry 'a' has a page anchor; entry 'b' has none → False."""
+    from verification_gate import verify_passport
+    passport = {
+        "literature_corpus": [
+            _entry(citation_key="a", ref_slug="slug-a"),
+            _entry(citation_key="b", ref_slug="slug-b"),
+        ]
+    }
+    anchors = {"slug-a": _PAGE_ANCHOR}  # slug-b absent → anchor_present False
+    outcomes = verify_passport(passport, clients=_clients(), anchors=anchors)
+    by_key = {o["citation_key"]: o for o in outcomes}
+    assert by_key["a"]["anchor_present"] is True
+    assert by_key["b"]["anchor_present"] is False
+
+
+def test_verify_passport_empty_corpus():
+    from verification_gate import verify_passport
+    assert verify_passport({"literature_corpus": []}, clients=_clients()) == []
+    assert verify_passport({}, clients=_clients()) == []
+
+
+def test_cache_argument_is_honest_not_silent_noop():
+    """cache wiring at this layer is a forward-decl; passing a non-None cache
+    must raise (not silently drop it), so a caller is never misled into
+    thinking caching took effect."""
+    from verification_gate import verify_citation
+    with pytest.raises(NotImplementedError):
+        verify_citation(_entry(), _clients(), cache=object())

--- a/scripts/test_verify_passport_cli.py
+++ b/scripts/test_verify_passport_cli.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for the verify_passport CLI (Delta 5 ad-hoc entry point).
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 5
+(`python -m scripts.verify_passport <passport.yaml>`).
+
+The CLI is a thin wrapper: it loads a passport YAML and prints the
+verification summary as JSON. Network resolvers are real by default; tests
+inject a no-network clients factory via the public `run` seam.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _no_network_clients():
+    def default():
+        m = MagicMock()
+        m.doi_lookup_with_title_check.return_value = None
+        m.title_search.return_value = None
+        m.arxiv_id_lookup.return_value = None
+        m.lookup.return_value = {"matched": False}
+        return m
+    return {n: default() for n in
+            ("crossref", "openalex", "semantic_scholar", "arxiv")}
+
+
+def _write_passport(tmp_path, corpus):
+    p = tmp_path / "passport.yaml"
+    p.write_text(yaml.safe_dump({"literature_corpus": corpus}), encoding="utf-8")
+    return p
+
+
+def test_cli_emits_json_summary(tmp_path, capsys):
+    from verify_passport import run
+
+    # Production-shaped corpus entry: no anchor field (the anchor lives in writer
+    # prose, not in literature_corpus). The ad-hoc CLI has no prose document, so
+    # anchor_present is honestly False — a prose-join is a later-batch concern.
+    passport = _write_passport(tmp_path, [
+        {"citation_key": "a", "ref_slug": "slug-a", "title": "T",
+         "doi": "10.5/x", "obtained_via": "folder-scan"},
+    ])
+    rc = run([str(passport)], clients_factory=_no_network_clients)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 1
+    assert out[0]["citation_key"] == "a"
+    assert out[0]["lookup_verified"] == "false"  # id-keyed unmatched
+    assert out[0]["anchor_present"] is False  # no prose anchor available
+
+
+def test_cli_missing_file_errors(tmp_path):
+    from verify_passport import run
+    rc = run([str(tmp_path / "nope.yaml")], clients_factory=_no_network_clients)
+    assert rc != 0
+
+
+def test_cli_requires_path_arg():
+    from verify_passport import run
+    with pytest.raises(SystemExit):
+        run([], clients_factory=_no_network_clients)

--- a/scripts/verification_gate/__init__.py
+++ b/scripts/verification_gate/__init__.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""verification_gate — citation existence verification API (Delta 5).
+
+Public functions:
+  - verify_citation(entry, clients, cache=None) -> CitationVerificationOutcome
+  - verify_passport(passport, clients, cache=None) -> list[outcome]
+
+Composes the four resolvers (crossref / openalex / semantic_scholar / arxiv),
+maps each resolver's execution to a {status, queried_by} outcome, derives the
+3-class lookup_verified via the Delta 4 reducer (narrowed-false, C-V6(a)),
+reads anchor_present from the v3.7.3 anchor marker, and stamps
+verification_timestamp. Does NOT duplicate the v3.8 audit pipeline — it composes
+the same lower-layer resolvers and writes the unified summary schema (Delta 4).
+
+The returned dict validates against
+shared/contracts/passport/citation_verification_summary.schema.json.
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 5.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+try:
+    from citation_verification_summary import (
+        STATUS_MATCHED,
+        STATUS_SKIPPED,
+        STATUS_UNMATCHED,
+        STATUS_UNREACHABLE,
+        reduce_lookup_verified,
+    )
+    from crossref_client import CrossrefUnavailable
+    from openalex_client import OpenAlexUnavailable
+    from arxiv_client import ArxivUnavailable
+    from contamination_signals import (
+        SemanticScholarUnavailable,
+        _resolve_arxiv_id_then_title,
+        _resolve_doi_then_title,
+        queried_by_for,
+    )
+except ImportError:  # pragma: no cover - dual-path import
+    from scripts.citation_verification_summary import (
+        STATUS_MATCHED,
+        STATUS_SKIPPED,
+        STATUS_UNMATCHED,
+        STATUS_UNREACHABLE,
+        reduce_lookup_verified,
+    )
+    from scripts.crossref_client import CrossrefUnavailable
+    from scripts.openalex_client import OpenAlexUnavailable
+    from scripts.arxiv_client import ArxivUnavailable
+    from scripts.contamination_signals import (
+        SemanticScholarUnavailable,
+        _resolve_arxiv_id_then_title,
+        _resolve_doi_then_title,
+        queried_by_for,
+    )
+
+_ANCHOR_PRESENT_KINDS = frozenset({"quote", "page", "section", "paragraph"})
+
+
+def _outcome(status: str, queried_by: str | None,
+             response_summary: str | None = None) -> dict[str, Any]:
+    return {"status": status, "queried_by": queried_by,
+            "response_summary": response_summary}
+
+
+def _ran_outcome(unmatched: bool, queried_by: str | None) -> dict[str, Any]:
+    """Map a ran-resolver result (matched/unmatched) to an outcome dict."""
+    return _outcome(STATUS_UNMATCHED if unmatched else STATUS_MATCHED, queried_by)
+
+
+def _run_doi_then_title(entry, client, unavailable_exc) -> dict[str, Any]:
+    """Run a doi-then-title resolver, mapping execution to a status outcome.
+    Used by crossref / openalex (same flow + DOI key, different exception).
+    The manual exemption is short-circuited upstream in verify_citation."""
+    try:
+        unmatched, _matched_by, queried_by = _resolve_doi_then_title(entry, client)
+    except unavailable_exc:
+        return _outcome(STATUS_UNREACHABLE, None)
+    return _ran_outcome(unmatched, queried_by)
+
+
+def _run_semantic_scholar(entry, client) -> dict[str, Any]:
+    """S2's lookup(entry) is a single entry-keyed call (DOI-first then title
+    internally). queried_by follows the has-an-id rule (C-V6(a)). The manual
+    exemption is short-circuited upstream in verify_citation."""
+    queried_by = queried_by_for(entry, id_field="doi")
+    try:
+        matched = bool(client.lookup(entry).get("matched", False))
+    except SemanticScholarUnavailable:
+        return _outcome(STATUS_UNREACHABLE, None)
+    return _ran_outcome(not matched, queried_by)
+
+
+def _run_arxiv(entry, client) -> dict[str, Any]:
+    """arXiv resolver is applicable only when the citation has an arXiv ID;
+    otherwise it is skipped (not unmatched) per Delta 1 / spec line 119. The
+    manual exemption is short-circuited upstream in verify_citation."""
+    if not entry.get("arxiv_id"):
+        return _outcome(STATUS_SKIPPED, None)  # non-arXiv citation → not applicable
+    try:
+        unmatched, _matched_by, queried_by = _resolve_arxiv_id_then_title(entry, client)
+    except ArxivUnavailable:
+        return _outcome(STATUS_UNREACHABLE, None)
+    return _ran_outcome(unmatched, queried_by)
+
+
+def _anchor_present(anchor: Any) -> bool:
+    """True iff the v3.7.3 anchor marker has kind ∈ {quote,page,section,paragraph}
+    (not none). `anchor` is the already-parsed {kind, value} marker sourced from
+    writer prose and joined by ref_slug upstream — NEVER read off the corpus
+    entry (the literature_corpus_entry schema has no anchor field; reading it
+    there would be a permanent silent False)."""
+    if not isinstance(anchor, Mapping):
+        return False
+    return anchor.get("kind") in _ANCHOR_PRESENT_KINDS
+
+
+def verify_citation(
+    entry: Mapping[str, Any],
+    clients: Mapping[str, Any],
+    *,
+    anchor: Mapping[str, Any] | None = None,
+    cache=None,
+) -> dict[str, Any]:
+    """Verify one citation's existence across the four resolvers.
+
+    `entry` carries citation_key, ref_slug, title, optional doi / arxiv_id,
+    obtained_via. `clients` is a mapping {crossref, openalex, semantic_scholar,
+    arxiv} of resolver clients (injected so callers control network / cache).
+    `anchor` is the v3.7.3 anchor marker ({kind, value}) for this citation's
+    ref_slug, already parsed from writer prose and joined upstream (None when no
+    anchor marker exists for the ref_slug). It is a SEPARATE input, not an entry
+    field — the anchor lives in prose, not in literature_corpus (spec Delta 4:
+    the summary is a join across three sources). `cache` is reserved for future
+    cache-through wiring at this layer (the resolver-level cache lands in
+    contamination_signals; threading it here is a Delta-2 follow-up).
+
+    Returns a dict validating against citation_verification_summary.schema.json:
+    {citation_key, ref_slug, lookup_verified, anchor_present,
+     verification_timestamp, resolver_outcomes}.
+    """
+    if cache is not None:
+        # Honest forward-decl: the resolver-level cache lands in
+        # contamination_signals, but it is not yet threaded through this layer
+        # (a Delta-2 follow-up). Refuse rather than silently drop a cache the
+        # caller passed expecting it to take effect.
+        raise NotImplementedError(
+            "cache-through at the verification_gate layer is not yet wired "
+            "(#182 Delta-2 follow-up); pass cache=None"
+        )
+    if entry.get("obtained_via") == "manual":
+        # v3.7.3 manual exemption: no resolver runs — all four skipped (checked
+        # once here rather than re-checked inside each resolver helper).
+        resolver_outcomes = {
+            r: _outcome(STATUS_SKIPPED, None)
+            for r in ("crossref", "openalex", "semantic_scholar", "arxiv")
+        }
+    else:
+        resolver_outcomes = {
+            "crossref": _run_doi_then_title(
+                entry, clients["crossref"], CrossrefUnavailable),
+            "openalex": _run_doi_then_title(
+                entry, clients["openalex"], OpenAlexUnavailable),
+            "semantic_scholar": _run_semantic_scholar(
+                entry, clients["semantic_scholar"]),
+            "arxiv": _run_arxiv(entry, clients["arxiv"]),
+        }
+    return {
+        "citation_key": entry.get("citation_key"),
+        "ref_slug": entry.get("ref_slug"),
+        "lookup_verified": reduce_lookup_verified(resolver_outcomes),
+        "anchor_present": _anchor_present(anchor),
+        "verification_timestamp": datetime.now(timezone.utc).isoformat(),
+        "resolver_outcomes": resolver_outcomes,
+    }
+
+
+def verify_passport(
+    passport: Mapping[str, Any],
+    clients: Mapping[str, Any],
+    *,
+    anchors: Mapping[str, Mapping[str, Any]] | None = None,
+    cache=None,
+) -> list[dict[str, Any]]:
+    """Batch helper: run verify_citation over every entry in the passport's
+    literature_corpus[]. `anchors` is the {ref_slug: anchor-marker} join map
+    parsed from writer prose (the v3.7.3 <!--anchor:kind:value--> markers); each
+    entry's anchor is looked up by its ref_slug (absent → anchor_present False).
+    Threading the join here keeps verify_citation a pure per-citation unit."""
+    corpus = passport.get("literature_corpus") or []
+    anchors = anchors or {}
+    return [
+        verify_citation(
+            entry, clients, anchor=anchors.get(entry.get("ref_slug")),
+            cache=cache)
+        for entry in corpus
+    ]

--- a/scripts/verify_passport.py
+++ b/scripts/verify_passport.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""verify_passport CLI — ad-hoc citation existence verification (Delta 5).
+
+    python -m scripts.verify_passport <passport.yaml>
+
+Loads a Material Passport YAML, runs verification_gate.verify_passport over its
+literature_corpus[], and prints the list of per-citation summaries as JSON. A
+standalone entry point for ad-hoc verification, separate from the Stage 4->5
+audit pipeline.
+
+Anchor note: the v3.7.3 anchor lives in writer prose (the <!--anchor:...-->
+markers), not in literature_corpus. This ad-hoc CLI has no prose document to
+join against, so every `anchor_present` is False. The prose-marker join (passing
+an {ref_slug: anchor} map into verify_passport) is wired by the Stage 4->5
+pipeline / formatter batch, not by this standalone tool.
+
+Spec: docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 5.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+try:
+    from verification_gate import verify_passport
+except ImportError:  # pragma: no cover
+    from scripts.verification_gate import verify_passport
+
+
+def _real_clients() -> dict:
+    """Construct the four production resolver clients. Imported lazily so the
+    CLI module loads without network deps and tests can inject a stub factory.
+    Dual-path import: under `python -m scripts.verify_passport` the repo root is
+    on sys.path (not scripts/), so the bare imports fall back to scripts.*."""
+    try:
+        from crossref_client import CrossrefClient
+        from openalex_client import OpenAlexClient
+        from arxiv_client import ArxivClient
+        from semantic_scholar_client import SemanticScholarClient
+    except ImportError:  # pragma: no cover - exercised via `python -m`
+        from scripts.crossref_client import CrossrefClient
+        from scripts.openalex_client import OpenAlexClient
+        from scripts.arxiv_client import ArxivClient
+        from scripts.semantic_scholar_client import SemanticScholarClient
+    return {
+        "crossref": CrossrefClient(),
+        "openalex": OpenAlexClient(),
+        "semantic_scholar": SemanticScholarClient(),
+        "arxiv": ArxivClient(),
+    }
+
+
+def run(argv: list[str] | None = None, *, clients_factory=_real_clients) -> int:
+    parser = argparse.ArgumentParser(
+        prog="verify_passport",
+        description="Verify citation existence across a Material Passport.",
+    )
+    parser.add_argument("passport", help="Path to the passport YAML file.")
+    args = parser.parse_args(argv)
+
+    path = Path(args.passport)
+    if not path.is_file():
+        print(f"[verify_passport ERROR] passport not found: {path}",
+              file=sys.stderr)
+        return 1
+    try:
+        passport = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        print(f"[verify_passport ERROR] could not parse YAML: {e}",
+              file=sys.stderr)
+        return 1
+
+    outcomes = verify_passport(passport, clients=clients_factory())
+    print(json.dumps(outcomes, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/shared/contracts/passport/citation_verification_summary.schema.json
+++ b/shared/contracts/passport/citation_verification_summary.schema.json
@@ -43,7 +43,13 @@
     "resolver_outcomes": {
       "type": "object",
       "additionalProperties": false,
-      "description": "One optional field per resolver. status is one-of (mutually exclusive). queried_by records what the resolver ACTUALLY queried by (v3.11 #182 Delta 4 / C-V6(a)): the narrowed-false reducer treats an unmatched with queried_by=id as fabrication evidence and queried_by=title as a coverage gap. Downstream consumers needing to distinguish manual exemption from total outage read status directly.",
+      "description": "Exactly four fields, one per resolver — ALL required (the summary contract is fully-populated; a resolver that did not run carries status=skipped, never an absent key, so a consumer never disambiguates 'absent' from 'skipped'). status is one-of (mutually exclusive). queried_by records what the resolver ACTUALLY queried by (v3.11 #182 Delta 4 / C-V6(a)): the narrowed-false reducer treats an unmatched with queried_by=id as fabrication evidence and queried_by=title as a coverage gap. Downstream consumers needing to distinguish manual exemption from total outage read status directly.",
+      "required": [
+        "crossref",
+        "openalex",
+        "semantic_scholar",
+        "arxiv"
+      ],
       "properties": {
         "crossref": {
           "$ref": "#/$defs/resolver_outcome"
@@ -65,7 +71,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "status"
+        "status",
+        "queried_by"
       ],
       "properties": {
         "status": {
@@ -88,7 +95,7 @@
             "title",
             null
           ],
-          "description": "v3.11 #182 Delta 4 / C-V6(a): what the resolver actually queried by. `id` = an exact identifier (DOI or arXiv ID) lookup was attempted (so an `unmatched` here is ID-keyed = fabrication evidence). `title` = only a title search was possible (no resolvable identifier; an `unmatched` here is a coverage gap, reduces to unresolvable not false). `null` for skipped / pure-unreachable outcomes where no meaningful query completed. This reflects resolver EXECUTION, not entry shape (the entry having a DOI does not prove the DOI was queried — it may have been malformed/rejected)."
+          "description": "v3.11 #182 Delta 4 / C-V6(a): what the resolver actually queried by. REQUIRED (load-bearing for narrowed-false; an absent key would let an ambiguous unmatched silently reduce to unresolvable instead of false). `id` = an exact identifier (DOI or arXiv ID) lookup was attempted (so an `unmatched` here is ID-keyed = fabrication evidence). `title` = only a title search was possible (no resolvable identifier; an `unmatched` here is a coverage gap, reduces to unresolvable not false). `null` for skipped / pure-unreachable outcomes where no meaningful query completed. This reflects resolver EXECUTION, not entry shape (the entry having a DOI does not prove the DOI was queried — it may have been malformed/rejected)."
         },
         "response_summary": {
           "type": [
@@ -97,7 +104,52 @@
           ],
           "description": "Optional human-readable summary of the resolver response (e.g. matched title, error class). Null when not captured."
         }
-      }
+      },
+      "allOf": [
+        {
+          "description": "A ran resolver (matched / unmatched) always knows what it keyed on: queried_by MUST be id or title, never null. This closes the exact ambiguity the narrowed-false reducer can be fooled by (a null-keyed unmatched).",
+          "if": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "matched",
+                  "unmatched"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "queried_by": {
+                "enum": [
+                  "id",
+                  "title"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "description": "A resolver that did not complete a query (skipped / unreachable) MUST carry queried_by=null — there was no meaningful query to attribute.",
+          "if": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "skipped",
+                  "unreachable"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "queried_by": {
+                "const": null
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/shared/contracts/passport/citation_verification_summary.schema.json
+++ b/shared/contracts/passport/citation_verification_summary.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/passport/citation_verification_summary.schema.json",
+  "title": "Citation Verification Summary Entry",
+  "description": "v3.11 #182 Delta 4 derived-view aggregate: one entry per (citation_key, ref_slug) pair, joining the v3.7.3 anchor signal, the v3.9.0/v3.11 triangulation unmatched signals, and the v3.8 audit verdicts into a single 'is this citation verified' view. The read interface for the §3.6 verification_gate contract (#183) and the #184 eval harness. Detection is unconditional (the aggregate is always populated so the signal is always visible, C-V6(e)); only the terminality is policy-gated by terminal_policies.citation_existence (Delta 3 / C-V6, a later batch). lookup_verified uses the v3.11 narrowed-false definition (C-V6(a)): false requires at least one ID-keyed unmatched, never a title-only unmatched. Spec docs/design/2026-05-21-v3.10-182-promote-citation-gate-spec.md §2 Delta 4 + §0(4a) + C-V6(a).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "citation_key",
+    "ref_slug",
+    "lookup_verified",
+    "anchor_present",
+    "verification_timestamp",
+    "resolver_outcomes"
+  ],
+  "properties": {
+    "citation_key": {
+      "type": "string",
+      "description": "Joins to literature_corpus_entry.citation_key."
+    },
+    "ref_slug": {
+      "type": "string",
+      "description": "Joins to the <!--ref:slug--> markers used in writer prose."
+    },
+    "lookup_verified": {
+      "type": "string",
+      "enum": [
+        "true",
+        "false",
+        "unresolvable"
+      ],
+      "description": "3-class existence verdict (a STRING enum, never a JSON boolean). `true` iff >=1 applicable resolver returned status=matched (matched WINS). `false` (v3.11 narrowed, C-V6(a)) iff no applicable resolver is matched AND >=1 applicable resolver is an ID-keyed unmatched (status=unmatched with queried_by=id, i.e. a DOI/arXiv ID that provably fails to resolve = fabrication evidence). `unresolvable` otherwise: every applicable resolver unreachable (total outage), OR every resolver skipped (manual-entry exempt, empty adjudicating set), OR the only negative signals are title-only unmatched (queried_by=title, no resolvable identifier to key on = coverage gap, NOT fabrication). `skipped` outcomes are excluded from classification (applicability/policy, not adjudication). Anti-fabrication bias: a bogus-DOI citation with 3 ID-keyed unmatched + 1 unreachable is `false`, not `unresolvable` (one transient outage does not cancel positive non-existence evidence). The reducer in scripts/citation_verification_summary.py is the single source of truth."
+    },
+    "anchor_present": {
+      "type": "boolean",
+      "description": "True iff the citation's v3.7.3 anchor marker has kind in {quote, page, section, paragraph} (not none). Read by the #183 epistemic-status gate to know whether the row is anchorless."
+    },
+    "verification_timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC. When >=1 resolver ran, the latest resolver timestamp; when all resolvers were skipped (manual entry) or all unreachable (outage), the attempt timestamp (when the summary was generated). Never null."
+    },
+    "resolver_outcomes": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "One optional field per resolver. status is one-of (mutually exclusive). queried_by records what the resolver ACTUALLY queried by (v3.11 #182 Delta 4 / C-V6(a)): the narrowed-false reducer treats an unmatched with queried_by=id as fabrication evidence and queried_by=title as a coverage gap. Downstream consumers needing to distinguish manual exemption from total outage read status directly.",
+      "properties": {
+        "crossref": {
+          "$ref": "#/$defs/resolver_outcome"
+        },
+        "openalex": {
+          "$ref": "#/$defs/resolver_outcome"
+        },
+        "semantic_scholar": {
+          "$ref": "#/$defs/resolver_outcome"
+        },
+        "arxiv": {
+          "$ref": "#/$defs/resolver_outcome"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "resolver_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "matched",
+            "unmatched",
+            "unreachable",
+            "skipped"
+          ],
+          "description": "matched = resolver returned a match. unmatched = resolver ran and returned no match. unreachable = API outage / timeout. skipped = resolver did not run (manual entry per v3.7.3 exemption, or arXiv resolver on a non-arXiv citation per Delta 1)."
+        },
+        "queried_by": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "id",
+            "title",
+            null
+          ],
+          "description": "v3.11 #182 Delta 4 / C-V6(a): what the resolver actually queried by. `id` = an exact identifier (DOI or arXiv ID) lookup was attempted (so an `unmatched` here is ID-keyed = fabrication evidence). `title` = only a title search was possible (no resolvable identifier; an `unmatched` here is a coverage gap, reduces to unresolvable not false). `null` for skipped / pure-unreachable outcomes where no meaningful query completed. This reflects resolver EXECUTION, not entry shape (the entry having a DOI does not prove the DOI was queried — it may have been malformed/rejected)."
+        },
+        "response_summary": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional human-readable summary of the resolver response (e.g. matched title, error class). Null when not captured."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What this is

The **data-layer** batch of #182 (deterministic citation verification gate): Delta 4 (unified `lookup_verified` summary + narrowed-false reducer) and Delta 5 (`verification_gate` API). This does **NOT** close #182 — the policy layer that gates on `lookup_verified` (`terminal_policies.citation_existence`) and the prose-anchor join wiring land in a follow-up batch.

`[skip-closes-check]`

## Delta 4 — unified summary + reducer

- `scripts/citation_verification_summary.py` — the **single source of truth** `reduce_lookup_verified`. v3.11 narrowed-false (C-V6(a)): `false` requires ≥1 **ID-keyed** unmatched (a DOI/arXiv ID that provably fails to resolve = fabrication evidence) and no matched; a title-only unmatched (no resolvable identifier) is a coverage gap → `unresolvable`, never `false`. `run_evals.py` and `check_evals_gold_set.py` (I9b) defer to it — no parallel copy of the logic.
- `shared/contracts/passport/citation_verification_summary.schema.json` — per-(citation_key, ref_slug) aggregate. Tightened so the contract can't silently weaken the signal: all four resolver keys required; `queried_by` required; status-dependent `queried_by` (ran → `id`/`title`, skipped/unreachable → `null`).

## Delta 5 — verification_gate API

- `scripts/verification_gate/__init__.py` — `verify_citation` / `verify_passport`. Composes the four resolvers into the summary, deriving `lookup_verified` via the reducer. Does **not** duplicate the audit pipeline — it calls the same lower-layer resolvers.
- **Anchor is an explicit input, joined by `ref_slug`.** The v3.7.3 anchor lives in writer prose (`<!--anchor:kind:value-->`), not in `literature_corpus`. `verify_citation` takes an `anchor` param; `verify_passport` owns the `ref_slug → anchor` join from a passed-in map. (Reading `entry.get("anchor")` would have been a permanent silent `False` in production — fixed here, with an anti-regression test.)
- `scripts/verify_passport.py` — `python -m scripts.verify_passport <passport.yaml>` ad-hoc entry point (resolver clients injectable via a test seam).

## Gold set

- `051` (no-identifier fabrication, by-design FN per spec OQ-5) + `052` (legitimately-unindexed regional paper) form the **C-V6(a) coverage-gap pair**: both reduce to `unresolvable`, proving the gate treats fabrication and coverage-gap symmetrically when no resolvable identifier exists. `sample_n` 51 → 52.

## Verification

- Full suite: **2038 passed, 3 skipped** (anaconda system python).
- TDD throughout (RED → GREEN → mutation check); the six new schema constraints are mutation-verified (each violation rejected, each valid shape accepted).
- Gold-set invariants pass; the tightened schema validates all 52 gold entries.

## Known intermediate state (accepted)

`lookup_verified` is computed but **not yet gated on** — the consuming policy (`terminal_policies.citation_existence`, enum `{advisory, strict}`) and the prose-anchor join in the Stage 4→5 pipeline are the next batch. The reducer module carries an explicit deferral note for the OQ-5 recall limit's user-facing surfacing.
