### PR TITLE
feat(lint): police docs/ARCHITECTURE.md component-version markers (#345)

### DIFF
--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -132,9 +132,18 @@ def check_pipeline_docs() -> None:
     )
 
 
+# A version token is a dot-separated run of ≥3 numeric components. The repo's own grammar
+# already ships 4-component versions (v3.9.4.2), so a fixed `\d+\.\d+\.\d+` would capture only
+# the first three components of `3.9.4.2` and silently compare a truncated `3.9.4` — making a
+# genuinely-stale 4-component marker pass. `(?:\.\d+)*` is greedy, so it captures the FULL token;
+# the trailing `(?!\.?\d)` is a hard right boundary so a longer numeric run can never tail-match a
+# shorter capture (e.g. `3.9.4` must not partial-match inside `3.9.4.2`).
+_VERSION = r"\d+\.\d+\.\d+(?:\.\d+)*(?!\.?\d)"
+
+
 def _suite_version() -> str | None:
-    """Parse the canonical suite version from `.claude/CLAUDE.md` (`**Suite version**: X.Y.Z`)."""
-    match = re.search(r"\*\*Suite version\*\*:\s*(\d+\.\d+\.\d+)", read(".claude/CLAUDE.md"))
+    """Parse the canonical suite version from `.claude/CLAUDE.md` (`**Suite version**: X.Y.Z[.W]`)."""
+    match = re.search(rf"\*\*Suite version\*\*:\s*({_VERSION})", read(".claude/CLAUDE.md"))
     return match.group(1) if match else None
 
 
@@ -165,7 +174,7 @@ def check_architecture_component_version() -> None:
 
     # 1. Mermaid orchestrator node: `academic-pipeline<br/>orchestrator<br/>vX.Y.Z`.
     node_versions = re.findall(
-        r"academic-pipeline<br/>orchestrator<br/>v(\d+\.\d+\.\d+)", text
+        rf"academic-pipeline<br/>orchestrator<br/>v({_VERSION})", text
     )
     if not node_versions:
         fail(f"{rel_path}: no mermaid `academic-pipeline<br/>orchestrator<br/>vX.Y.Z` node found")
@@ -177,10 +186,14 @@ def check_architecture_component_version() -> None:
             )
 
     # 2. Component table + stage rows: ` academic-pipeline vX.Y.Z` (table cell / `(gate)` rows).
-    #    The `academic-pipeline ` prefix with a leading space (a markdown table cell or backticked
-    #    `\`academic-pipeline\` vX.Y.Z`) distinguishes these from the timeline `vX.Y.Z :` form,
-    #    which never carries the `academic-pipeline` token on the same marker.
-    row_versions = re.findall(r"`?academic-pipeline`?\s+v(\d+\.\d+\.\d+)", text)
+    #    Anchored to markdown table rows (`^\s*\|` … on the same line) so the scan only ever sees
+    #    component/stage cells — never prose like `` `academic-pipeline` v3.9.4 introduced … ``,
+    #    which is feature-history provenance and must NOT be policed against the suite version.
+    #    The timeline `vX.Y.Z :` form never carries the `academic-pipeline` token, so it is already
+    #    out of scope; the table-row anchor additionally excludes any narrative mention.
+    row_versions = re.findall(
+        rf"(?m)^\s*\|.*?`?academic-pipeline`?\s+v({_VERSION})", text
+    )
     if not row_versions:
         fail(f"{rel_path}: no `academic-pipeline vX.Y.Z` component/stage row found")
     for found in row_versions:

--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -132,6 +132,65 @@ def check_pipeline_docs() -> None:
     )
 
 
