### PR TITLE
fix(shared): retire stale Opus 4.7 primary-model strings (#301 harness audit)

### DIFF
--- a/shared/artifact_reproducibility_pattern.md
+++ b/shared/artifact_reproducibility_pattern.md
@@ -45,11 +45,11 @@ you CONFIGURATION DOCUMENTATION sufficient to INVESTIGATE divergence — not to 
 repro_lock:
   schema_version: "1.0"                    # lock schema version
   stochasticity_declaration: "LLM outputs are not byte-reproducible. This lockfile documents configuration, not a deterministic replay guarantee."
-  ars_version: "3.3.5"                     # suite version at run time
+  ars_version: "<suite-version-at-run-time>"   # e.g. "3.11.1" — the suite version when this run executed
 
   model:
     family: claude                          # provider family
-    id: claude-opus-4-7                    # model identifier (not weight hash)
+    id: "<model-id-at-run-time>"           # model identifier at run time, e.g. the inherited Claude Code session model (not weight hash)
     weight_stable: false                    # always false until signed attestation exists
 
   prompts:
@@ -62,7 +62,7 @@ repro_lock:
     count: 8                               # number of session materials
 
   external_protocols:
-    s2_api_protocol_version: "3.3"         # S2 query protocol version
+    s2_api_protocol_version: "<s2-protocol-version-at-run-time>"   # the S2 query protocol version that ran
     s2_snapshot_available: false           # whether a response cache exists
 
   cross_model:

--- a/shared/cross_model_verification.md
+++ b/shared/cross_model_verification.md
@@ -4,7 +4,7 @@
 
 This protocol enables optional cross-model verification for high-stakes AI judgments. When enabled, a second AI model independently reviews outputs from the primary model, reducing shared-bias blind spots.
 
-**This is entirely optional.** All ARS skills work with Claude Opus 4.7 alone. Cross-model verification is an additional layer for users who want higher confidence in integrity checks, devil's advocate challenges, and review judgments.
+**This is entirely optional.** All ARS skills work with the primary Claude model alone. Cross-model verification is an additional layer for users who want higher confidence in integrity checks, devil's advocate challenges, and review judgments.
 
 **Consent boundary:** Before unpublished manuscripts, private notes, corpus text,
 reviewer comments, decision letters, response letters, or other review material
@@ -25,12 +25,12 @@ A stress test of 68 AI-generated citations found 31% had problems — and all pa
 
 | Model | API ID | Provider | Best For |
 |-------|--------|----------|----------|
-| Claude Opus 4.7 | `claude-opus-4-7` | Anthropic | Primary model (default for all ARS skills) |
+| Claude Opus 4.8 | _(inherited Claude Code session model)_ | Anthropic | Primary model (default for all ARS skills) |
 | GPT-5.4 Pro | `gpt-5.4-pro` | OpenAI | Cross-verification — strongest reasoning |
 | GPT-5.4 | `gpt-5.4` | OpenAI | Cross-verification — balanced cost/performance |
 | Gemini 3.1 Pro | `gemini-3.1-pro-preview` | Google | Cross-verification — strong at factual verification |
 
-**Recommended cross-verification pair:** Claude Opus 4.7 (primary) + GPT-5.4 Pro or Gemini 3.1 Pro (verifier).
+**Recommended cross-verification pair:** Claude Opus 4.8 (primary) + GPT-5.4 Pro or Gemini 3.1 Pro (verifier).
 
 Using two non-Anthropic models as primary+verifier is possible but not tested with ARS prompts.
 
@@ -174,7 +174,7 @@ The DA agent, after completing its checkpoint report, should:
 
 ### OpenAI (GPT-5.4 / GPT-5.4 Pro)
 
-In Claude Code, the agent can use the Bash tool to make API calls:
+In Claude Code, the agent can use the Bash tool to make API calls. Both call patterns below set `temperature: 0.1` deliberately: reference existence/metadata checking is a deterministic factual task, and low temperature reduces run-to-run variance in the VERIFIED / NOT_FOUND / MISMATCH verdict. `max_tokens` is bounded (≤5 references per call) to cap cost, not for determinism.
 
 ```bash
 curl -s https://api.openai.com/v1/chat/completions \


### PR DESCRIPTION
## What

Retire stale `Opus 4.7` primary-model strings in two `shared/` files and document the `repro_lock` run-time fields. Surfaced by the 2026-06 harness-retirement audit (#301).

The audit's headline result: the 32 agent prompts carry **zero** expired scaffolds — the dense `MUST NOT` / anti-fabrication / refuse-gates are load-bearing for the citation-provenance use case (silent-failure guards), and the Opus 4.7 migration already scrubbed model IDs out of the agent layer. The only actionable drift was two `shared/` files still asserting Opus 4.7 as the primary model after the 4.7→4.8 bump.

## Changes

**`shared/cross_model_verification.md`**
- Primary model → Opus 4.8 (overview line, Supported Models table, recommended pair).
- The primary "API ID" cell now reflects that ARS's primary model is the **inherited Claude Code session model**, rather than asserting an unverified `claude-opus-4-8` id string (no in-repo source verifies that exact id, and the file elsewhere warns against hard-coding model versions). The cross-verifier ids (`gpt-5.4-pro`, `gpt-5.4`, `gemini-3.1-pro-preview`) were checked against current provider docs, confirmed live, and left concrete — they must stay concrete because users set `ARS_CROSS_MODEL` to one of them.
- Added a one-line note documenting *why* the API call examples use `temperature: 0.1` (reference existence/metadata checking is a deterministic factual task; low temp reduces verdict variance), closing the "undocumented sampling override" read without changing behaviour.

**`shared/artifact_reproducibility_pattern.md`**
- The `repro_lock` **example** block now uses placeholders for the three run-time snapshot fields (`ars_version`, `model.id`, `s2_api_protocol_version`) so a reader who copies the block records their actual run, not a stale literal. Feature-introduction labels (`v3.3.5+`) stay concrete — they record which version shipped the pattern, not a run-time value.

**Left unchanged:** `examples/passport_with_repro_lock.yaml` — it is a self-consistent historical snapshot (its date, model, and suite version all correspond to one real ~2026-04 run) and is validated for *structure* by `check_repro_lock.py`, not a stale current-marker.

## Verification

- `scripts/check_repro_lock.py` passes on the example fixture; the placeholder YAML in the pattern doc parses and would pass the validator (presence + `schema_version`/`hash_timing` checks only).
- `scripts/check_spec_consistency.py` passes.
- Docs-only change; no agent prompt, schema, or code path touched.

## Not in this PR

A separate correctness gap found during the same pass is filed as #346 (the cross-model verify prompt tells the verifier to "search the web" but the shipped API examples wire in no grounding tool — risk of a silent false `VERIFIED`). It is not an expired scaffold, so it is tracked independently.

Refs #301

[skip-closes-check] — intentionally no auto-close keyword. #301 is the monthly harness-retirement audit issue; its lifecycle ends when the full audit is signed off, not when this single follow-up (3 stale-string fixes) merges. The audit's headline finding was that the agent layer needs zero retirements. This PR links the issue with `Refs` so the audit issue stays open for sign-off.
