### PR TITLE
fix(v3.10-policy): wire laundering guard to real entries + per-block terminal-marker validation (#329)

### DIFF
--- a/scripts/adapters/tests/test_check_literature_corpus_schema.py
+++ b/scripts/adapters/tests/test_check_literature_corpus_schema.py
@@ -333,3 +333,46 @@ def test_v3_9_0_rejects_manual_entry_with_openalex_unmatched(tmp_path):
         f"Expected validation failure for manual entry with openalex_unmatched. "
         f"stdout={r.stdout}\nstderr={r.stderr}"
     )
+
+
+def _laundering_entry(venue_type_source):
+    return {
+        "citation_key": "launder2024",
+        "title": "Real Paper",
+        "authors": [{"family": "Chen"}],
+        "year": 2024,
+        "source_pointer": "file:///x.pdf",
+        "obtained_via": "folder-scan",
+        "venue_type": "journal-article",
+        "venue_type_provenance": "trusted_source_declared",
+        "venue_type_source": venue_type_source,
+    }
+
+
+def test_v3_10_rejects_laundered_venue_type_source(tmp_path):
+    """#329: the laundering guard (R2-P1) must run over REAL passport entries, not
+    just fixtures. An entry whose venue_type_provenance is trusted_source_declared
+    but whose venue_type_source names a lookup index (OpenAlex) is laundering a
+    k=3-unmatched signal into a declared-trust signal. The schema only types the
+    field as a non-empty string, so this MUST be caught by the wired lint."""
+    passport = {"literature_corpus": [_laundering_entry("OpenAlex")]}
+    path = _write_yaml(tmp_path, "passport.yaml", passport)
+    r = _run(["--passport", str(path)])
+    assert r.returncode != 0, (
+        f"Expected validation failure for laundered venue_type_source=OpenAlex. "
+        f"stdout={r.stdout}\nstderr={r.stderr}"
+    )
+    assert "launder" in (r.stdout + r.stderr).lower() or "lookup index" in (r.stdout + r.stderr).lower()
+
+
+def test_v3_10_accepts_legitimate_declared_venue_type_source(tmp_path):
+    """#329 negative control: a trusted_source_declared entry whose venue_type_source
+    names a legitimate publisher/registry feed (NOT one of the three lookup indexes)
+    passes. Guards against the wired lint over-rejecting every declared source."""
+    passport = {"literature_corpus": [_laundering_entry("Springer-publisher-feed")]}
+    path = _write_yaml(tmp_path, "passport.yaml", passport)
+    r = _run(["--passport", str(path)])
+    assert r.returncode == 0, (
+        f"Expected a legitimate declared venue_type_source to pass. "
+        f"stdout={r.stdout}\nstderr={r.stderr}"
+    )

--- a/scripts/adapters/tests/test_check_literature_corpus_schema.py
+++ b/scripts/adapters/tests/test_check_literature_corpus_schema.py
@@ -376,3 +376,21 @@ def test_v3_10_accepts_legitimate_declared_venue_type_source(tmp_path):
         f"Expected a legitimate declared venue_type_source to pass. "
         f"stdout={r.stdout}\nstderr={r.stderr}"
     )
+
+
+def test_v3_10_non_string_venue_type_source_reports_schema_error_not_crash(tmp_path):
+    """#329 (codex P2): a non-string venue_type_source (123) is a schema-type
+    violation. The wired laundering guard calls .strip(), which would crash on a
+    non-str. The validator must report the schema error cleanly, NOT traceback —
+    the guard is only run on string fields."""
+    entry = _laundering_entry("placeholder")
+    entry["venue_type_source"] = 123  # schema-invalid: must be a string
+    passport = {"literature_corpus": [entry]}
+    path = _write_yaml(tmp_path, "passport.yaml", passport)
+    r = _run(["--passport", str(path)])
+    assert r.returncode != 0
+    combined = r.stdout + r.stderr
+    assert "Traceback" not in combined and "AttributeError" not in combined, (
+        f"validator crashed instead of reporting a schema error: {combined}"
+    )
+    assert "schema" in combined.lower() or "validation" in combined.lower()