+def _suite_version() -> str | None:
+    """Parse the canonical suite version from `.claude/CLAUDE.md` (`**Suite version**: X.Y.Z`)."""
+    match = re.search(r"\*\*Suite version\*\*:\s*(\d+\.\d+\.\d+)", read(".claude/CLAUDE.md"))
+    return match.group(1) if match else None
+
+
+def check_architecture_component_version() -> None:
+    """Invariant-4 (#345): the *current-component* `academic-pipeline` version markers in
+    docs/ARCHITECTURE.md must equal the suite version.
+
+    docs/ARCHITECTURE.md carries two kinds of version string and only the first must track the
+    suite version:
+      - current-component markers — the mermaid orchestrator node + the component table row + the
+        four stage-table `(gate)` / stage-6 rows — describe what the *current* pipeline is.
+      - feature-history markers — the `timeline` block (`vX.Y.Z : <feature>`) and inline
+        "introduced in vX.Y.Z" provenance — record which version first shipped a gate/feature and
+        must NOT be bumped on a release that adds no new gate.
+
+    This check anchors on the `academic-pipeline <ver>` component pattern specifically (mermaid
+    `<br/>vX.Y.Z` node + ` academic-pipeline vX.Y.Z` table/stage rows) and never inspects the
+    timeline block, so a stale current-component marker fails while a feature-history marker is
+    left alone. (Surfaced during the v3.11.1 release: six component markers were missed by the
+    bump and only caught by a manual sweep — #343/#344.)
+    """
+    rel_path = "docs/ARCHITECTURE.md"
+    version = _suite_version()
+    if version is None:
+        fail(".claude/CLAUDE.md: could not parse '**Suite version**: X.Y.Z' for ARCHITECTURE check")
+        return
+    text = read(rel_path)
+
+    # 1. Mermaid orchestrator node: `academic-pipeline<br/>orchestrator<br/>vX.Y.Z`.
+    node_versions = re.findall(
+        r"academic-pipeline<br/>orchestrator<br/>v(\d+\.\d+\.\d+)", text
+    )
+    if not node_versions:
+        fail(f"{rel_path}: no mermaid `academic-pipeline<br/>orchestrator<br/>vX.Y.Z` node found")
+    for found in node_versions:
+        if found != version:
+            fail(
+                f"{rel_path}: mermaid orchestrator node version v{found} != suite v{version} "
+                f"(invariant-4: current-component marker must equal the suite version)"
+            )
+
+    # 2. Component table + stage rows: ` academic-pipeline vX.Y.Z` (table cell / `(gate)` rows).
+    #    The `academic-pipeline ` prefix with a leading space (a markdown table cell or backticked
+    #    `\`academic-pipeline\` vX.Y.Z`) distinguishes these from the timeline `vX.Y.Z :` form,
+    #    which never carries the `academic-pipeline` token on the same marker.
+    row_versions = re.findall(r"`?academic-pipeline`?\s+v(\d+\.\d+\.\d+)", text)
+    if not row_versions:
+        fail(f"{rel_path}: no `academic-pipeline vX.Y.Z` component/stage row found")
+    for found in row_versions:
+        if found != version:
+            fail(
+                f"{rel_path}: `academic-pipeline v{found}` component/stage row != suite v{version} "
+                f"(invariant-4: current-component marker must equal the suite version)"
+            )
+
+
 def check_readme_sections() -> None:
     rel_path = "README.md"
     text = read(rel_path)
@@ -459,6 +518,7 @@ def main() -> int:
     check_claude_md()
     check_reviewer_version_block()
     check_pipeline_docs()
+    check_architecture_component_version()
     check_readme_sections()
     check_readme_zh_sections()
     check_readme_ja_sections()

--- a/scripts/test_check_spec_consistency.py
+++ b/scripts/test_check_spec_consistency.py
@@ -326,10 +326,12 @@ class TestReadmeZhSections(unittest.TestCase):
             )
 
 
