### PR TITLE
fix(citation-gate): bound judge-supplied rationale on success-path rows (#360)

### DIFF
--- a/scripts/claim_audit_pipeline.py
+++ b/scripts/claim_audit_pipeline.py
@@ -75,22 +75,58 @@ _RATIONALE_TRUNC_MARK = "…[truncated]"
 _WIDEST_FAULT_PREFIX = "retrieval_network_error: "
 
 
-def _bounded_failure_detail(message: str) -> str:
-    """Clamp a failure detail so the emitted rationale fits the schema maxLength.
+def _clamp_to_rationale_budget(text: str, *, reserved: int) -> str:
+    """Clamp `text` so that `reserved + len(result)` fits the rationale maxLength.
 
-    The row builder forms the rationale as ``f"{fault_class}: {detail}"``. A
-    malformed payload's repr embedded in `message` (a >1000-char sub_claim_text,
-    an over-decomposed breakdown, a giant non-string judgment/method) can push
-    the detail past the rationale maxLength, making the fallback row
-    schema-invalid (#355 P2#3). Truncate to a budget that leaves room for the
-    widest fault-class prefix and a truncation marker, preserving the diagnostic
-    head (which says WHICH malformed shape) at the front.
+    Single length-budgeting choke point for every untrusted string that lands in
+    a row's `rationale` (#355 P2#3 / #360). `reserved` is the number of chars the
+    caller will prepend before this text reaches the rationale field:
+
+    - Failure paths emit ``f"{fault_class}: {detail}"`` → reserved = widest
+      fault-class prefix width, so the worst-case composed rationale still fits.
+    - Success paths copy a judge's own `rationale` verbatim onto the row → no
+      prefix → reserved = 0.
+
+    Truncation preserves the diagnostic head (which says WHAT the string is) and
+    marks the dropped tail, so a short string that already fits passes through
+    byte-for-byte.
     """
-    budget = _RATIONALE_MAX_LEN - len(_WIDEST_FAULT_PREFIX)
-    if len(message) <= budget:
-        return message
+    budget = _RATIONALE_MAX_LEN - reserved
+    if len(text) <= budget:
+        return text
     keep = budget - len(_RATIONALE_TRUNC_MARK)
-    return message[:keep] + _RATIONALE_TRUNC_MARK
+    return text[:keep] + _RATIONALE_TRUNC_MARK
+
+
+def _bounded_failure_detail(message: str) -> str:
+    """Clamp a failure detail so ``f"{fault_class}: {detail}"`` fits the maxLength.
+
+    A malformed payload's repr embedded in `message` (a >1000-char
+    sub_claim_text, an over-decomposed breakdown, a giant non-string
+    judgment/method) can push the detail past the rationale maxLength, making the
+    fallback row schema-invalid (#355 P2#3). Budgets against the widest
+    fault-class prefix so the composed rationale fits for every fault class.
+    """
+    return _clamp_to_rationale_budget(message, reserved=len(_WIDEST_FAULT_PREFIX))
+
+
+def _bounded_judge_rationale(rationale: Any) -> str:
+    """Clamp a judge-supplied `rationale` copied verbatim onto a SUCCESS-path row.
+
+    The judge is an LLM with no pre-emission length guarantee; an over-long
+    `rationale` makes a *clean* completed / constraint_violation row
+    schema-invalid (#360 — the success-path parallel to the #359 fallback fix).
+    No fault-class prefix is prepended on the success path, so reserved = 0.
+
+    `_validate_judge_dict` only checks that the `rationale` key is present, not
+    that its value is a string — a JSON-null (or otherwise non-string) rationale
+    passes that gate. Return "" for a non-string value so each caller's existing
+    fallback (`... or "(no rationale provided)"` / the constraint default) takes
+    over, rather than calling len() on it and aborting the audit run.
+    """
+    if not isinstance(rationale, str):
+        return ""
+    return _clamp_to_rationale_budget(rationale, reserved=0)
 
 
 def _active_constraints_for_claim(
@@ -512,7 +548,9 @@ def _judge_result_entry(
 ) -> dict[str, Any]:
     """§4 Steps 5-6: route judge verdict to the right (judgment, defect_stage) row."""
     verdict = judge_result["judgment"]
-    rationale = judge_result.get("rationale", "")
+    # #360: a judge is an LLM with no length guarantee; clamp its rationale to
+    # the schema maxLength before it lands on the completed row (success path).
+    rationale = _bounded_judge_rationale(judge_result.get("rationale", ""))
 
     if verdict == "SUPPORTED":
         judgment, defect_stage, violated_id = "SUPPORTED", None, None
@@ -641,7 +679,10 @@ def _constraint_violation_entry(
         "scoped_manifest_id": scoped_manifest_id,
         "manifest_claim_id": manifest_claim_id,
         "judge_verdict": "VIOLATED",
-        "rationale": judge_result.get("rationale", "Constraint violated by uncited claim."),
+        # #360: clamp the judge-supplied rationale (success path) to maxLength;
+        # `or` default catches a missing/null/empty rationale (schema minLength=1).
+        "rationale": _bounded_judge_rationale(judge_result.get("rationale"))
+        or "Constraint violated by uncited claim.",
         "judge_model": judge_model,
         "judge_run_at": now_iso,
         "rule_version": DRIFT_RULE_VERSION,

--- a/scripts/test_claim_audit_pipeline.py
+++ b/scripts/test_claim_audit_pipeline.py
@@ -43,6 +43,15 @@ _CAR_SCHEMA = load_json_schema(
 )
 _CAR_VALIDATOR = build_schema_validator(_CAR_SCHEMA)
 
+# constraint_violation schema validator — a VIOLATED uncited claim rides in its
+# own aggregate (rationale maxLength=2000 too). Its rationale is also copied
+# straight from untrusted judge output on the success path (#360), so the same
+# overflow can land a schema-invalid constraint_violation row.
+_CV_SCHEMA = load_json_schema(
+    Path(__file__).resolve().parent.parent / "shared/contracts/passport/constraint_violation.schema.json"
+)
+_CV_VALIDATOR = build_schema_validator(_CV_SCHEMA)
+
 
 MANIFEST_ID = "M-2026-05-15T10:00:00Z-a1b2"
 MANIFEST_ID_OTHER = "M-2026-05-15T10:05:00Z-c3d4"
@@ -210,6 +219,22 @@ class _PipelineTestBase(unittest.TestCase):
         }
         defaults.update(kwargs)
         return run_audit_pipeline(**defaults)
+
+    def _validate_passport(
+        self, out: dict[str, Any], manifests: list[dict[str, Any]] | None = None
+    ) -> list[Any]:
+        from scripts.check_claim_audit_consistency import validate_passport
+
+        body = {
+            "claim_intent_manifests": manifests if manifests is not None else [_manifest()],
+            "claim_audit_results": out["claim_audit_results"],
+            "uncited_assertions": out.get("uncited_assertions", []),
+            "claim_drifts": out.get("claim_drifts", []),
+            "constraint_violations": out.get("constraint_violations", []),
+            "audit_sampling_summaries": out.get("audit_sampling_summaries", []),
+            "uncited_audit_failures": out.get("uncited_audit_failures", []),
+        }
+        return validate_passport(body)
 
 
 # ---------------------------------------------------------------------------
@@ -1776,19 +1801,6 @@ class TP24PartialDecomposition(_PipelineTestBase):
     against both the schema and the INV-19 lint.
     """
 
-    def _validate_passport(self, out: dict[str, Any]) -> list[Any]:
-        from scripts.check_claim_audit_consistency import validate_passport
-
-        body = {
-            "claim_intent_manifests": [_manifest()],
-            "claim_audit_results": out["claim_audit_results"],
-            "uncited_assertions": out.get("uncited_assertions", []),
-            "claim_drifts": out.get("claim_drifts", []),
-            "constraint_violations": out.get("constraint_violations", []),
-            "audit_sampling_summaries": out.get("audit_sampling_summaries", []),
-            "uncited_audit_failures": out.get("uncited_audit_failures", []),
-        }
-        return validate_passport(body)
 
     def test_partial_normalizes_to_unsupported_source_description(self) -> None:
         out = self.run_pipeline(citations=[_citation()], judge_fn=_judge_partial())
@@ -1971,6 +1983,155 @@ class TP24PartialDecomposition(_PipelineTestBase):
                 e = out["claim_audit_results"][0]
                 self.assertTrue(e["rationale"].startswith("judge_parse_error"))
                 self.assertEqual(sorted(_CAR_VALIDATOR.iter_errors(e), key=str), [])
+
+
+class TP360JudgeRationaleBoundOnSuccessPath(_PipelineTestBase):
+    """#360: a judge-returned `rationale` is copied onto SUCCESS-path rows with
+    no length bound. A judge is an LLM with no pre-emission length guarantee, so
+    an over-long rationale yields a schema-INVALID row on the *clean* success
+    path — the same defect class as the #359 fallback fix, but on completed /
+    constraint_violation rows rather than the inconclusive fallback. Both
+    success-path rationale assignments MUST clamp to the schema maxLength=2000.
+    """
+
+    # 2500 > 2000 schema maxLength, so an unbounded copy overflows the row.
+    _OVERLONG = "Cited page supports the claim. " + ("y" * 2500)
+
+    def test_completed_row_clamps_overlong_judge_rationale(self) -> None:
+        # SUPPORTED verdict → _judge_result_entry completed row (pipeline line 558).
+        def judge_fn(**kwargs: Any) -> dict[str, Any]:
+            return {"judgment": "SUPPORTED", "rationale": self._OVERLONG}
+
+        out = self.run_pipeline(citations=[_citation()], judge_fn=judge_fn)
+        e = out["claim_audit_results"][0]
+        self.assertEqual(e["judgment"], "SUPPORTED")
+        self.assertEqual(e["audit_status"], "completed")
+        # Diagnostic head preserved (so the bound truncates the tail, not the head).
+        self.assertTrue(
+            e["rationale"].startswith("Cited page supports the claim."),
+            f"clamp must preserve the diagnostic head; got {e['rationale'][:60]!r}",
+        )
+        self.assertLessEqual(
+            len(e["rationale"]), 2000,
+            f"completed-row rationale must fit schema maxLength=2000; got {len(e['rationale'])}",
+        )
+        errors = sorted(_CAR_VALIDATOR.iter_errors(e), key=str)
+        self.assertEqual(
+            errors, [], f"completed row with over-long judge rationale must satisfy schema; got {errors}"
+        )
+        self.assertEqual(self._validate_passport(out), [], "completed row must also be lint-clean")
+
+    def test_completed_row_keeps_short_rationale_verbatim(self) -> None:
+        # Regression guard: a short rationale that never needed truncating must
+        # pass through unchanged (the bound must not mangle the common case).
+        def judge_fn(**kwargs: Any) -> dict[str, Any]:
+            return {"judgment": "SUPPORTED", "rationale": "Cited page contains the figure verbatim."}
+
+        out = self.run_pipeline(citations=[_citation()], judge_fn=judge_fn)
+        e = out["claim_audit_results"][0]
+        self.assertEqual(e["rationale"], "Cited page contains the figure verbatim.")
+        self.assertEqual(sorted(_CAR_VALIDATOR.iter_errors(e), key=str), [])
+
+    def test_constraint_violation_row_clamps_overlong_judge_rationale(self) -> None:
+        # VIOLATED uncited claim → _constraint_violation_entry (pipeline line 644).
+        manifest = _manifest(
+            claims=[
+                {
+                    "claim_id": "C-001",
+                    "claim_text": "Manifest claim about the cohort.",
+                    "intended_evidence_kind": "empirical",
+                    "planned_refs": [],
+                }
+            ],
+            mncs=[{"constraint_id": "MNC-1", "rule": "MUST NOT generalize beyond cohort"}],
+        )
+        sentence = {
+            "sentence_text": "All practitioners benefit.",
+            "section_path": "Discussion",
+        }
+
+        def judge_fn(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "judgment": "VIOLATED",
+                "violated_constraint_id": "MNC-1",
+                "rationale": self._OVERLONG,
+            }
+
+        out = self.run_pipeline(
+            citations=[],
+            manifests=[manifest],
+            uncited_sentences=[],
+            all_uncited_sentences=[sentence],
+            judge_fn=judge_fn,
+        )
+        cv = out["constraint_violations"]
+        self.assertEqual(len(cv), 1, f"exactly one CV row; got {cv!r}")
+        e = cv[0]
+        self.assertTrue(
+            e["rationale"].startswith("Cited page supports the claim."),
+            f"clamp must preserve the diagnostic head; got {e['rationale'][:60]!r}",
+        )
+        self.assertLessEqual(
+            len(e["rationale"]), 2000,
+            f"constraint_violation rationale must fit schema maxLength=2000; got {len(e['rationale'])}",
+        )
+        errors = sorted(_CV_VALIDATOR.iter_errors(e), key=str)
+        self.assertEqual(
+            errors, [], f"constraint_violation row with over-long judge rationale must satisfy schema; got {errors}"
+        )
+        self.assertEqual(self._validate_passport(out, [manifest]), [], "constraint_violation row must also be lint-clean")
+
+
+class TP360NonStringJudgeRationale(_PipelineTestBase):
+    """#360 follow-up: `_validate_judge_dict` accepts a present-but-null
+    `rationale` (it only checks key presence, not value type). The success-path
+    clamp must NOT call len() on a non-string value — a JSON-null rationale from
+    the judge/cache must degrade to the default placeholder, not abort the audit
+    run with TypeError.
+    """
+
+    def test_completed_row_null_rationale_falls_back_to_placeholder(self) -> None:
+        def judge_fn(**kwargs: Any) -> dict[str, Any]:
+            return {"judgment": "SUPPORTED", "rationale": None}
+
+        out = self.run_pipeline(citations=[_citation()], judge_fn=judge_fn)
+        e = out["claim_audit_results"][0]
+        self.assertEqual(e["rationale"], "(no rationale provided)")
+        self.assertEqual(sorted(_CAR_VALIDATOR.iter_errors(e), key=str), [])
+        self.assertEqual(self._validate_passport(out), [])
+
+    def test_constraint_violation_null_rationale_falls_back_to_default(self) -> None:
+        manifest = _manifest(
+            claims=[
+                {
+                    "claim_id": "C-001",
+                    "claim_text": "Manifest claim about the cohort.",
+                    "intended_evidence_kind": "empirical",
+                    "planned_refs": [],
+                }
+            ],
+            mncs=[{"constraint_id": "MNC-1", "rule": "MUST NOT generalize beyond cohort"}],
+        )
+        sentence = {"sentence_text": "All practitioners benefit.", "section_path": "Discussion"}
+
+        def judge_fn(**kwargs: Any) -> dict[str, Any]:
+            return {"judgment": "VIOLATED", "violated_constraint_id": "MNC-1", "rationale": None}
+
+        out = self.run_pipeline(
+            citations=[],
+            manifests=[manifest],
+            uncited_sentences=[],
+            all_uncited_sentences=[sentence],
+            judge_fn=judge_fn,
+        )
+        cv = out["constraint_violations"]
+        self.assertEqual(len(cv), 1, f"exactly one CV row; got {cv!r}")
+        e = cv[0]
+        # Non-empty (schema minLength=1) and schema-valid — the null degraded
+        # to the default, not to None (which would be schema-invalid).
+        self.assertTrue(e["rationale"], "null rationale must degrade to a non-empty default")
+        self.assertEqual(sorted(_CV_VALIDATOR.iter_errors(e), key=str), [])
+        self.assertEqual(self._validate_passport(out, [manifest]), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A judge-returned `rationale` is copied verbatim onto **success-path** rows — completed `claim_audit_result` rows and `constraint_violation` rows — with no length bound. A judge is an LLM with no pre-emission length guarantee, so an over-long rationale makes a *clean* success-path row exceed the schema `maxLength=2000` and become schema-invalid (the row meant to be the well-formed case). Same defect class as the malformed-fallback fix in #359, but on the success path rather than the fallback path; pre-existing, not introduced by #213 / #359.

## What changed

Generalize the #359 clamp into a single length-budgeting choke point `_clamp_to_rationale_budget(text, *, reserved)`:

- `_bounded_failure_detail` (failure path) → `reserved` = widest fault-class prefix width, so `f"{fault_class}: {detail}"` still fits.
- `_bounded_judge_rationale` (success path) → `reserved = 0`, applied at the two success-path rationale write sites (`_judge_result_entry`, `_constraint_violation_entry`).

Both wrappers share one guard; the diagnostic head is preserved and the tail truncated with an explicit marker, so a short rationale passes through byte-for-byte.

### Non-string rationale guard

`_validate_judge_dict` only checks that the `rationale` key is **present**, not that its value is a string — a JSON-null rationale passes that gate. The clamp guards non-string input (returns `""` so each caller's existing fallback takes over) instead of calling `len()` on it and aborting the audit run with `TypeError`. The constraint_violation site gains an `or` default so a null/empty rationale degrades to a non-empty string (schema `minLength=1`).

## Verification

- RED→GREEN + **mutation-verified** for both guards: a no-op clamp re-fails the bound tests (and the #359 fallback test, proving the shared choke point); removing the non-string guard re-fails the null-rationale tests.
- Short-rationale regression guard (common case unchanged, byte-for-byte).
- Full suite **2268 passed / 3 skipped**.
- Independent review + security review both at **0 P1/P2**.

Follow-up from #359 (finding 1 of 2). The other #359 follow-up (cache prompt-versioning) is tracked in #361.

Closes #360