### PR TITLE
fix(citation-gate): bound failure rationale + require PARTIAL gold sub-claims (#213 follow-up)

### DIFF
--- a/scripts/claim_audit_calibration.py
+++ b/scripts/claim_audit_calibration.py
@@ -82,7 +82,7 @@ class GoldSetValidationError(ValueError):
 
 
 def validate_gold_set(tuples: list[dict[str, Any]]) -> None:
-    """Validate the gold set per spec §7.7 rules (a)..(d).
+    """Validate the gold set per spec §7.7 rules (a)..(d) + rule (e) (#355).
 
     Raises GoldSetValidationError on the first failed rule. Returns None
     on success so the call site can ignore the return value — the
@@ -110,6 +110,15 @@ def validate_gold_set(tuples: list[dict[str, Any]]) -> None:
                         f"tuple {idx}: alignment tuple must not carry "
                         f"constraint field {forbidden!r} (rule (b))"
                     )
+            # Rule (e): a PARTIAL fixture must declare non-empty expected_sub_claims;
+            # without them `_breakdown_covers_expected` early-returns True and the
+            # #213 atomic-decomposition subset metric is silently bypassed.
+            if tup.get("expected_prompt_verdict") == "PARTIAL" and not tup.get("expected_sub_claims"):
+                raise GoldSetValidationError(
+                    f"tuple {idx}: PARTIAL fixture must declare non-empty "
+                    f"expected_sub_claims (rule (e); else the atomic-decomposition "
+                    f"subset metric is silently skipped)"
+                )
         else:  # constraint
             if expected not in CONSTRAINT_JUDGMENTS:
                 raise GoldSetValidationError(

--- a/scripts/claim_audit_pipeline.py
+++ b/scripts/claim_audit_pipeline.py
@@ -63,6 +63,36 @@ def _hash_text(text: str | None) -> str:
     return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
 
 
+# claim_audit_result.rationale schema maxLength (#355 P2#3). A judge/retrieval
+# failure detail that embeds the offending payload's repr must fit here, or the
+# "clean inconclusive" fallback row it produces is itself schema-invalid. Every
+# JudgeInvocationError / RetrievalInvocationError detail ends up in a row's
+# rationale via `f"{fault_class}: {detail}"`, so the bound lives in those
+# exceptions' constructors (single choke point) rather than at each raise site.
+_RATIONALE_MAX_LEN = 2000
+_RATIONALE_TRUNC_MARK = "…[truncated]"
+# Widest fault-class prefix across both exception families ("retrieval_network_error: ").
+_WIDEST_FAULT_PREFIX = "retrieval_network_error: "
+
+
+def _bounded_failure_detail(message: str) -> str:
+    """Clamp a failure detail so the emitted rationale fits the schema maxLength.
+
+    The row builder forms the rationale as ``f"{fault_class}: {detail}"``. A
+    malformed payload's repr embedded in `message` (a >1000-char sub_claim_text,
+    an over-decomposed breakdown, a giant non-string judgment/method) can push
+    the detail past the rationale maxLength, making the fallback row
+    schema-invalid (#355 P2#3). Truncate to a budget that leaves room for the
+    widest fault-class prefix and a truncation marker, preserving the diagnostic
+    head (which says WHICH malformed shape) at the front.
+    """
+    budget = _RATIONALE_MAX_LEN - len(_WIDEST_FAULT_PREFIX)
+    if len(message) <= budget:
+        return message
+    keep = budget - len(_RATIONALE_TRUNC_MARK)
+    return message[:keep] + _RATIONALE_TRUNC_MARK
+
+
 def _active_constraints_for_claim(
     *,
     scoped_manifest_id: str,
@@ -136,7 +166,23 @@ _CITED_PATH_JUDGMENTS: frozenset[str] = frozenset(
 _UNCITED_PATH_JUDGMENTS: frozenset[str] = frozenset({"VIOLATED", "NOT_VIOLATED"})
 
 
-class JudgeInvocationError(Exception):
+class _AuditInvocationError(Exception):
+    """Base for audit-tool invocation failures (judge / retrieval).
+
+    Carries an INV-14 fault-class tag + detail. The detail is bounded so the
+    `f"{fault_class}: {detail}"` rationale it becomes fits the claim_audit_result
+    schema maxLength (#355 P2#3) — every subclass's detail flows to a row
+    rationale, so the bound lives here (single choke point).
+    """
+
+    def __init__(self, fault_class: str, detail: str) -> None:
+        detail = _bounded_failure_detail(detail)
+        super().__init__(f"{fault_class}: {detail}")
+        self.fault_class = fault_class
+        self.detail = detail
+
+
+class JudgeInvocationError(_AuditInvocationError):
     """Raised by `_invoke_judge` when judge_fn fails or returns malformed output.
 
     Carries the INV-14 fault-class tag + detail so the caller can emit a
@@ -145,13 +191,8 @@ class JudgeInvocationError(Exception):
     audit pass.
     """
 
-    def __init__(self, fault_class: str, detail: str) -> None:
-        super().__init__(f"{fault_class}: {detail}")
-        self.fault_class = fault_class
-        self.detail = detail
 
-
-class RetrievalInvocationError(Exception):
+class RetrievalInvocationError(_AuditInvocationError):
     """Raised by `_invoke_retrieve` when retrieve_fn fails or returns malformed output.
 
     Mirrors JudgeInvocationError but tags faults with the INV-14 retrieval_*
@@ -159,11 +200,6 @@ class RetrievalInvocationError(Exception):
     so a transient retrieval outage surfaces as audit_tool_failure rather than
     aborting the audit pass (Step 13 R2 codex P2 finding).
     """
-
-    def __init__(self, fault_class: str, detail: str) -> None:
-        super().__init__(f"{fault_class}: {detail}")
-        self.fault_class = fault_class
-        self.detail = detail
 
 
 def _validate_judge_dict(

--- a/scripts/test_claim_audit_calibration.py
+++ b/scripts/test_claim_audit_calibration.py
@@ -378,6 +378,62 @@ class TC3GoldSetShape(unittest.TestCase):
         # Positive path — the shipped gold set MUST validate cleanly.
         self.assertIsNone(validate_gold_set(self.gold_set))
 
+    def test_validate_gold_set_rejects_partial_without_expected_sub_claims(self) -> None:
+        # #355 P2#4 — rule (e): a PARTIAL fixture is the ONLY thing exercising
+        # the atomic-decomposition subset metric. If it omits expected_sub_claims,
+        # `_breakdown_covers_expected` early-returns True and the metric is
+        # silently skipped — any generic two-line true-partial breakdown reports
+        # miss_rate=0, defeating the whole point of the #213 calibration. Ingestion
+        # MUST reject a PARTIAL tuple with missing/empty expected_sub_claims.
+        for missing in ({}, {"expected_sub_claims": []}, {"expected_sub_claims": None}):
+            with self.subTest(missing=missing):
+                broken = [
+                    {
+                        "tuple_kind": "alignment",
+                        "claim_text": "compound claim with two parts",
+                        "ref_text_excerpt": "excerpt",
+                        "anchor": {"kind": "page", "value": "1"},
+                        "expected_judgment": "UNSUPPORTED",
+                        "expected_prompt_verdict": "PARTIAL",
+                        **missing,
+                    }
+                ]
+                with self.assertRaises(GoldSetValidationError) as ctx:
+                    validate_gold_set(broken)
+                msg = str(ctx.exception)
+                self.assertIn("rule (e)", msg, f"diagnostic must name rule (e); got {msg!r}")
+                self.assertIn("expected_sub_claims", msg)
+
+    def test_validate_gold_set_accepts_partial_with_expected_sub_claims(self) -> None:
+        # Positive: a PARTIAL fixture that declares expected_sub_claims passes
+        # rule (e). Guards the rule from over-firing on well-formed fixtures.
+        # Padded with 3 NOT_VIOLATED constraint tuples to satisfy rule (d).
+        ok = [
+            {
+                "tuple_kind": "alignment",
+                "claim_text": "compound claim with two parts",
+                "ref_text_excerpt": "excerpt",
+                "anchor": {"kind": "page", "value": "1"},
+                "expected_judgment": "UNSUPPORTED",
+                "expected_prompt_verdict": "PARTIAL",
+                "expected_sub_claims": [
+                    {"key_tokens": ["first"], "sub_verdict": "SUPPORTED"},
+                    {"key_tokens": ["second"], "sub_verdict": "UNSUPPORTED"},
+                ],
+            },
+            *[
+                {
+                    "tuple_kind": "constraint",
+                    "claim_text": f"nv-filler-{i}",
+                    "expected_judgment": "NOT_VIOLATED",
+                    "constraint_under_test_id": "MNC-1",
+                    "constraint_under_test_rule_text": "filler rule",
+                }
+                for i in range(3)
+            ],
+        ]
+        self.assertIsNone(validate_gold_set(ok))
+
     def test_run_calibration_rejects_manifest_only_constraint_tuple(self) -> None:
         # round-2 review closure: validate_gold_set accepts EITHER inline
         # rule_text OR manifest_fixture_path per spec §7.7 rule (c), but

--- a/scripts/test_claim_audit_pipeline.py
+++ b/scripts/test_claim_audit_pipeline.py
@@ -22,6 +22,8 @@ import unittest
 from pathlib import Path
 from typing import Any, Callable
 
+from tests.test_helpers import build_schema_validator, load_json_schema
+
 try:
     from scripts.claim_audit_pipeline import run_audit_pipeline  # noqa: F401
     _MODULE_IMPORT_ERR: Exception | None = None
@@ -30,6 +32,16 @@ except Exception as exc:  # pragma: no cover — import-time error pathway is ex
 
     def run_audit_pipeline(*args: Any, **kwargs: Any) -> Any:
         raise _MODULE_IMPORT_ERR  # type: ignore[misc]
+
+
+# claim_audit_result schema validator — an emitted row MUST satisfy the
+# passport entry schema (incl. rationale maxLength=2000). Some failure paths
+# build the rationale from untrusted judge output, so a row that is supposed to
+# be a clean inconclusive fallback can still overflow the schema (#355 P2#3).
+_CAR_SCHEMA = load_json_schema(
+    Path(__file__).resolve().parent.parent / "shared/contracts/passport/claim_audit_result.schema.json"
+)
+_CAR_VALIDATOR = build_schema_validator(_CAR_SCHEMA)
 
 
 MANIFEST_ID = "M-2026-05-15T10:00:00Z-a1b2"
@@ -1908,6 +1920,57 @@ class TP24PartialDecomposition(_PipelineTestBase):
             ),
         )
         self.assertEqual(self._validate_passport(out), [])
+
+    def test_malformed_partial_with_oversized_text_emits_schema_valid_row(self) -> None:
+        # #355 P2#3: the malformed-PARTIAL fallback embeds the offending
+        # breakdown's repr in the rationale. A >1000-char sub_claim_text is
+        # itself a malformed trigger (is_emittable rejects len>1000), so its repr
+        # alone overflows the rationale maxLength=2000 and the "clean inconclusive"
+        # fallback row becomes schema-INVALID. The row MUST satisfy the schema.
+        # 1700-char text overflows the rationale (measured: 2017 chars > 2000).
+        # A judge is an LLM with no pre-emission length guarantee, so an
+        # over-long claim or an over-decomposed breakdown is a real malformed
+        # input — not a synthetic edge.
+        bad = [
+            {"sub_claim_text": "x" * 1700, "sub_verdict": "SUPPORTED"},
+            {"sub_claim_text": "second", "sub_verdict": "UNSUPPORTED"},
+        ]
+        out = self.run_pipeline(
+            citations=[_citation()], judge_fn=_judge_partial_malformed(breakdown=bad)
+        )
+        e = out["claim_audit_results"][0]
+        self.assertEqual(e["judgment"], "RETRIEVAL_FAILED")
+        self.assertEqual(e["audit_status"], "inconclusive")
+        self.assertTrue(e["rationale"].startswith("judge_parse_error"))
+        self.assertLessEqual(
+            len(e["rationale"]), 2000,
+            f"fallback rationale must fit schema maxLength=2000; got {len(e['rationale'])}",
+        )
+        errors = sorted(_CAR_VALIDATOR.iter_errors(e), key=str)
+        self.assertEqual(
+            errors, [], f"malformed-PARTIAL fallback row must satisfy claim_audit_result schema; got {errors}"
+        )
+        self.assertEqual(self._validate_passport(out), [], "fallback row must also be lint-clean")
+
+    def test_malformed_partial_short_breakdown_fallback_is_schema_valid(self) -> None:
+        # Regression guard: the existing short-breakdown malformed paths
+        # (single-item, all-SUPPORTED) must STILL emit schema-valid rows after
+        # the #355 P2#3 truncation fix — i.e. the bound must not drop the
+        # fault-class tag or mangle short messages that never needed truncating.
+        for bad in (
+            [{"sub_claim_text": "a", "sub_verdict": "SUPPORTED"}],  # single-item
+            [
+                {"sub_claim_text": "a", "sub_verdict": "SUPPORTED"},
+                {"sub_claim_text": "b", "sub_verdict": "SUPPORTED"},
+            ],  # all-supported, not true-partial
+        ):
+            with self.subTest(bad=bad):
+                out = self.run_pipeline(
+                    citations=[_citation()], judge_fn=_judge_partial_malformed(breakdown=bad)
+                )
+                e = out["claim_audit_results"][0]
+                self.assertTrue(e["rationale"].startswith("judge_parse_error"))
+                self.assertEqual(sorted(_CAR_VALIDATOR.iter_errors(e), key=str), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two correctness gaps in the #213 sub-claim decomposition path, surfaced by the post-squash integration review tracked in #355 and confirmed by first-party reading of the code. Both are in the new `PARTIAL` machinery; neither is reachable on pre-#213 inputs.

## What changed

**(1) Malformed-`PARTIAL` fallback could emit a schema-invalid row.**
When a `PARTIAL` verdict carries a non-emittable breakdown, the judge-output parse error embeds the offending breakdown's `repr` in its `detail`, which becomes the fallback row's `rationale`. An over-long `sub_claim_text` (>1000 chars — itself a malformed trigger) or an over-decomposed breakdown pushed the derived rationale past the `claim_audit_result` schema `maxLength=2000`, so the row meant to be a *clean inconclusive fallback* was itself schema-invalid (measured: a 1700-char `sub_claim_text` yields a 2017-char rationale).

Fix: bound the detail at a single choke point — a shared `_AuditInvocationError` base whose `__init__` clamps `detail` so the `f"{fault_class}: {detail}"` rationale always fits, budgeted against the widest fault-class prefix and preserving the diagnostic head. `JudgeInvocationError` / `RetrievalInvocationError` now inherit it (also removes the duplicated constructor).

**(2) Calibration could silently skip the atomic-decomposition metric.**
`validate_gold_set` did not require an `expected_prompt_verdict=PARTIAL` fixture to carry non-empty `expected_sub_claims`. Absent/empty, `_breakdown_covers_expected` early-returns `True`, so any generic two-line true-partial breakdown scores `miss_rate=0` — defeating the #213 atomic-decomposition subset metric (the whole point of the gold fixtures). The 5 shipped fixtures all declare them, but the gate didn't enforce it.

Fix: new **rule (e)** rejects a `PARTIAL` fixture with missing/empty `expected_sub_claims` at ingestion (fail-closed, fires on `{}` / `[]` / `None`).

## Verification

- RED-then-GREEN + **mutation-verified** for both guards (a trivial accept-all replacement makes the matching test fail).
- New short-breakdown schema-validity regression guard (existing malformed paths must keep emitting schema-valid rows after the truncation fix).
- Full suite **2263 passed / 3 skipped**.
- Independent post-squash review + security review both at **0 P1/P2**. The widest fault-class prefix (`retrieval_network_error: `, 25 chars) puts the worst-case bounded rationale at exactly 2000 — at the limit, not over.

## Out of scope (tracked separately)

- A parallel unbounded path: a judge's *own* returned `rationale` field is copied onto **completed** (non-fallback) rows with no length bound. Same defect class as fix (1) but on the success path; pre-existing, not introduced here. Noted in #355 for follow-up.
- Cache prompt-versioning (a stale pre-#213 cache entry can bypass the new Step-0 decomposition). Pre-existing cache-key design, affects every prompt revision, not specific to `PARTIAL`. Noted in #355.

## Issue linkage

Addresses the actionable findings from #355. `#355` is a CI-generated **advisory** post-squash review issue; it is closed manually after the per-finding adjudication is posted (not auto-closed on merge), so this PR intentionally does **not** carry a `Closes #N` keyword.

[skip-closes-check] advisory issue closed manually with adjudication record, per post-ship advisory discipline — auto-close would strip the required finding-by-finding verdict.