-# Minimal docs/ARCHITECTURE.md fixture carrying BOTH marker kinds the invariant-4 check (#345)
-# must distinguish: current-component markers (mermaid node + component/stage rows, which MUST
-# equal the suite version) and a feature-history timeline marker (`vX.Y.Z : <feature>`, which must
-# NOT be policed). The `{comp}` slots are the component version; `{hist}` is the timeline version.
+# Minimal docs/ARCHITECTURE.md fixture carrying the THREE marker kinds the invariant-4 check (#345)
+# must distinguish: current-component markers (mermaid node + component/stage rows, which MUST equal
+# the suite version), a feature-history timeline marker (`vX.Y.Z : <feature>`, which must NOT be
+# policed), and a prose mention of `academic-pipeline vX.Y.Z` (provenance narrative, which must also
+# NOT be policed — it is excluded by the table-row anchor). `{comp}` = current-component version;
+# `{hist}` = timeline version; `{prose}` = the version named in the narrative provenance line.
 ARCHITECTURE_TEMPLATE = """\
 # Architecture
 
@@ -347,6 +349,8 @@ flowchart TD
 |-----------|------|
 | `academic-pipeline` v{comp} | orchestrator (delegates to sub-skill modes) |
 
+The `academic-pipeline` v{prose} release first introduced the integrity gate (narrative provenance).
+
 ```mermaid
 timeline
     title ARS evolution timeline
@@ -355,15 +359,22 @@ timeline
 """
 
 
