### PR TITLE
fix(citation): arXiv resolver skip on no-ID + non-Atom 200 guard + miss-safe cache decode (#331)

### DIFF
--- a/deep-research/references/arxiv_api_protocol.md
+++ b/deep-research/references/arxiv_api_protocol.md
@@ -31,7 +31,7 @@ GET ?id_list={arxiv_id}
 
 **Matching rule (mirrors the Crossref/S2 `DOI_MISMATCH` pattern):** ID lookup hits are gated by a 0.70 title cross-check (same SequenceMatcher threshold as the sibling clients). If the resolved entry's title is below threshold → ID_MISMATCH, return None, fall through to title search. An empty feed (non-existent ID) is a miss → None.
 
-### Pattern 2: Title Search (fallback when no arXiv ID or ID_MISMATCH)
+### Pattern 2: Title Search (fallback on ID-miss / ID_MISMATCH)
 
 ```
 GET ?search_query=ti:"{title}"&max_results=5
@@ -41,11 +41,9 @@ GET ?search_query=ti:"{title}"&max_results=5
 
 ## `arxiv_unmatched` derivation
 
-`true` if and only if:
-- arXiv ID present: ID lookup either returns an empty feed (miss), misses the title cross-check, AND title search returns no match meeting threshold; OR
-- arXiv ID absent: title search alone returns no match meeting threshold.
+`true` if and only if the citation **has an arXiv ID** AND the ID lookup either returns an empty feed (miss) or misses the title cross-check, AND the title-search fallback returns no match meeting threshold.
 
-The check fires only when `obtained_via != 'manual'`.
+A citation with **no arXiv ID** is `skipped` (not `unmatched`) — the resolver does not run and the caller omits `arxiv_unmatched` (absent ≠ false, #331). arXiv applicability is ID-gated: a title-only miss against arXiv is a coverage gap for a non-arXiv work, not non-existence evidence, so it must never emit a triangulation signal. The check fires only when `obtained_via != 'manual'` AND an arXiv ID is present.
 
 Note: the unified `lookup_verified` summary (#182 Delta 4, a later batch) narrows the existence-gate `false` to **ID-keyed** unmatched — a title-only `arxiv_unmatched` with no resolvable ID is a coverage-gap signal, not fabrication evidence (C-V6(a)). This protocol's `arxiv_unmatched` boolean is the raw triangulation signal; the narrowing happens at the Delta 4 reducer, not here.
 

--- a/scripts/arxiv_client.py
+++ b/scripts/arxiv_client.py
@@ -122,12 +122,8 @@ class ArxivClient:
                     # drops mid-stream and truncated / malformed bodies surface
                     # as ArxivUnavailable -- honoring the per-API degradation
                     # contract (one transient failure drops only arxiv_unmatched,
-                    # never aborts the backfill). Note: a *complete* non-Atom
-                    # body (e.g. a well-formed HTML error page served with 200)
-                    # parses fine and yields zero Atom entries -- that is a miss,
-                    # not a degradation; only genuinely malformed XML raises
-                    # ParseError here. Mirrors crossref_client.py's read/parse
-                    # except (ET.ParseError replaces JSONDecodeError).
+                    # never aborts the backfill). Mirrors crossref_client.py's
+                    # read/parse except (ET.ParseError replaces JSONDecodeError).
                     try:
                         body = resp.read()
                         root = ET.fromstring(body)
@@ -143,6 +139,19 @@ class ArxivClient:
                         raise ArxivUnavailable(
                             f"arXiv response read/parse failed: {e}"
                         ) from e
+                    # #331: a *complete* non-Atom body (e.g. a well-formed HTML
+                    # error page served with 200 by a proxy/CDN) parses cleanly
+                    # but is NOT an arXiv result. arXiv's genuine empty result is
+                    # a well-formed Atom <feed> with zero <entry> children, so the
+                    # root tag distinguishes the two. Treat a non-feed root as a
+                    # degradation (omit-on-degradation path), NOT a cached miss --
+                    # otherwise an upstream outage persists as a false
+                    # arxiv_unmatched for the cache TTL.
+                    if root.tag != f"{_ATOM_NS}feed":
+                        raise ArxivUnavailable(
+                            f"arXiv returned a non-Atom 200 body (root tag "
+                            f"{root.tag!r}, not an Atom feed)"
+                        )
                     return root.findall(f"{_ATOM_NS}entry")
             except urllib.error.HTTPError as e:
                 if e.code == 429 and attempt < _MAX_RETRIES:

--- a/scripts/contamination_signals.py
+++ b/scripts/contamination_signals.py
@@ -349,15 +349,18 @@ def _resolve_arxiv_id_then_title(
     (unmatched, matched_by, queried_by). matched_by ∈ {'arxiv', 'title', None};
     queried_by ∈ {'id', 'title'} per the C-V6(a) signal (see
     _resolve_doi_then_title). 'id' when an arXiv ID was present. Never catches —
-    exception differentiation stays at the wrapper."""
+    exception differentiation stays at the wrapper.
+
+    Precondition: only called for entries carrying an arxiv_id — both callers
+    (`resolve_arxiv_unmatched` and verification_gate `_run_arxiv`) skip the
+    resolver when arxiv_id is absent (#331), so the ID lookup always runs and a
+    title search is only the ID-miss fallback."""
     title = entry.get("title", "")
-    arxiv_id = entry.get("arxiv_id")
     queried_by = queried_by_for(entry, id_field="arxiv_id")
-    if arxiv_id:
-        hit = client.arxiv_id_lookup(arxiv_id, title)
-        if hit is not None:
-            return False, "arxiv", queried_by
-        # ID miss or MISMATCH — fall through to title search.
+    hit = client.arxiv_id_lookup(entry.get("arxiv_id"), title)
+    if hit is not None:
+        return False, "arxiv", queried_by
+    # ID miss or MISMATCH — fall through to title search.
     hit = client.title_search(title)
     if hit is not None:
         return False, "title", queried_by
@@ -375,15 +378,20 @@ def resolve_arxiv_unmatched(
     `doi_lookup_with_title_check`). The title fallback is identical.
 
     - Manual entry → return None (caller MUST omit field).
+    - arXiv ID absent → SKIP the resolver, return None (caller MUST omit field).
+      A non-arXiv citation is not title-searched against arXiv: a title miss
+      there is a coverage gap, not non-existence evidence (#331). The spec keys
+      the arXiv index on arxiv_id and states arxiv_unmatched is absent on
+      citations with no arXiv ID ('arXiv resolver skipped on a non-arXiv
+      citation per Delta 1', spec §4; orchestrator k_max rule).
     - arXiv ID present + ID hit (passes title cross-check) → return False.
     - arXiv ID present + ID miss/MISMATCH → fall through to title search.
-    - arXiv ID absent → title search only.
     - No hit anywhere → return True (unmatched).
 
     Returns:
         True: arXiv returned no match by ID (with title cross-check) or title.
         False: arXiv found a match.
-        None: obtained_via='manual' → exempt, caller must omit field.
+        None: obtained_via='manual' OR no arxiv_id → skipped, caller omits field.
 
     Raises:
         ArxivUnavailable: API degraded, caller must omit field per R-L3-2-C.
@@ -392,6 +400,10 @@ def resolve_arxiv_unmatched(
         byte-equivalent to no caching.
     """
     if entry.get("obtained_via") == "manual":
+        return None
+    # #331: no arXiv ID → resolver is skipped (no network, not cached — a skip
+    # is resolver applicability, not an adjudication, so it never persists).
+    if not entry.get("arxiv_id"):
         return None
     return _cached_verdict(
         cache=cache,

--- a/scripts/test_arxiv_client.py
+++ b/scripts/test_arxiv_client.py
@@ -274,11 +274,11 @@ def test_malformed_xml_body_raises_unavailable():
     the ParseError to ArxivUnavailable. Mirrors crossref's
     test_invalid_json_body_raises_unavailable.
 
-    Note: a *complete* HTML error page (`<html>...</html>`) is itself
-    well-formed XML and parses without error -- it just yields zero Atom
-    entries (a miss), not an exception. Only genuinely malformed bytes
-    (truncated/unclosed) trigger ParseError, which is what an interrupted
-    transfer actually produces."""
+    Distinct from the non-Atom-200 case (#331): a *complete* HTML error page
+    parses without ParseError but has a non-feed root tag, so it is rejected by
+    the explicit root-tag check (test_non_atom_200_body_raises_unavailable), not
+    here. This test covers genuinely malformed bytes (truncated/unclosed),
+    which is what an interrupted transfer actually produces."""
     from arxiv_client import ArxivClient, ArxivUnavailable
 
     with patch("urllib.request.urlopen", return_value=_mock_resp(
@@ -286,6 +286,34 @@ def test_malformed_xml_body_raises_unavailable():
         client = ArxivClient()
         with pytest.raises(ArxivUnavailable):
             client.title_search("any title")
+
+
+def test_non_atom_200_body_raises_unavailable():
+    """#331: a complete, well-formed non-Atom body served with 200 (e.g. an HTML
+    error page from a proxy/CDN) must NOT be treated as a real empty-result miss.
+    arXiv's genuine empty result is an Atom <feed> with zero <entry> children;
+    an HTML error page has a non-feed root tag. The non-feed root must raise
+    ArxivUnavailable (omit-on-degradation) so it is never cached as a false
+    arxiv_unmatched=true for the 90-day TTL."""
+    from arxiv_client import ArxivClient, ArxivUnavailable
+
+    html_error_page = b"<html><body><h1>503 Service Unavailable</h1></body></html>"
+    with patch("urllib.request.urlopen", return_value=_mock_resp(html_error_page)):
+        client = ArxivClient()
+        with pytest.raises(ArxivUnavailable):
+            client.title_search("any title")
+
+
+def test_genuine_empty_atom_feed_is_miss_not_unavailable():
+    """#331 guard against over-correction: a genuine empty Atom <feed> (zero
+    <entry>, the real arXiv miss shape) must still resolve to a miss (None), NOT
+    raise. The root-tag check accepts the feed root and findall returns []."""
+    from arxiv_client import ArxivClient
+
+    empty_feed = b'<feed xmlns="http://www.w3.org/2005/Atom"><title>arXiv Query</title></feed>'
+    with patch("urllib.request.urlopen", return_value=_mock_resp(empty_feed)):
+        client = ArxivClient()
+        assert client.title_search("nonexistent paper") is None
 
 
 def test_oserror_during_read_raises_unavailable():

--- a/scripts/test_contamination_signals.py
+++ b/scripts/test_contamination_signals.py
@@ -488,17 +488,24 @@ class ResolveArxivUnmatchedTest(unittest.TestCase):
         mock_client.arxiv_id_lookup.assert_not_called()
         mock_client.title_search.assert_not_called()
 
-    def test_arxiv_id_absent_falls_through_to_title(self):
-        """arXiv ID absent: title search alone, NO id lookup attempted."""
+    def test_arxiv_id_absent_skips_resolver(self):
+        """arXiv ID absent (#331 P2): the arXiv resolver is SKIPPED — return None
+        (caller omits arxiv_unmatched) and run NO network query. A non-arXiv
+        citation (e.g. a DOI-keyed journal article) must not be title-searched
+        against arXiv: a title miss there is a coverage gap, not non-existence
+        evidence, and would emit a false arxiv_unmatched=true (inflating the
+        triangulation k on a clean citation). Spec §4 / the orchestrator k_max
+        rule both state arxiv_unmatched is ABSENT on citations with no arXiv ID
+        ('arXiv resolver skipped on a non-arXiv citation per Delta 1')."""
         from contamination_signals import resolve_arxiv_unmatched
 
         mock_client = MagicMock()
-        mock_client.title_search.return_value = {"title": "X", "year": 2017}
 
         entry = {"title": "X", "obtained_via": "obsidian-vault"}  # no arxiv_id
         result = resolve_arxiv_unmatched(entry, mock_client)
-        self.assertIs(result, False)
+        self.assertIsNone(result)
         mock_client.arxiv_id_lookup.assert_not_called()
+        mock_client.title_search.assert_not_called()
 
     def test_arxiv_id_miss_falls_through_to_title(self):
         """ID present but ID lookup misses → fall through to title search."""
@@ -559,12 +566,28 @@ class BuildSignalsArxivExtensionTest(unittest.TestCase):
         )
         self.assertIs(result["arxiv_unmatched"], True)
 
+    def test_no_arxiv_id_omits_arxiv_field_even_with_client(self) -> None:
+        """#331: a non-arXiv citation (arxiv_client present but entry has no
+        arxiv_id) omits arxiv_unmatched and runs NO arXiv query. Without the
+        skip, the resolver would title-search arXiv and emit a false
+        arxiv_unmatched=true, inflating triangulation k on a clean citation."""
+        ss = MagicMock()
+        ss.lookup.return_value = {"matched": True}
+        ax = MagicMock()
+        result = cs.build_signals_object(
+            self._entry(), ss, arxiv_client=ax  # _entry() carries no arxiv_id
+        )
+        self.assertNotIn("arxiv_unmatched", result)
+        ax.arxiv_id_lookup.assert_not_called()
+        ax.title_search.assert_not_called()
+
     def test_manual_entry_omits_arxiv_field_even_with_client(self) -> None:
         """Manual entry: arxiv_unmatched omitted (not-rule), like the ss field."""
         ss = MagicMock()
         ax = MagicMock()
         result = cs.build_signals_object(
-            self._entry(obtained_via="manual"), ss, arxiv_client=ax
+            self._entry(obtained_via="manual", arxiv_id="1706.03762"), ss,
+            arxiv_client=ax
         )
         self.assertNotIn("arxiv_unmatched", result)
         ax.arxiv_id_lookup.assert_not_called()
@@ -866,14 +889,12 @@ class ResolveArxivQueriedByTest(unittest.TestCase):
         self.assertIs(unmatched, True)
         self.assertEqual(queried_by, "id")
 
-    def test_no_arxiv_id_unmatched_queried_by_title(self):
-        client = MagicMock()
-        client.title_search.return_value = None
-        unmatched, matched_by, queried_by = cs._resolve_arxiv_id_then_title(
-            {"title": "Unindexed"}, client  # no arxiv_id
-        )
-        self.assertIs(unmatched, True)
-        self.assertEqual(queried_by, "title")
+    # (#331) No test for the no-arxiv_id case here: _resolve_arxiv_id_then_title's
+    # precondition is now "entry has an arxiv_id" — both callers
+    # (resolve_arxiv_unmatched and verification_gate._run_arxiv) skip the resolver
+    # before reaching it when arxiv_id is absent. The skip is covered by
+    # ResolveArxivUnmatchedTest.test_arxiv_id_absent_skips_resolver and the
+    # verification_gate skipped-status tests.
 
     def test_arxiv_id_match_queried_by_id(self):
         client = MagicMock()

--- a/scripts/test_verification_cache.py
+++ b/scripts/test_verification_cache.py
@@ -166,3 +166,48 @@ def test_response_roundtrips_nested_structure(cache):
     }
     cache.put("vaswani2017", "crossref", "10.5555/abc", payload)
     assert cache.get("vaswani2017", "crossref", "10.5555/abc") == payload
+
+
+def test_corrupted_json_payload_is_miss(tmp_path, monkeypatch):
+    """#331 P3: a row whose response_json is not decodable JSON is a miss
+    (return None → live recompute), not a JSONDecodeError that aborts
+    verification. Contract: 'malformed cache payload = miss'."""
+    from verification_cache import VerificationCache
+
+    db = tmp_path / "verification.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    c = VerificationCache()
+    c.put("bad2024", "crossref", "10.5555/bad", {"matched": True})
+
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "UPDATE verification_cache SET response_json = ? WHERE citation_key = ?",
+        ("{not valid json", "bad2024"),
+    )
+    conn.commit()
+    conn.close()
+
+    assert c.get("bad2024", "crossref", "10.5555/bad") is None
+
+
+def test_non_dict_payload_is_miss(tmp_path, monkeypatch):
+    """#331 P3: a row decoding to a non-dict value (e.g. a bare list/string from
+    an older or manual writer) is a miss — the caller's `"matched" in cached`
+    join logic expects a dict. Return None rather than hand back a shape the
+    caller cannot read."""
+    from verification_cache import VerificationCache
+
+    db = tmp_path / "verification.db"
+    monkeypatch.setenv("ARS_VERIFICATION_CACHE_PATH", str(db))
+    c = VerificationCache()
+    c.put("list2024", "crossref", "10.5555/list", {"matched": True})
+
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "UPDATE verification_cache SET response_json = ? WHERE citation_key = ?",
+        ('["matched", true]', "list2024"),  # valid JSON, but a list not a dict
+    )
+    conn.commit()
+    conn.close()
+
+    assert c.get("list2024", "crossref", "10.5555/list") is None

--- a/scripts/verification_cache.py
+++ b/scripts/verification_cache.py
@@ -101,7 +101,18 @@ class VerificationCache:
         response_json, ts = row
         if self._is_expired(ts):
             return None
-        return json.loads(response_json)
+        # #331: a corrupted payload (not decodable) or a non-dict value (e.g.
+        # written by an older/other tool) is a miss, not a hard error — the
+        # documented contract is "malformed cache payload = miss". Returning None
+        # forces a clean live recompute instead of aborting verification with a
+        # JSONDecodeError or handing the caller a shape it cannot read.
+        try:
+            value = json.loads(response_json)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(value, dict):
+            return None
+        return value
 
     def put(
         self,


### PR DESCRIPTION
## What

Resolves the three post-ship defects in #331 — the #182 Delta 1+2 citation-integrity data layer (arXiv resolver + verification cache). All three were verified first-party on `main`; the 106 PR tests never exercised these paths.

## Findings fixed

### 1. [P2] arXiv resolver emitted a false `arxiv_unmatched=true` on no-ID citations
`resolve_arxiv_unmatched` ran a title search against arXiv for citations with no `arxiv_id` (e.g. a DOI-keyed journal article), returning `true` on a title miss. That inflated the triangulation `k` (k=3→k=4, rendering `CONTAMINATED-QUADRANGULATION-UNMATCHED` on a clean journal citation) plus a wasted ~3s request.

**Fix:** skip the resolver (return `None` → caller omits the field) when `arxiv_id` is absent. This matches the spec — §4 and the orchestrator `k_max` rule both state arXiv is ID-gated and `skipped` on non-arXiv citations per Delta 1 — and the guard already present in `verification_gate._run_arxiv`. `_resolve_arxiv_id_then_title` is now precondition-gated (both callers skip the no-ID case before reaching it). The narrowed-`false` `lookup_verified` path was already protected; this aligns the parallel triangulation-advisory path with it.

### 2. [P2] Non-Atom 200 body cached as a real miss
A well-formed non-Atom 200 body (e.g. a proxy/CDN HTML error page) parsed cleanly via `ET.fromstring` and its empty `findall(entry)` was treated — and cached — as a real no-results miss for the 90-day TTL.

**Fix:** `arxiv_client._get` validates `root.tag == {atom}feed` before treating an empty entry list as a miss; a non-feed root raises `ArxivUnavailable` (omit-on-degradation, not cached). arXiv's genuine empty result is a well-formed Atom `<feed>` with zero `<entry>` children, so the root tag distinguishes the two. A negative test pins that a genuine empty feed still resolves to a miss (guard against over-correction).

### 3. [P3] Corrupted / non-dict cache row aborted verification
`VerificationCache.get` did a bare `json.loads(response_json)`; a corrupt payload raised `JSONDecodeError` and a non-dict value handed the caller a shape its `"matched" in cached` join couldn't read.

**Fix:** treat `JSONDecodeError` / `TypeError` / a non-dict decode as a miss (clean recompute), honoring the documented "malformed cache payload = miss" contract.

## Tests
- Reversed two tests that **codified the buggy behavior**: `test_arxiv_id_absent_falls_through_to_title` → `test_arxiv_id_absent_skips_resolver` (asserts None + no client calls); the malformed-XML test's docstring no longer claims an HTML error page is a miss.
- New: `test_non_atom_200_body_raises_unavailable`, `test_genuine_empty_atom_feed_is_miss_not_unavailable`, `test_no_arxiv_id_omits_arxiv_field_even_with_client`, `test_corrupted_json_payload_is_miss`, `test_non_dict_payload_is_miss`.
- Tightened `test_manual_entry_omits_arxiv_field_even_with_client` to carry an `arxiv_id` so it actually exercises the manual guard (was shadowed by the new no-ID guard).
- Synced `arxiv_api_protocol.md`'s `arxiv_unmatched` derivation, which self-contradicted (lines 13/65 said "skipped"; 34/46 said "title search alone"). The Crossref/OpenAlex "DOI absent → title search" rule is intentionally NOT touched — those are general indexes; arXiv's ID-gating is a deliberate asymmetry.
- Full suite: **2131 pass / 3 skipped**, no regressions. verification_gate's 32 tests green (confirms the `_resolve_arxiv_id_then_title` signature change is safe).

## Review (dual-track ship gate)
- `codex review` (gpt-5.5, xhigh): **PASS, 0 findings** — "the updated resolver behavior, arXiv response validation, and cache miss handling are covered by tests, and the full test suite passes."
- `security-review`: **0 findings** — the two response/cache guards are net hardening; no new injection / deserialization / auth surface.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)