--- a/scripts/check_literature_corpus_schema.py
+++ b/scripts/check_literature_corpus_schema.py
@@ -37,6 +37,14 @@ except ImportError as e:
     )
     sys.exit(2)
 
+# Dual-path import (mirrors arxiv_client.py): the v3.10 laundering guard
+# (#329) lives in check_v3_10_policy and is wired here so it runs over REAL
+# passport entries, not just fixtures.
+try:
+    from check_v3_10_policy import assert_venue_type_source_clean
+except ImportError:
+    from scripts.check_v3_10_policy import assert_venue_type_source_clean
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENTRY_SCHEMA_PATH = REPO_ROOT / "shared/contracts/passport/literature_corpus_entry.schema.json"
 REJECTION_SCHEMA_PATH = REPO_ROOT / "shared/contracts/passport/rejection_log.schema.json"
@@ -138,6 +146,17 @@ def validate_passport(
             errors.append(
                 f"{path}: literature_corpus[{i}] schema validation error: {err.message}"
             )
+        # v3.10 laundering guard (R2-P1, #329): the schema types venue_type_source
+        # as a non-empty string but cannot express the lookup-index exclusion, so
+        # the semantic check runs here over real entries. A trusted_source_declared
+        # entry whose venue_type_source names a lookup index (OpenAlex / Crossref /
+        # Semantic Scholar) is laundering a k=3-unmatched signal into declared trust.
+        if isinstance(entry, dict):
+            for problem in assert_venue_type_source_clean(
+                entry.get("venue_type_source", ""),
+                entry.get("venue_type_provenance", ""),
+            ):
+                errors.append(f"{path}: literature_corpus[{i}]: {problem}")
         key = entry.get("citation_key") if isinstance(entry, dict) else None
         if key:
             citation_keys[key] = citation_keys.get(key, 0) + 1

--- a/scripts/check_literature_corpus_schema.py
+++ b/scripts/check_literature_corpus_schema.py
@@ -151,12 +151,15 @@ def validate_passport(
         # the semantic check runs here over real entries. A trusted_source_declared
         # entry whose venue_type_source names a lookup index (OpenAlex / Crossref /
         # Semantic Scholar) is laundering a k=3-unmatched signal into declared trust.
+        # Only run on string fields — a non-string venue_type_source / provenance is
+        # already a schema-type error (reported above); the semantic guard must not
+        # crash on it (.strip() on a non-str), so let the schema error stand alone.
         if isinstance(entry, dict):
-            for problem in assert_venue_type_source_clean(
-                entry.get("venue_type_source", ""),
-                entry.get("venue_type_provenance", ""),
-            ):
-                errors.append(f"{path}: literature_corpus[{i}]: {problem}")
+            vts = entry.get("venue_type_source", "")
+            vtp = entry.get("venue_type_provenance", "")
+            if isinstance(vts, str) and isinstance(vtp, str):
+                for problem in assert_venue_type_source_clean(vts, vtp):
+                    errors.append(f"{path}: literature_corpus[{i}]: {problem}")
         key = entry.get("citation_key") if isinstance(entry, dict) else None
         if key:
             citation_keys[key] = citation_keys.get(key, 0) + 1

--- a/scripts/check_v3_10_policy.py
+++ b/scripts/check_v3_10_policy.py
@@ -101,7 +101,8 @@ class ParsedMarker:
     """Structured parse of a single <!--ref:...--> marker."""
 
     def __init__(self, *, slug, base_status, advisory_suffix, terminal,
-                 severity, policy, reason, mode, policy_hash, unknown_tokens=None):
+                 severity, policy, reason, mode, policy_hash, unknown_tokens=None,
+                 terminal_blocks=None):
         self.slug = slug
         self.base_status = base_status
         self.advisory_suffix = advisory_suffix
@@ -112,6 +113,15 @@ class ParsedMarker:
         self.mode = mode
         self.policy_hash = policy_hash
         self.unknown_tokens = unknown_tokens or []
+        # Per-block terminal metadata (C-V6(g) multi-policy co-emission): one dict
+        # {severity,policy,reason,mode} per TERMINAL-BLOCK sentinel. is_well_formed
+        # validates each block independently rather than the flattened fields,
+        # which "last value wins" and cannot prove per-block completeness (#329).
+        self.terminal_blocks = terminal_blocks or []
+
+    @property
+    def terminal_block_count(self) -> int:
+        return len(self.terminal_blocks)
 
     @property
     def is_legacy(self) -> bool:
@@ -127,19 +137,27 @@ class ParsedMarker:
         """A grammatical marker: has a base-status ∈ {ok, LOW-WARN} and no
         unrecognized residual tokens. A marker lacking a base-status (e.g.
         `<!--ref:smith2024 policy_hash=...-->`) is malformed — the v3.7.3 5-cell
-        base resolution always produces one. A terminal marker must additionally
-        carry severity=HIGH-BLOCK AND the four mandatory terminal-grammar fields
-        (policy / reason / mode / policy_hash) — the freshness + remediation
-        metadata the formatter gate depends on (#329). A stripped terminal marker
-        missing any of them is malformed, not silently accepted."""
+        base resolution always produces one.
+
+        A terminal marker (#329) must carry, for EACH TERMINAL-BLOCK independently,
+        severity=HIGH-BLOCK + non-empty policy / reason / mode (validated per block
+        so a complete later block in a C-V6(g) co-emission cannot mask an earlier
+        block's stripped metadata), plus the marker-level shared policy_hash. Empty
+        tokens (`policy=`) count as missing — the formatter gate needs the value."""
         if self.base_status not in _BASE_STATUS:
             return False
         if self.unknown_tokens:
             return False
         if self.terminal:
-            if self.severity != "HIGH-BLOCK":
-                return False
-            if None in (self.policy, self.reason, self.mode, self.policy_hash):
+            # Each TERMINAL-BLOCK must be individually complete (C-V6(g)).
+            for block in self.terminal_blocks:
+                if block.get("severity") != "HIGH-BLOCK":
+                    return False
+                if not all((block.get("policy"), block.get("reason"), block.get("mode"))):
+                    return False
+            # policy_hash is marker-level (one shared slug encoding all keys),
+            # required on any finalized terminal marker.
+            if not self.policy_hash:
                 return False
         return True
 
@@ -178,19 +196,37 @@ def _parse_inner(inner: str) -> ParsedMarker | None:
     terminal = False
     severity = policy = reason = mode = policy_hash = None
     unknown_tokens: list[str] = []
+    # Per-block terminal metadata (C-V6(g)): each TERMINAL-BLOCK sentinel opens a
+    # new block; its severity/policy/reason/mode tokens belong to THAT block.
+    # policy_hash is marker-level (one shared slug encoding all keys), not
+    # per-block — it is kept in the flat field only. The flat severity/policy/
+    # reason/mode keep the legacy "last value wins" semantics for backward compat;
+    # is_well_formed reads terminal_blocks for per-block completeness (#329).
+    terminal_blocks: list[dict[str, str | None]] = []
 
     # key=value tokens + the TERMINAL-BLOCK sentinel. Anything else is residual.
     for tok in rest:
         if tok == "TERMINAL-BLOCK":
             terminal = True
+            terminal_blocks.append(
+                {"severity": None, "policy": None, "reason": None, "mode": None}
+            )
         elif tok.startswith("severity="):
             severity = tok.split("=", 1)[1]
+            if terminal_blocks:
+                terminal_blocks[-1]["severity"] = severity
         elif tok.startswith("policy="):
             policy = tok.split("=", 1)[1]
+            if terminal_blocks:
+                terminal_blocks[-1]["policy"] = policy
         elif tok.startswith("reason="):
             reason = tok.split("=", 1)[1]
+            if terminal_blocks:
+                terminal_blocks[-1]["reason"] = reason
         elif tok.startswith("mode="):
             mode = tok.split("=", 1)[1]
+            if terminal_blocks:
+                terminal_blocks[-1]["mode"] = mode
         elif tok.startswith("policy_hash="):
             policy_hash = tok.split("=", 1)[1]
         else:
@@ -200,6 +236,7 @@ def _parse_inner(inner: str) -> ParsedMarker | None:
         slug=slug, base_status=base_status, advisory_suffix=advisory_suffix,
         terminal=terminal, severity=severity, policy=policy, reason=reason,
         mode=mode, policy_hash=policy_hash, unknown_tokens=unknown_tokens,
+        terminal_blocks=terminal_blocks,
     )
 
 

--- a/scripts/check_v3_10_policy.py
+++ b/scripts/check_v3_10_policy.py
@@ -128,13 +128,19 @@ class ParsedMarker:
         unrecognized residual tokens. A marker lacking a base-status (e.g.
         `<!--ref:smith2024 policy_hash=...-->`) is malformed — the v3.7.3 5-cell
         base resolution always produces one. A terminal marker must additionally
-        carry severity=HIGH-BLOCK."""
+        carry severity=HIGH-BLOCK AND the four mandatory terminal-grammar fields
+        (policy / reason / mode / policy_hash) — the freshness + remediation
+        metadata the formatter gate depends on (#329). A stripped terminal marker
+        missing any of them is malformed, not silently accepted."""
         if self.base_status not in _BASE_STATUS:
             return False
         if self.unknown_tokens:
             return False
-        if self.terminal and self.severity != "HIGH-BLOCK":
-            return False
+        if self.terminal:
+            if self.severity != "HIGH-BLOCK":
+                return False
+            if None in (self.policy, self.reason, self.mode, self.policy_hash):
+                return False
         return True
 
 

--- a/scripts/test_check_v3_10_policy.py
+++ b/scripts/test_check_v3_10_policy.py
@@ -192,6 +192,41 @@ def test_terminal_marker_without_high_block_is_malformed():
     assert pm.is_well_formed is False
 
 
+def test_terminal_marker_missing_metadata_fields_is_malformed():
+    """#329: a TERMINAL-BLOCK severity=HIGH-BLOCK marker MUST carry the four
+    mandatory terminal-grammar fields (policy / reason / mode / policy_hash) — the
+    freshness + remediation metadata the formatter gate depends on. A marker with
+    severity=HIGH-BLOCK but any of them missing is malformed, even though the
+    base-status, terminal flag, and severity are all valid in isolation. Without
+    this, a stripped terminal marker passes the grammar's reference checker and a
+    downstream finalizer-output validator loses the metadata it needs."""
+    # All four absent.
+    bare = parse_ref_marker("<!--ref:x ok TERMINAL-BLOCK severity=HIGH-BLOCK-->")
+    assert bare.terminal is True and bare.is_high_block is True
+    assert bare.is_well_formed is False
+
+    # A complete terminal marker is well-formed (positive control).
+    full = parse_ref_marker(
+        "<!--ref:x ok TERMINAL-BLOCK severity=HIGH-BLOCK "
+        "policy=citation_existence reason=lookup_verified_false mode=strict "
+        "policy_hash=citation_existence.strict-->"
+    )
+    assert full.is_well_formed is True
+
+    # Each single missing field individually breaks well-formedness (mutation).
+    parts = {
+        "policy": "policy=citation_existence",
+        "reason": "reason=lookup_verified_false",
+        "mode": "mode=strict",
+        "policy_hash": "policy_hash=citation_existence.strict",
+    }
+    for omit in parts:
+        tokens = " ".join(v for k, v in parts.items() if k != omit)
+        marker = f"<!--ref:x ok TERMINAL-BLOCK severity=HIGH-BLOCK {tokens}-->"
+        pm = parse_ref_marker(marker)
+        assert pm.is_well_formed is False, f"missing {omit} should be malformed: {marker}"
+
+
 def test_well_formed_markers_pass():
     assert parse_ref_marker("<!--ref:smith2024 ok policy_hash=contamination_triangulation.strict-->").is_well_formed
     assert parse_ref_marker("<!--ref:smith2024 LOW-WARN-->").is_well_formed  # legacy, no stamp

--- a/scripts/test_check_v3_10_policy.py
+++ b/scripts/test_check_v3_10_policy.py
@@ -226,6 +226,68 @@ def test_terminal_marker_missing_metadata_fields_is_malformed():
         pm = parse_ref_marker(marker)
         assert pm.is_well_formed is False, f"missing {omit} should be malformed: {marker}"
 
+    # A blank token (`policy=`) parses to "" not None — present-but-empty must be
+    # malformed too, same as missing (codex P2: the formatter gate needs the value).
+    blank = parse_ref_marker(
+        "<!--ref:x ok TERMINAL-BLOCK severity=HIGH-BLOCK "
+        "policy= reason= mode= policy_hash=-->"
+    )
+    assert blank.terminal is True and blank.is_high_block is True
+    assert blank.is_well_formed is False
+    for omit in parts:
+        # one field blank, the rest valid → still malformed
+        toks = " ".join((f"{k}=" if k == omit else v) for k, v in parts.items())
+        pm = parse_ref_marker(f"<!--ref:x ok TERMINAL-BLOCK severity=HIGH-BLOCK {toks}-->")
+        assert pm.is_well_formed is False, f"blank {omit} should be malformed"
+
+
+def test_multi_terminal_block_per_block_validation(self_unused=None):
+    """#329 (codex R2/R3): a multi-TERMINAL-BLOCK co-emission (C-V6(g)) is
+    validated PER BLOCK — each TERMINAL-BLOCK must independently carry
+    severity=HIGH-BLOCK + policy/reason/mode, plus the marker-level policy_hash.
+    A complete later block must NOT mask an earlier block's stripped metadata."""
+    # First block missing mode=, second block complete — the flat field would
+    # fill mode from the second block, but per-block validation catches the gap.
+    masked = parse_ref_marker(
+        "<!--ref:both ok TERMINAL-BLOCK severity=HIGH-BLOCK "
+        "policy=contamination_triangulation reason=k3_all_indexes_unmatched "
+        "TERMINAL-BLOCK severity=HIGH-BLOCK policy=citation_existence "
+        "reason=lookup_verified_false mode=strict policy_hash=x-->"
+    )
+    assert masked.terminal_block_count == 2
+    assert masked.is_well_formed is False  # first block has no mode=
+
+    # A fully-complete dual-block co-emission (the C-V6(g) canonical marker) is
+    # well-formed — every block carries its four fields and the marker carries the
+    # shared policy_hash. (R3: do not reject valid dual-policy markers.)
+    full_dual = parse_ref_marker(
+        "<!--ref:both LOW-WARN CONTAMINATED-TRIANGULATION-UNMATCHED "
+        "TERMINAL-BLOCK severity=HIGH-BLOCK policy=contamination_triangulation "
+        "reason=k3_all_indexes_unmatched mode=strict "
+        "TERMINAL-BLOCK severity=HIGH-BLOCK policy=citation_existence "
+        "reason=lookup_verified_false mode=strict "
+        "policy_hash=citation_existence.strict+contamination_triangulation.strict-->"
+    )
+    assert full_dual.terminal_block_count == 2
+    assert full_dual.is_well_formed is True
+    assert marker_triggers_refusal(
+        "<!--ref:both LOW-WARN CONTAMINATED-TRIANGULATION-UNMATCHED "
+        "TERMINAL-BLOCK severity=HIGH-BLOCK policy=contamination_triangulation "
+        "reason=k3_all_indexes_unmatched mode=strict "
+        "TERMINAL-BLOCK severity=HIGH-BLOCK policy=citation_existence "
+        "reason=lookup_verified_false mode=strict "
+        "policy_hash=citation_existence.strict+contamination_triangulation.strict-->"
+    ) is True
+
+    # A dual-block marker missing the marker-level policy_hash is malformed.
+    no_hash = parse_ref_marker(
+        "<!--ref:both ok TERMINAL-BLOCK severity=HIGH-BLOCK "
+        "policy=contamination_triangulation reason=k3_all_indexes_unmatched mode=strict "
+        "TERMINAL-BLOCK severity=HIGH-BLOCK policy=citation_existence "
+        "reason=lookup_verified_false mode=strict-->"
+    )
+    assert no_hash.is_well_formed is False
+
 
 def test_well_formed_markers_pass():
     assert parse_ref_marker("<!--ref:smith2024 ok policy_hash=contamination_triangulation.strict-->").is_well_formed


### PR DESCRIPTION
## What

Resolves the two P2 enforcement/grammar gaps in #329 (the shipped v3.10 triangulation policy layer). Both verified first-party on `main`; the 45 policy-layer tests passed because each guard was only exercised in isolation, never wired to the surface it protects.

## Findings fixed

### 1. [P2] Laundering guard was dead protection
`assert_venue_type_source_clean` (rejects a `venue_type_source` naming a lookup index under `trusted_source_declared`) had no production caller — only tests. The entry schema's own `venue_type_source` description promises *"enforced by check_v3_10_policy.py"*, but nothing ran it over real entries, so a passport with `venue_type_provenance: trusted_source_declared` + `venue_type_source: OpenAlex` (laundering a k=3-unmatched signal into a declared-trust signal) passed both the JSON-Schema validator and the policy lint.

**Fix:** wired the check into `check_literature_corpus_schema.validate_passport`'s entry loop (the validator that runs over real corpora + reference adapter examples in CI), via a dual-path import mirroring `arxiv_client.py`. A laundered source now fails; a legitimate publisher/registry feed name still passes (negative control). Guarded to run only on string fields so a schema-invalid non-string `venue_type_source` surfaces as a clean schema error, not a `.strip()` traceback.

### 2. [P2] `is_well_formed` accepted incomplete terminal markers
A `<!--ref:x ok TERMINAL-BLOCK severity=HIGH-BLOCK-->` (missing the mandatory `policy`/`reason`/`mode`/`policy_hash` terminal-grammar fields) parsed as well-formed. Once a finalizer-output validator uses `is_well_formed` to gate terminal completeness, a stripped marker slips through and the gate loses the freshness/remediation metadata it depends on.

**Fix:** `_parse_inner` now keeps per-block `{severity, policy, reason, mode}` for each `TERMINAL-BLOCK`, and `is_well_formed` validates **each block independently** (HIGH-BLOCK + non-empty policy/reason/mode) plus the marker-level shared `policy_hash`. This handles the C-V6(g) multi-policy co-emission correctly: a complete dual-policy marker is well-formed, but a complete later block can no longer mask an earlier block's stripped metadata. Empty tokens (`policy=`) count as missing.

## Tests
- `test_terminal_marker_missing_metadata_fields_is_malformed`: each of the four fields omitted (and each blank) individually → malformed; complete single-block positive control.
- `test_multi_terminal_block_per_block_validation`: first-block-missing-mode → malformed; complete dual-block → well-formed AND still triggers refusal; missing marker-level policy_hash → malformed.
- `test_v3_10_rejects_laundered_venue_type_source` + `test_v3_10_accepts_legitimate_declared_venue_type_source` + `test_v3_10_non_string_venue_type_source_reports_schema_error_not_crash` (over the real validator).
- Full suite **2136 pass / 3 skip**, no regressions. Both lints clean; default-mode example scan unaffected.

## Review (dual-track ship gate)
- `codex review` (gpt-5.5, xhigh): **converged to PASS, 0 findings at round 4**. R1 surfaced 2 P2 (non-string crash + blank tokens); R2 surfaced the multi-block masking; R3 caught that a blanket `count>1` reject would wrongly reject the canonical complete dual-policy marker; R4 confirmed the per-block validation is correct and breaks nothing.
- `security-review`: **0 findings** — net hardening (a dead guard now runs; a parser check is tightened); no injection / deserialization / auth surface.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)