-def _write_architecture_fixture(root: Path, *, suite: str, comp: str, hist: str) -> None:
-    """Write `.claude/CLAUDE.md` (suite version source) + a docs/ARCHITECTURE.md fixture."""
+def _write_architecture_fixture(
+    root: Path, *, suite: str, comp: str, hist: str, prose: str | None = None
+) -> None:
+    """Write `.claude/CLAUDE.md` (suite version source) + a docs/ARCHITECTURE.md fixture.
+
+    `prose` defaults to the suite version so the narrative line is innocuous unless a test
+    deliberately sets it to a stale version to assert the prose mention is not policed.
+    """
     (root / ".claude").mkdir(parents=True, exist_ok=True)
     (root / ".claude" / "CLAUDE.md").write_text(
         f"# ARS\n\n- **Suite version**: {suite} (per CHANGELOG.md)\n", encoding="utf-8"
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
     (root / "docs" / "ARCHITECTURE.md").write_text(
-        ARCHITECTURE_TEMPLATE.format(comp=comp, hist=hist), encoding="utf-8"
+        ARCHITECTURE_TEMPLATE.format(comp=comp, hist=hist, prose=prose or suite),
+        encoding="utf-8",
     )
 
 
@@ -446,6 +457,60 @@ class TestArchitectureComponentVersion(unittest.TestCase):
             self.assertTrue(
                 any("no mermaid" in e or "no `academic-pipeline" in e for e in csc.ERRORS),
                 msg=f"expected missing-marker error in: {csc.ERRORS!r}",
+            )
+
+    def test_four_component_aligned_passes(self) -> None:
+        """#352 P2: the repo's own grammar ships 4-component versions (v3.9.4.2). A suite and
+        component markers both at a 4-component version must pass — the version regex must capture
+        the FULL token, not truncate to three components."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_architecture_fixture(root, suite="3.9.4.2", comp="3.9.4.2", hist="3.9.4")
+
+            csc.check_architecture_component_version()
+
+            self.assertEqual(
+                csc.ERRORS, [],
+                msg=f"unexpected errors on aligned 4-component fixture: {csc.ERRORS!r}",
+            )
+
+    def test_four_component_marker_against_three_component_suite_fails(self) -> None:
+        """#352 P2 (the silent-pass this fix closes): suite is the 3-component `3.9.4` but a
+        component marker carries the 4-component `3.9.4.2`. A truncating `\\d+\\.\\d+\\.\\d+`
+        would capture `3.9.4` from the marker and falsely pass (3.9.4 == 3.9.4). The full-token
+        capture must instead see `3.9.4.2` and fail it against the suite."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_architecture_fixture(root, suite="3.9.4", comp="3.9.4.2", hist="3.9.4")
+
+            csc.check_architecture_component_version()
+
+            # The error must name the FULL 4-component marker as != the 3-component suite. Asserting
+            # on `!= suite v3.9.4` (not just substring `3.9.4`, which is contained in `3.9.4.2`)
+            # proves the captured marker was the full `3.9.4.2`, i.e. the truncation was closed.
+            self.assertTrue(
+                any("v3.9.4.2" in e and "!= suite v3.9.4 " in e for e in csc.ERRORS),
+                msg=f"expected 4-vs-3-component drift error in: {csc.ERRORS!r}",
+            )
+
+    def test_prose_provenance_mention_does_not_fail(self) -> None:
+        """#352 P3: a narrative line naming `academic-pipeline v<old>` (feature provenance) must
+        NOT be policed against the suite version — only markdown table-row component cells are.
+        Component markers + timeline are aligned/innocuous; only the prose line is stale."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_architecture_fixture(
+                root, suite="3.11.1", comp="3.11.1", hist="3.9.4", prose="3.9.4"
+            )
+
+            csc.check_architecture_component_version()
+
+            self.assertEqual(
+                csc.ERRORS, [],
+                msg=f"prose provenance mention must not be policed, but got: {csc.ERRORS!r}",
             )
 
 

--- a/scripts/test_check_spec_consistency.py
+++ b/scripts/test_check_spec_consistency.py
@@ -326,5 +326,128 @@ class TestReadmeZhSections(unittest.TestCase):
             )
 
 
+# Minimal docs/ARCHITECTURE.md fixture carrying BOTH marker kinds the invariant-4 check (#345)
+# must distinguish: current-component markers (mermaid node + component/stage rows, which MUST
+# equal the suite version) and a feature-history timeline marker (`vX.Y.Z : <feature>`, which must
+# NOT be policed). The `{comp}` slots are the component version; `{hist}` is the timeline version.
+ARCHITECTURE_TEMPLATE = """\
+# Architecture
+
+```mermaid
+flowchart TD
+    Pipeline[academic-pipeline<br/>orchestrator<br/>v{comp}<br/>Agent Team: 5]
+```
+
+| Stage | Gate | ... |
+|-------|------|-----|
+| **2.5 INTEGRITY** | `academic-pipeline` v{comp} (gate) | VERIFIED_ONLY |
+| **6. PROCESS SUMMARY** | `academic-pipeline` v{comp} | VERIFIED_ONLY |
+
+| Component | Role |
+|-----------|------|
+| `academic-pipeline` v{comp} | orchestrator (delegates to sub-skill modes) |
+
+```mermaid
+timeline
+    title ARS evolution timeline
+    v{hist} : deterministic citation verification gate (#182)
+```
+"""
+
+
+def _write_architecture_fixture(root: Path, *, suite: str, comp: str, hist: str) -> None:
+    """Write `.claude/CLAUDE.md` (suite version source) + a docs/ARCHITECTURE.md fixture."""
+    (root / ".claude").mkdir(parents=True, exist_ok=True)
+    (root / ".claude" / "CLAUDE.md").write_text(
+        f"# ARS\n\n- **Suite version**: {suite} (per CHANGELOG.md)\n", encoding="utf-8"
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs" / "ARCHITECTURE.md").write_text(
+        ARCHITECTURE_TEMPLATE.format(comp=comp, hist=hist), encoding="utf-8"
+    )
+
+
+class TestArchitectureComponentVersion(unittest.TestCase):
+    """#345: invariant-4 lint for docs/ARCHITECTURE.md current-component version markers."""
+
+    def setUp(self) -> None:
+        self._orig_root = csc.ROOT
+        self._orig_errors = list(csc.ERRORS)
+        csc.ERRORS.clear()
+
+    def tearDown(self) -> None:
+        csc.ROOT = self._orig_root
+        csc.ERRORS.clear()
+        csc.ERRORS.extend(self._orig_errors)
+
+    def test_aligned_passes(self) -> None:
+        """All component markers at the suite version → no errors (timeline at an older version
+        is fine — it records history)."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_architecture_fixture(root, suite="3.11.1", comp="3.11.1", hist="3.11.0")
+
+            csc.check_architecture_component_version()
+
+            self.assertEqual(
+                csc.ERRORS, [], msg=f"unexpected errors on aligned fixture: {csc.ERRORS!r}"
+            )
+
+    def test_stale_component_marker_fails(self) -> None:
+        """A current-component marker left at the prior version (the exact #343/#344 drift) must
+        fail — both the mermaid node and the rows carry the stale version here."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_architecture_fixture(root, suite="3.11.1", comp="3.11.0", hist="3.11.0")
+
+            csc.check_architecture_component_version()
+
+            self.assertTrue(
+                any("ARCHITECTURE.md" in e and "3.11.0" in e and "3.11.1" in e for e in csc.ERRORS),
+                msg=f"expected stale-component drift error in: {csc.ERRORS!r}",
+            )
+
+    def test_stale_timeline_marker_does_not_fail(self) -> None:
+        """The critical distinction: a timeline `vX.Y.Z : <feature>` node at a DIFFERENT version
+        from the suite must NOT fail — it records which version shipped a feature, and a
+        naive `v3.x` scan would wrongly flag it. Component markers are aligned here."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            # Component markers all at the suite version; only the timeline records an old version.
+            _write_architecture_fixture(root, suite="3.11.1", comp="3.11.1", hist="3.9.4")
+
+            csc.check_architecture_component_version()
+
+            self.assertEqual(
+                csc.ERRORS, [],
+                msg=f"timeline marker must not be policed, but got: {csc.ERRORS!r}",
+            )
+
+    def test_missing_component_marker_fails(self) -> None:
+        """If the component markers vanish entirely (e.g. a refactor removes them), the check must
+        surface that rather than silently passing on an empty match."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            (root / ".claude").mkdir(parents=True, exist_ok=True)
+            (root / ".claude" / "CLAUDE.md").write_text(
+                "- **Suite version**: 3.11.1 (per CHANGELOG.md)\n", encoding="utf-8"
+            )
+            (root / "docs").mkdir(parents=True, exist_ok=True)
+            (root / "docs" / "ARCHITECTURE.md").write_text(
+                "# Architecture\n\nNo component markers here.\n", encoding="utf-8"
+            )
+
+            csc.check_architecture_component_version()
+
+            self.assertTrue(
+                any("no mermaid" in e or "no `academic-pipeline" in e for e in csc.ERRORS),
+                msg=f"expected missing-marker error in: {csc.ERRORS!r}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #345

## Problem

`scripts/check_spec_consistency.py` polices version markers in README (×4 langs), `.claude/CLAUDE.md`, `MODE_REGISTRY.md`, and `academic-pipeline/SKILL.md` — but **not** `docs/ARCHITECTURE.md`. During the v3.11.1 release, six "current academic-pipeline component version" strings in `docs/ARCHITECTURE.md` were missed by the release bump and only caught by a manual first-party sweep (#343/#344). This is exactly the invariant-4 alignment the release discipline calls for, but it was not enforced.

## Fix

New `check_architecture_component_version()` parses the suite version from `.claude/CLAUDE.md` and asserts the six current-component markers equal it:
- the mermaid orchestrator node (`academic-pipeline<br/>orchestrator<br/>vX.Y.Z`)
- the component table row + the four stage-table rows (`academic-pipeline vX.Y.Z`)

**The distinction it respects:** `docs/ARCHITECTURE.md` carries two kinds of version string. Current-component markers must equal the suite version; feature-history markers (the `timeline` block `vX.Y.Z : <feature>`, and "introduced in vX.Y.Z" prose) record *which* version first shipped a gate and must NOT be bumped on a patch that adds no new gate. The check anchors on the `academic-pipeline <ver>` component pattern specifically and never inspects the timeline — so a naive `v3.x` grep-replace corruption is avoided.

## Tests

4 cases in `test_check_spec_consistency.py`:
- aligned markers → pass
- a stale **component** marker → fail (the exact #343/#344 drift)
- a stale **timeline** marker → does NOT fail (the critical distinction)
- missing component markers → fail (not a silent empty-match pass)

Wired automatically: the lint runs in `spec-consistency.yml`, and the test file already runs via `python3 -m unittest scripts.test_check_spec_consistency`. spec + version consistency green; pyflakes clean.