### PR TITLE
fix: schema-valid symlink rejection + encoded Crossref locator (#310 follow-up)

### DIFF
--- a/scripts/adapters/folder_scan.py
+++ b/scripts/adapters/folder_scan.py
@@ -159,7 +159,8 @@ def main() -> int:
             except ValueError:
                 rejected.append({
                     "source": rel_str,
-                    "reason": "symlink_outside_input_root",
+                    "reason": "other",
+                    "detail": "symlink resolves outside the input root",
                     "raw": rel_str,
                     "missing_fields": [],
                 })

--- a/scripts/adapters/tests/test_folder_scan.py
+++ b/scripts/adapters/tests/test_folder_scan.py
@@ -198,18 +198,28 @@ def test_symlink_pointing_outside_input_does_not_crash(tmp_path):
     r_out = tmp_path / "r.yaml"
     r = _run("--input", str(inside), "--passport", str(p_out), "--rejection-log", str(r_out))
     assert r.returncode == 0, r.stderr
+    import json
     import yaml
+    import jsonschema
     with p_out.open() as f:
         passport = yaml.safe_load(f)
     with r_out.open() as f:
         rejection = yaml.safe_load(f)
     assert passport == {"literature_corpus": []}
     assert rejection["rejected"] == [{
+        "detail": "symlink resolves outside the input root",
         "missing_fields": [],
         "raw": "Smith2024_link.pdf",
-        "reason": "symlink_outside_input_root",
+        "reason": "other",
         "source": "Smith2024_link.pdf",
     }]
+    # The emitted rejection log must satisfy the rejection-log contract, not
+    # just be crash-free — a non-enum reason would pass the run but break the
+    # schema (Codex follow-up to #310).
+    schema = json.loads(
+        (REPO_ROOT / "shared/contracts/passport/rejection_log.schema.json").read_text()
+    )
+    jsonschema.validate(rejection, schema)
 
 
 def test_parseable_non_pdf_extension(tmp_path):

--- a/scripts/bootstrap_timeline_yaml.py
+++ b/scripts/bootstrap_timeline_yaml.py
@@ -81,6 +81,10 @@ def _bootstrap_entry(entry: dict, dry_run: bool) -> dict:
     doi = entry.get("doi")
     crossref_data = _crossref_lookup(doi, dry_run) if doi else None
     if crossref_data:
+        # Encode the DOI the same way _crossref_lookup does so the recorded
+        # provenance points at the URL actually queried (DOIs contain '/' and
+        # may carry reserved characters).
+        quoted_doi = urllib.parse.quote(doi, safe="")
         issued = crossref_data.get("issued", {}).get("date-parts", [[None]])[0]
         if issued and issued[0]:
             precision_map = {1: "year", 2: "month", 3: "day"}
@@ -94,7 +98,7 @@ def _bootstrap_entry(entry: dict, dry_run: bool) -> dict:
                 "provenance": {
                     "method": "crossref_lookup",
                     "raw": str(issued),
-                    "source_locator": f"https://api.crossref.org/works/{doi}",
+                    "source_locator": f"https://api.crossref.org/works/{quoted_doi}",
                     "confidence": "high",
                 },
             }

--- a/scripts/test_bootstrap_timeline_yaml.py
+++ b/scripts/test_bootstrap_timeline_yaml.py
@@ -103,6 +103,28 @@ def test_crossref_lookup_quotes_doi_path(monkeypatch):
     ]
 
 
+def test_bootstrap_entry_locator_matches_queried_url(monkeypatch):
+    # Codex follow-up to #310: the lookup encodes the DOI, so the recorded
+    # source_locator must point at the same encoded URL — not the raw DOI —
+    # or provenance references a resource that was never queried.
+    module = _load_script_module()
+
+    monkeypatch.setattr(
+        module,
+        "_crossref_lookup",
+        lambda doi, dry_run: {"issued": {"date-parts": [[2024, 3]]}},
+    )
+
+    out = module._bootstrap_entry(
+        {"citation_key": "foo2024", "doi": "10.1000/foo?bar=baz"},
+        dry_run=False,
+    )
+
+    assert out["published_date"]["provenance"]["source_locator"] == (
+        "https://api.crossref.org/works/10.1000%2Ffoo%3Fbar%3Dbaz"
+    )
+
+
 def test_pdftotext_uses_resolved_executable(monkeypatch, tmp_path):
     module = _load_script_module()
     pdf = tmp_path / "paper.pdf"


### PR DESCRIPTION
Closes #324.

## Summary

Post-merge codex review of #310 (security-boundary hardening) surfaced two correctness issues in edge cases that #310's tests — happy-path / crash-free only — did not catch. Both were independently verified before fixing.

- **Schema-invalid symlink rejection** (`scripts/adapters/folder_scan.py`). When a symlink escapes the input root, the adapter wrote `reason: symlink_outside_input_root` to `rejection_log.yaml`, but that value is not in the `rejection_log.schema.json` `reason` enum. So the rejection log was contract-invalid exactly in the new symlink-rejection path. Now uses `other` + `detail` (schema-valid; the schema's `allOf` requires `detail` when `reason == other`).

- **Crossref locator pointed at an unqueried URL** (`scripts/bootstrap_timeline_yaml.py`). The lookup queries `…/works/{quote(doi)}` (encoded) but `source_locator` recorded `…/works/{doi}` (raw). Provenance therefore named a URL that was never queried. This affects every DOI, not only reserved-character ones — `/` encodes to `%2F`. Now records the encoded DOI to match the queried URL.

## Tests

Strengthened to close the blind spot (assert emitted content, not just exit code):

- `test_symlink_pointing_outside_input_does_not_crash` now `jsonschema.validate()`s the emitted rejection log against the rejection-log contract.
- New `test_bootstrap_entry_locator_matches_queried_url` asserts `source_locator` equals the encoded lookup URL.

```
231 passed
python scripts/check_version_consistency.py --path .   # green
python scripts/check_literature_corpus_schema.py       # green
```

codex re-review of the fix returned no introduced issues.
