### PR TITLE
docs(orchestrator): add citation_existence to the canonical terminal-marker grammar (#333 item 2)

### DIFF
--- a/academic-pipeline/agents/pipeline_orchestrator_agent.md
+++ b/academic-pipeline/agents/pipeline_orchestrator_agent.md
@@ -835,10 +835,10 @@ Every finalized marker takes ONE of two shapes (the literal `TERMINAL-BLOCK` sen
     ```
 - **Terminal** (entry hit a HIGH-BLOCK under a strict policy — only reachable under a non-advisory policy, so always stamped): the advisory suffix stays in its optional slot; the terminal token sequence is ADDITIONAL:
   ```
-  <!--ref:<slug> <base-status> [<advisory-suffix>] TERMINAL-BLOCK severity=HIGH-BLOCK policy=<contamination_triangulation|temporal_integrity> reason=<reason-token> mode=<strict|strict_articles_only> policy_hash=<slug>-->
+  <!--ref:<slug> <base-status> [<advisory-suffix>] TERMINAL-BLOCK severity=HIGH-BLOCK policy=<contamination_triangulation|temporal_integrity|citation_existence> reason=<reason-token> mode=<strict|strict_articles_only> policy_hash=<slug>-->
   ```
 
-Where `<base-status>` ∈ {`ok`, `LOW-WARN`} (the v3.7.3 5-cell base resolution) and `[<advisory-suffix>]` is the OPTIONAL v3.9.0 contamination suffix (one token max, drawn from the v3.9.0 allowlist), present iff the entry fired an advisory signal. `reason` carries the typed payload that preserves remediation context — for contamination k=3 it is `reason=k3_all_indexes_unmatched`.
+Where `<base-status>` ∈ {`ok`, `LOW-WARN`} (the v3.7.3 5-cell base resolution) and `[<advisory-suffix>]` is the OPTIONAL v3.9.0 contamination suffix (one token max, drawn from the v3.9.0 allowlist), present iff the entry fired an advisory signal. `reason` carries the typed payload that preserves remediation context — for contamination k=3 it is `reason=k3_all_indexes_unmatched`. The `mode=` enumeration above is the union across policies; the valid modes are **per-policy**: `contamination_triangulation` ∈ {`strict`, `strict_articles_only`}, `citation_existence` is `strict` only (no `strict_articles_only`), and `temporal_integrity` is forward-reserved advisory-only (no terminal mode wired). A `policy=citation_existence` token therefore always carries `mode=strict`.
 
 **Legacy (v3.9.0) markers carry NO `policy_hash`** — and so does a v3.10 marker finalized under an all-advisory passport (they are byte-identical). They are NOT malformed; the formatter's legacy/default-transition rule (§ Formatter) passes a stampless marker under an advisory passport and refuses it only when the current passport is non-advisory (the user opted into hard-block, so the stampless draft must be re-finalized).
 

--- a/scripts/test_check_v3_10_policy.py
+++ b/scripts/test_check_v3_10_policy.py
@@ -68,6 +68,45 @@ def test_marker_terminal_without_advisory_suffix_parses():
     assert marker_triggers_refusal(marker) is True
 
 
+def test_marker_citation_existence_terminal_parses_and_refuses():
+    """A `policy=citation_existence` terminal token (C-V6(c), the real line-869
+    example) is in-grammar: it parses cleanly with no residual/unknown token and
+    triggers refusal. Pins that the canonical grammar enumeration covers
+    citation_existence (#333) — citation_existence is `mode=strict` only (no
+    strict_articles_only), and unlike contamination it carries NO advisory suffix
+    in the slot (the `false` "why" lives in reason= + the aggregate)."""
+    marker = ("<!--ref:bogus2024 ok TERMINAL-BLOCK severity=HIGH-BLOCK "
+              "policy=citation_existence reason=lookup_verified_false mode=strict "
+              "policy_hash=citation_existence.strict-->")
+    pm = parse_ref_marker(marker)
+    assert pm is not None
+    assert pm.base_status == "ok"
+    assert pm.advisory_suffix is None  # citation_existence occupies no advisory slot
+    assert pm.terminal is True
+    assert pm.is_high_block is True
+    assert pm.policy == "citation_existence"
+    assert pm.reason == "lookup_verified_false"
+    assert pm.mode == "strict"
+    assert pm.policy_hash == "citation_existence.strict"
+    assert pm.unknown_tokens == []  # nothing falls outside the grammar
+    assert marker_triggers_refusal(marker) is True
+
+
+def test_marker_dual_policy_co_emit_parses_and_refuses():
+    """C-V6(g): a ref violating BOTH contamination_triangulation=strict (k=3) AND
+    citation_existence=strict carries two TERMINAL-BLOCK tokens. The generic
+    refusal must still fire (the formatter refuses on any unresolved HIGH-BLOCK,
+    no per-policy enumeration). Pins that the multi-policy grammar at line 887 is
+    consistent with the canonical shape (#333)."""
+    marker = ("<!--ref:both2024 LOW-WARN CONTAMINATED-TRIANGULATION-UNMATCHED "
+              "TERMINAL-BLOCK severity=HIGH-BLOCK policy=contamination_triangulation "
+              "reason=k3_all_indexes_unmatched mode=strict "
+              "TERMINAL-BLOCK severity=HIGH-BLOCK policy=citation_existence "
+              "reason=lookup_verified_false mode=strict "
+              "policy_hash=citation_existence.strict+contamination_triangulation.strict-->")
+    assert marker_triggers_refusal(marker) is True
+
+
 def test_marker_non_terminal_advisory_parses_no_refuse():
     """A non-terminal advisory marker under a NON-advisory passport: advisory suffix
     + a non-advisory policy_hash slug, NO terminal token → does not refuse. (Under an


### PR DESCRIPTION
## What

Resolves **item 2** of #333 (grammar consistency). The canonical "Two marker grammar shapes" terminal shape in `pipeline_orchestrator_agent.md:838` enumerated `policy=<contamination_triangulation|temporal_integrity>`, omitting `citation_existence` — even though the finalizer prose just below it (lines 867 / 869 / 887) emits `policy=citation_existence` terminal tokens. An agent following the canonical shape would treat `policy=citation_existence` as out-of-grammar, risking a malformed or omitted token.

(The formatter's generic `severity=HIGH-BLOCK` refusal catches the token regardless, so the gate never failed open — this was an internal self-contradiction in the prompt, not a gate hole.)

## Change

- Extend the enumeration: `policy=<contamination_triangulation|temporal_integrity|citation_existence>`.
- Reconcile the `mode=` clause — the modes are **per-policy** (`contamination_triangulation` ∈ {strict, strict_articles_only}; `citation_existence` is `strict` only; `temporal_integrity` forward-reserved advisory-only), so a `policy=citation_existence` token always carries `mode=strict`. (The flat `mode=<strict|strict_articles_only>` union alone would wrongly imply citation_existence can be `strict_articles_only`.)
- **Formatter needs no change** — it already references `policy=<...>` generically and its prose already handles `citation_existence` (co-emits no advisory suffix). The marker-grammar parser is enumeration-agnostic. The grep across orchestrator + formatter found no other canonical `policy=<...>` enumeration to update in lockstep.

## Tests
2 new parser fixtures in `test_check_v3_10_policy.py` (34 → green):
- a `policy=citation_existence` terminal token parses with no residual/unknown token and triggers refusal;
- a dual-policy (contamination + citation_existence) co-emit still triggers refusal (C-V6(g)).

## Scope
This PR is **item 2 only**. Item 1 of #333 (default-advisory `lookup_verified == false` emits no marker annotation vs spec C-V6(b)/(e) — a spec-vs-impl conflict with a safety angle) is intentionally left open for a separate decision on whether to bring the impl to spec or amend the spec. The issue stays open to track it.

## Review
- `codex review` (gpt-5.5): PASS, 0 findings — "aligns the marker grammar with the existing citation_existence terminal policy, and the added tests pass."

[skip-closes-check] This PR is intentionally item-2-only and uses `Refs #333` (not `Closes`): item 1 of #333 (default-advisory marker-annotation spec-vs-impl conflict) is a separate decision and #333 must stay open to track it. See the Scope section above.

Refs #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)
