### PR TITLE
fix: wire domain evidence profiles end-to-end (#327)

### DIFF
--- a/academic-paper/agents/intake_agent.md
+++ b/academic-paper/agents/intake_agent.md
@@ -60,7 +60,7 @@ You are the Intake Agent. You conduct a structured configuration interview to es
 
 ### When No Handoff Materials Are Detected
 
-Execute the original Phase 0 full interview flow (Step 1-11).
+Execute the original Phase 0 full interview flow (Step 1-11), then Step 12 (Domain Evidence Profile) per its own gating in that step.
 
 ---
 

--- a/academic-paper/agents/literature_strategist_agent.md
+++ b/academic-paper/agents/literature_strategist_agent.md
@@ -50,8 +50,9 @@ Reference: `academic-paper/references/domain_evidence_profiles.md`
 
 Graceful-fallback cases (none block — INVARIANT 4):
 - **(a) Row absent** → neutral `unknown_user_defined`. **In `full` mode, emit `[NO-PROFILE-NEUTRAL]`** so the neutral default is visible. (Paths that leave the row absent: `plan → full` and true mid-entry, where intake never set it. Resume-from-checkpoint carries whatever the prior intake wrote — present ⇒ that profile applies with no advisory; absent ⇒ neutral + advisory. A `deep-research → academic-paper` handoff is NOT absent — intake set the row.)
-- **(b) Row = `unknown_user_defined`** → neutral. **No `[NO-PROFILE-NEUTRAL]`** — the scholar actively chose/accepted neutral at intake; that tag is only for the absent-row case.
-- **(c) Row holds a value not in the 4 enum** (hallucinated, or a reserved value somehow stored as effective) → neutral, **and emit `[PROFILE-UNRESOLVED]`**.
+- **(b) Row is *exactly* `unknown_user_defined`** (no `(requested: …)` suffix) → neutral. **No `[NO-PROFILE-NEUTRAL]`** — the scholar actively chose/accepted neutral at intake; that tag is only for the absent-row case.
+- **(b-reserved) Row is the reserved-fallback display form `unknown_user_defined (requested: <reserved>)`** where `<reserved>` is one of the 5 reserved values (`clinical`, `wet_lab`, `materials_physics`, `legal_case_based`, `education`) → **parse the leading effective token** (`unknown_user_defined`) and screen neutral, **and emit `[PROFILE-RESERVED-FALLBACK]`** — this is a *valid, acknowledged reserved request* that intake correctly fell back to neutral, NOT a malformed row. Do **not** emit `[PROFILE-UNRESOLVED]` here. Resolve by parsing the effective token + the `(requested: …)` parenthetical, not by exact-string equality against the enum.
+- **(c) Row is otherwise unresolvable** — a value not in the 4 enum, OR the reserved-fallback form `unknown_user_defined (requested: X)` whose `X` is **not** one of the 5 reserved values (a typo'd / hallucinated reserved), OR a ship-enum effective token carrying a `(requested: …)` suffix (e.g. `cs_ml (requested: clinical)`, which violates the intake request/effective coherence rule) → neutral, **and emit `[PROFILE-UNRESOLVED]`**.
 - **(d) Discipline mismatch** (the profile's implied discipline ≠ PCR `Discipline`) → proceed with BOTH signals in their own lanes, **emit `[PROFILE-DISCIPLINE-MISMATCH]`**. This is a warning, not a fallback — admissibility still uses the profile; `Discipline` still drives database selection. Nothing is blocked.
 
 **Profile → implied-discipline map** (so "implies a discipline" is deterministic, a string-category comparison — not inference):
@@ -477,7 +478,11 @@ Receive a candidate source ->
 ├── Is it within the time range (default 10 years)?
 │   ├── No -> Is it a foundational/milestone work in the field (cited > 100 times)?
 │   │   ├── Yes -> Include (tag as "seminal work")
-│   │   └── No -> Exclude
+│   │   └── No -> Is it admissible under the active domain evidence profile's currency rule?
+│   │       (humanities_interpretive: primary / archival / canonical source; recency is not a quality signal)
+│   │       ├── Yes -> tag by evidence type, then CONTINUE to the relevance + methodology nodes below
+│   │       │          (profile admit path, loosen-only — it does NOT short-circuit to Include)
+│   │       └── No -> Exclude
 │   └── Yes ->
 ├── Does the abstract directly address at least one aspect of the RQ?
 │   ├── No -> Exclude
@@ -488,7 +493,7 @@ Receive a candidate source ->
 │   └── Yes -> Include
 ```
 
-A profile-admitted source is added at the peer-review node only and then continues through the unchanged relevance and methodology nodes; the profile never bypasses a universal-quality node and never short-circuits to Include.
+A profile-admitted source is added only at the tree's PROFILE_LOOSENABLE nodes — the peer-review / publication-type node and the currency-window (time-range) node — and then continues through the unchanged universal relevance and methodology nodes; the profile never bypasses a universal-quality node and never short-circuits to Include. (Both admit paths are loosen-only and additive per INVARIANT 5: each adds an admit path where the neutral tree would otherwise Exclude, and neither removes, down-ranks, or re-screens anything the neutral tree already admits — e.g. the neutral `cited > 100` seminal-work Include is untouched.)
 
 ### Literature Quality Quick Assessment Checklist
 

--- a/scripts/check_domain_evidence_profile.py
+++ b/scripts/check_domain_evidence_profile.py
@@ -24,6 +24,8 @@ RESERVED = ("clinical", "wet_lab", "materials_physics", "legal_case_based", "edu
 
 INTAKE_STEP12_HEADING = "### Step 12: Domain Evidence Profile"
 CONSUMER_RESOLUTION_HEADING = "### Domain Evidence Profile Resolution"
+INTAKE_NO_HANDOFF_HEADING = "### When No Handoff Materials Are Detected"
+DECISION_TREE_HEADING = "### Literature Screening Decision Tree"
 
 
 def _read(p: Path) -> str:
@@ -364,9 +366,155 @@ def check_c7() -> list[str]:
     return f
 
 
+def check_c8() -> list[str]:
+    """Control-flow guard (#327 P1): the no-handoff interview directive's upper
+    bound MUST cover Step 12 (Domain Evidence Profile producer).
+
+    Unlike C1-C7 (documentation-surface presence), this check inspects a
+    control-flow BOUND. The original directive
+    `Execute the original Phase 0 full interview flow (Step 1-11).` bounded the
+    most common full-mode entry (a fresh paper with no deep-research handoff) at
+    Step 11, orphaning the Step-12 profile producer: an agent following it stops
+    at Step 11, never writes the PCR `Domain Evidence Profile` row, and the
+    consumer silently takes the `[NO-PROFILE-NEUTRAL]` fallback — the feature
+    never activates on that path.
+
+    Scope: only the `### When No Handoff Materials Are Detected` block, via the
+    fence-aware `_heading_range` helper (so a `Step 1-11` mention in unrelated
+    prose — e.g. plan-mode's "instead of the full 11" — never trips it). The
+    requirement is that the block reaches Step 12; a directive that stops at
+    Step 11 will not mention Step 12 and so fails.
+    """
+    f: list[str] = []
+    t = _read(INTAKE)
+    if not t:
+        return ["C8: intake_agent.md not found"]
+    block = _heading_range(t, INTAKE_NO_HANDOFF_HEADING)
+    if block is None:
+        return [f"C8: missing exact heading '{INTAKE_NO_HANDOFF_HEADING}'"]
+    # Require a POSITIVE execution directive, not bare `Step 12` token presence:
+    # a directive like "Execute (Step 1-11). Do not run Step 12 in this flow."
+    # contains the token yet still orphans the producer. `then Step 12` is the
+    # affirmative form the fix uses ("Step 1-11, then Step 12 per its own gating").
+    if "then Step 12" not in block:
+        f.append(
+            "C8: no-handoff flow directive does not positively execute Step 12 — "
+            "the Domain Evidence Profile producer (Step 12) is orphaned from the "
+            "most common full-mode entry. The directive must affirmatively reach "
+            "Step 12 (e.g. 'Step 1-11, then Step 12 per its own gating'), not "
+            "merely mention the token."
+        )
+    return f
+
+
+def check_c9() -> list[str]:
+    """Reserved-fallback parse guard (#327 P2#2): the consumer must route a
+    reserved-fallback row to its OWN advisory, not the malformed signal.
+
+    Intake stores a reserved request as the display form
+    `unknown_user_defined (requested: <reserved>)`. The original consumer had no
+    parse step for that form, so it fell into case (c) (value not in the 4 enum)
+    and emitted `[PROFILE-UNRESOLVED]` — the malformed/hallucinated signal — for a
+    valid, acknowledged reserved request.
+
+    C9 pins, within the resolution block, BOTH:
+      (1) the distinct `[PROFILE-RESERVED-FALLBACK]` advisory tag exists, and
+      (2) the block actually parses the `(requested: …)` parenthetical
+          (otherwise the tag is unreachable and the row still routes to (c)).
+
+    Division of labour with C3: C3 guards the three *original* consumer tags
+    (NO-PROFILE-NEUTRAL / PROFILE-UNRESOLVED / PROFILE-DISCIPLINE-MISMATCH) and
+    is deliberately NOT extended here, so each tag's mutation fixture isolates one
+    check. C9 owns the fourth (reserved-fallback) tag + its parse semantics.
+    """
+    f: list[str] = []
+    t = _read(CONSUMER)
+    if not t:
+        return ["C9: literature_strategist_agent.md not found"]
+    block = _heading_range(t, CONSUMER_RESOLUTION_HEADING)
+    if block is None:
+        return [f"C9: missing exact heading '{CONSUMER_RESOLUTION_HEADING}'"]
+    if "[PROFILE-RESERVED-FALLBACK]" not in block:
+        f.append(
+            "C9: resolution block missing the reserved-fallback advisory tag "
+            "'[PROFILE-RESERVED-FALLBACK]' — a valid reserved request "
+            "(`unknown_user_defined (requested: <reserved>)`) would collapse back "
+            "into the [PROFILE-UNRESOLVED] malformed signal."
+        )
+    # Require BOTH the display form AND an explicit parse INSTRUCTION, not just
+    # the suffix token: a block can carry `(requested: …)` only as a display
+    # example while losing the "parse the parenthetical" instruction, leaving
+    # reserved fallbacks to route back to the (c) malformed case. (Hardening from
+    # codex review.) `parse`/`parsing` covers the instruction wording.
+    if "(requested:" not in block:
+        f.append(
+            "C9: resolution block lacks the `(requested: …)` display form — the "
+            "reserved-fallback path is unreachable, so the row routes to the (c) "
+            "malformed case."
+        )
+    elif "parse" not in block.lower():
+        f.append(
+            "C9: resolution block shows the `(requested: …)` form but gives no "
+            "parse INSTRUCTION (no 'parse'/'parsing' of the effective token + "
+            "parenthetical) — without it the agent falls back to exact-string "
+            "equality and the reserved fallback still routes to the (c) malformed "
+            "case."
+        )
+    return f
+
+
+def check_c10() -> list[str]:
+    """Profile-aware currency gate (#327 P2#3): the screening decision tree's
+    time-range (currency) node MUST consult the profile, and the "peer-review node
+    only" fossil wording MUST be gone.
+
+    `currency_window` is in PROFILE_LOOSENABLE and four prose passages say the
+    year-range relaxes for humanities_interpretive canonical texts. But the
+    time-range NODE in the decision tree had no profile branch, so a canonical
+    humanities source admitted at the peer-review node was re-excluded at the
+    time-range node (cited <= 100) — an INVARIANT 5 monotonic-admit violation. The
+    prose under the tree also said the profile admits "at the peer-review node
+    only", which encoded the bug and contradicted the four other passages.
+
+    Scope: the `### Literature Screening Decision Tree` heading range (tree +
+    its trailing prose), via `_heading_range`. Pins BOTH:
+      (1) the currency node consults the profile (`currency rule` admit branch),
+      (2) the `peer-review node only` fossil wording is absent.
+    """
+    f: list[str] = []
+    t = _read(CONSUMER)
+    if not t:
+        return ["C10: literature_strategist_agent.md not found"]
+    block = _heading_range(t, DECISION_TREE_HEADING)
+    if block is None:
+        return [f"C10: missing exact heading '{DECISION_TREE_HEADING}'"]
+    # Pin the currency-node admit branch on its load-bearing semantic phrase, not
+    # on a label. "recency is not a quality signal" lives ONLY inside the
+    # humanities currency-node admit branch in this block; it disappears if the
+    # branch is deleted and survives a label reword (e.g. "currency rule" ->
+    # "recency rule"). Keying on a label would let a benign reword silently defeat
+    # the guard while a broken edit that kept the label passed.
+    if "recency is not a quality signal" not in block:
+        f.append(
+            "C10: decision-tree time-range node is not profile-aware — missing the "
+            "humanities currency-node admit branch (its 'recency is not a quality "
+            "signal' rationale). A canonical humanities source admitted at the "
+            "peer-review node is re-excluded here (INVARIANT 5 violation)."
+        )
+    if "peer-review node only" in block:
+        f.append(
+            "C10: fossil wording 'peer-review node only' present — it encodes the "
+            "#327 P2#3 bug (profile can't touch the currency node) and contradicts "
+            "the four prose passages that relax currency for humanities. Name the "
+            "PROFILE_LOOSENABLE nodes the profile actually admits at instead."
+        )
+    return f
+
+
 CHECKS: list[tuple[str, Callable[[], list[str]]]] = [
     ("C1", check_c1), ("C2", check_c2), ("C3", check_c3), ("C4", check_c4),
-    ("C5", check_c5), ("C6", check_c6), ("C7", check_c7),
+    ("C5", check_c5), ("C6", check_c6), ("C7", check_c7), ("C8", check_c8),
+    ("C9", check_c9), ("C10", check_c10),
 ]
 
 

--- a/scripts/test_check_domain_evidence_profile.py
+++ b/scripts/test_check_domain_evidence_profile.py
@@ -22,6 +22,15 @@ PROFILES = "academic-paper/references/domain_evidence_profiles.md"
 CONSUMER = "academic-paper/agents/literature_strategist_agent.md"
 SQH = "deep-research/references/source_quality_hierarchy.md"
 
+# Heading literals the C8/C10 fixtures mutate, kept here (not imported from the
+# lint module) deliberately: the suite drives the lint via subprocess, so it
+# stays import-free. Names match the lint module's constants
+# (INTAKE_NO_HANDOFF_HEADING / DECISION_TREE_HEADING) so a future heading reword
+# is easy to keep in sync; if it drifts, the fixture precondition assert in the
+# affected test fails loudly in CI rather than silently passing.
+INTAKE_NO_HANDOFF_HEADING = "### When No Handoff Materials Are Detected"
+DECISION_TREE_HEADING = "### Literature Screening Decision Tree"
+
 
 def run_lint(cwd: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
@@ -259,3 +268,170 @@ def test_pos_historical_contrast_does_not_trip_c7(tmp_path):
     )
     r = run_lint(repo)
     assert r.returncode == 0, r.stderr
+
+
+# --- C8: no-handoff flow directive upper bound covers Step 12 (#327 P1) ---------
+#
+# Bug (#327 P1): intake_agent.md's ONLY no-handoff control-flow directive bounded
+# the interview at "Step 1-11", but the Domain Evidence Profile producer is
+# Step 12. An agent following the directive literally never runs Step 12, never
+# writes the PCR row, and the consumer silently takes the [NO-PROFILE-NEUTRAL]
+# fallback — the feature never activates on the most common path. C8 pins the
+# directive's upper bound so this cannot silently regress; the runtime fix is in
+# intake_agent.md line ~63.
+
+def test_neg_h_step12_bound_regression(tmp_path):
+    """(h) revert the no-handoff flow directive to a Step-11 upper bound (drop the
+    Step 12 coverage) -> C8 fails. This is the exact #327 P1 regression: the
+    directive that bounds the no-handoff interview must reach Step 12, or the
+    Domain Evidence Profile producer is orphaned. Mutate within the no-handoff
+    block so we exercise C8's scoped detection, not a global token scan."""
+    repo = _clone_repo(tmp_path)
+    p = repo / INTAKE
+    text = p.read_text(encoding="utf-8")
+    # Find the no-handoff block and strip every "Step 12" mention inside it,
+    # simulating the orphaned-bound regression.
+    idx = text.index(INTAKE_NO_HANDOFF_HEADING)
+    nxt = text.index("\n## ", idx)  # next H2 (Plan Mode Detection) ends the block
+    block = text[idx:nxt]
+    assert "then Step 12" in block, "fixture precondition: no-handoff block must execute Step 12"
+    mutated = block.replace("then Step 12", "then Step 11")
+    p.write_text(text[:idx] + mutated + text[nxt:], encoding="utf-8")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C8" in r.stderr
+
+
+def test_neg_h2_step12_mentioned_but_negated(tmp_path):
+    """(h2) C8 strength: a directive that MENTIONS the Step 12 token but negates
+    its execution ("Do not run Step 12 in this flow") must STILL fail C8. A bare
+    token-presence guard would let this orphan the producer; C8 requires the
+    affirmative 'then Step 12' directive. (Hardening from codex review.)"""
+    repo = _clone_repo(tmp_path)
+    p = repo / INTAKE
+    text = p.read_text(encoding="utf-8")
+    idx = text.index(INTAKE_NO_HANDOFF_HEADING)
+    nxt = text.index("\n## ", idx)
+    block = text[idx:nxt]
+    # Replace the affirmative directive with one that mentions but negates Step 12.
+    mutated = block.replace(
+        "then Step 12 (Domain Evidence Profile) per its own gating in that step.",
+        "Do not run Step 12 in this flow.",
+    )
+    assert mutated != block, "fixture precondition: affirmative directive must be present to replace"
+    p.write_text(text[:idx] + mutated + text[nxt:], encoding="utf-8")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C8" in r.stderr
+
+
+def test_pos_step11_outside_nohandoff_block_does_not_trip_c8(tmp_path):
+    """Scope-lock: a "Step 1-11" mention OUTSIDE the no-handoff block (e.g. the
+    plan-mode "instead of the full 11" prose) must NOT trip C8. C8 only inspects
+    the no-handoff directive's own block."""
+    repo = _clone_repo(tmp_path)
+    p = repo / INTAKE
+    # Append unrelated prose mentioning Step 1-11 far from the no-handoff block.
+    p.write_text(
+        p.read_text() + "\n\n## Misc\nSome other flow uses Step 1-11 only, unrelated.\n",
+        encoding="utf-8",
+    )
+    r = run_lint(repo)
+    assert r.returncode == 0, r.stderr
+
+
+# --- C9: reserved-fallback row gets its own advisory, not malformed (#327 P2#2) -
+#
+# Bug (#327 P2#2): intake writes a reserved request as the display form
+# `unknown_user_defined (requested: <reserved>)`. The consumer's case (c) (value
+# not in the 4 enum) then swept that valid reserved fallback into
+# [PROFILE-UNRESOLVED] — the "malformed/hallucinated row" signal. C9 pins that
+# the consumer resolution block (1) carries a distinct reserved-fallback advisory
+# tag and (2) actually parses the `(requested: …)` parenthetical, so a future
+# edit can't collapse the reserved-fallback path back into the malformed signal.
+
+
+def test_neg_i_reserved_fallback_tag_removed(tmp_path):
+    """(i) drop the reserved-fallback advisory tag from the consumer -> C9 fails.
+    Without a distinct tag the reserved-fallback path collapses back into the
+    [PROFILE-UNRESOLVED] malformed signal (the #327 P2#2 regression)."""
+    repo = _clone_repo(tmp_path)
+    _mutate(repo, CONSUMER, "[PROFILE-RESERVED-FALLBACK]", "[PROFILE-UNRESOLVED]")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C9" in r.stderr
+
+
+def test_neg_i2_reserved_parse_removed(tmp_path):
+    """(i2) remove the `(requested:` display form from the consumer block ->
+    C9 fails. The distinct tag is useless if the block never carries the
+    `(requested: <reserved>)` form the agent must route on."""
+    repo = _clone_repo(tmp_path)
+    _mutate(repo, CONSUMER, "(requested:", "(legacy-noparse:")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C9" in r.stderr
+
+
+def test_neg_i3_form_present_but_no_parse_instruction(tmp_path):
+    """(i3) C9 strength: keep the `(requested: …)` display form but strip the
+    explicit parse INSTRUCTION -> C9 must still fail. A block can show the form
+    as an example while losing the "parse the parenthetical" directive, leaving
+    the agent on exact-string equality so the reserved fallback routes to (c).
+    (Hardening from codex review.)"""
+    repo = _clone_repo(tmp_path)
+    p = repo / CONSUMER
+    text = p.read_text(encoding="utf-8")
+    # Remove the two parse/parsing instruction phrases inside the resolution
+    # block (verified by grep to be the block's only parse-instruction wording)
+    # while leaving the `(requested: …)` display form intact.
+    assert "parse the leading" in text and "Resolve by parsing" in text, (
+        "fixture precondition: both parse-instruction phrases must be present"
+    )
+    mutated = text.replace("parse the leading", "use the leading").replace(
+        "Resolve by parsing", "Resolve by reading"
+    )
+    assert "(requested:" in mutated, "fixture: display form must survive the mutation"
+    p.write_text(mutated, encoding="utf-8")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C9" in r.stderr
+
+
+# --- C10: currency/date gate is profile-aware in the decision tree (#327 P2#3) --
+#
+# Bug (#327 P2#3): currency_window is in PROFILE_LOOSENABLE and four prose
+# passages say the year-range relaxes for humanities_interpretive canonical
+# texts, but the time-range NODE in the screening decision tree had no profile
+# branch — so a canonical humanities source admitted at the peer-review node was
+# RE-EXCLUDED at the time-range node unless it had >100 cites (an INVARIANT 5
+# monotonic-admit violation). The prose just below the tree also said the profile
+# admits "at the peer-review node only", encoding the bug AND contradicting the
+# four other passages. C10 pins, inside the decision-tree block, that (1) the
+# currency node consults the profile and (2) the "peer-review node only" fossil
+# wording is gone.
+
+
+def test_neg_j_currency_node_not_profile_aware(tmp_path):
+    """(j) strip the currency-node profile branch from the decision tree -> C10
+    fails. This is the #327 P2#3 regression: without it, a canonical humanities
+    source is re-excluded at the time-range node, violating INVARIANT 5. C10 keys
+    on the branch-exclusive 'recency is not a quality signal' rationale (occurs
+    once, only in that admit branch), so deleting the branch trips it."""
+    repo = _clone_repo(tmp_path)
+    _mutate(repo, CONSUMER, "recency is not a quality signal", "REMOVED-PHRASE")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C10" in r.stderr
+
+
+def test_neg_j2_peer_review_node_only_fossil(tmp_path):
+    """(j2) reintroduce the "peer-review node only" fossil wording -> C10 fails.
+    That phrasing both encodes the bug (profile can't touch the currency node) and
+    contradicts the four prose passages that say currency relaxes for humanities.
+    The fix reworded it to name the PROFILE_LOOSENABLE gates; this fixture proves
+    C10 catches a regression back to the narrow wording."""
+    repo = _clone_repo(tmp_path)
+    p = repo / CONSUMER
+    text = p.read_text(encoding="utf-8")
+    block_idx = text.index(DECISION_TREE_HEADING)
+    # Inject the fossil phrase into the post-tree prose within the tree block.
+    nxt = text.index("\n### ", block_idx + len(DECISION_TREE_HEADING))
+    injected = text[:nxt] + "\nThe profile is added at the peer-review node only.\n" + text[nxt:]
+    p.write_text(injected, encoding="utf-8")
+    r = run_lint(repo)
+    assert r.returncode != 0 and "C10" in r.stderr


### PR DESCRIPTION
## Summary

Fixes all three defects in #327 (surfaced by the #259 post-ship review), each a real feature-logic gap that survived on `main` because the `check_domain_evidence_profile.py` lint only verified documentation-surface presence (C1–C7), never the control-flow bound, the consumer parse logic, or the date-gate semantics.

| # | Sev | Defect | Fix | Guard |
|---|-----|--------|-----|-------|
| 1 | P1 | Step 12 (profile producer) orphaned from the no-handoff flow directive (bounded at "Step 1-11") → profile silently never activates on the common path | `intake_agent.md` directive now affirmatively reaches Step 12 | new lint **C8** |
| 2 | P2 | Reserved-fallback row `unknown_user_defined (requested: <reserved>)` misparsed as case (c) → wrong `[PROFILE-UNRESOLVED]` malformed signal | consumer parses effective token + parenthetical, emits new `[PROFILE-RESERVED-FALLBACK]`; (c) narrowed to genuinely unresolvable rows | new lint **C9** |
| 3 | P2 | Currency (time-range) node not profile-aware → canonical humanities source re-excluded after being admitted at the peer-review node (INVARIANT 5 violation); "peer-review node only" prose encoded the bug | currency node gains a humanities admit branch (union/loosen-only, continues through universal gates, no short-circuit); prose reworded to name both PROFILE_LOOSENABLE nodes | new lint **C10** |

## INVARIANT 5 safety (P2#3)

The currency branch is **purely additive**: it adds an admit path only where the neutral tree would otherwise `Exclude`, mirrors the peer-review profile-admit path (tag → CONTINUE to the universal relevance + methodology nodes, never short-circuits to Include), and leaves the neutral `cited > 100` seminal-work Include untouched. No source the neutral tree admits is excluded, down-ranked, or re-screened.

## Method / discipline

- **TDD**: a RED mutation fixture proved each defect before the fix (incl. fixture preconditions that fail on `main`, demonstrating the bug).
- **Scope refinement vs the issue**: the four prose passages (lines 117/121/541/622) already declared the humanities currency loosening; the only gaps were the decision-tree node and the self-contradicting "peer-review node only" line. The fix makes the tree + that line match the existing contract rather than inventing new loosening logic.
- **Dual-track ship gate**:
  - **codex** (gpt-5.5, `--base main`): 0 P1, 2 P2 lint-strength findings (C8 token-presence too loose; C9 suffix-token != parse instruction) — both fixed and covered by new mutation fixtures (`test_neg_h2`, `test_neg_i3`).
  - **security review**: no findings (lint + markdown diff, no untrusted-input channel).
- **/simplify**: C10 guard re-anchored from the fragile `currency rule` label to the branch-exclusive `recency is not a quality signal` rationale; duplicate heading constants consolidated.
- **24 lint tests pass**; CI manifest already covers the test file (no manifest change needed).

Closes #327
