### PR TITLE
fix(disclosure): reground ACL/EMNLP rows to ACL Admin Wiki canonical (#242)

### DIFF
--- a/academic-paper/references/disclosure_mode_protocol.md
+++ b/academic-paper/references/disclosure_mode_protocol.md
@@ -30,7 +30,7 @@ If neither selector is supplied and the pipeline orchestrator does not infer one
 
 ## Why this mode exists
 
-`academic-paper` already ships two generic AI disclosure templates in `journal_submission_guide.md` ("Minimal Disclosure" and "Detailed Disclosure"). Those templates are a good starting point but they are venue-agnostic: they don't know that Nature requires disclosure in the Methods section specifically, that ICLR requires it in the paper body with acknowledgement that "LLMs were used as general-purpose writing tools", or that ACL requires the disclosure in a dedicated "Use of AI Assistance" subsection.
+`academic-paper` already ships two generic AI disclosure templates in `journal_submission_guide.md` ("Minimal Disclosure" and "Detailed Disclosure"). Those templates are a good starting point but they are venue-agnostic: they don't know that Nature requires disclosure in the Methods section specifically, that ICLR requires it in the paper body with acknowledgement that "LLMs were used as general-purpose writing tools", or that ACL requires the disclosure in the Acknowledgements section.
 
 The v3.2 venue track closes the venue-specific gap. The #108 anchor track closes the policy-framework-specific gap that emerges when authors target a policy anchor (PRISMA-trAIce SLR guideline, ICMJE recommendations, Nature Portfolio editorial policy, IEEE author guidelines) rather than a specific journal venue.
 

--- a/academic-paper/references/venue_disclosure_policies.md
+++ b/academic-paper/references/venue_disclosure_policies.md
@@ -1,6 +1,6 @@
 # AI-Usage Disclosure Policy Database — v1
 
-**Snapshot date**: 2026-04-09
+**Snapshot date**: 2026-04-09 (original v1 database build; individual rows carry their own "access date" recording when each was last re-verified)
 **Scope**: v1 covers 6 ML/NLP-focused venues. Education/QA journals deferred to v2.
 **Maintenance**: policies drift. Before submission, the user should verify against the venue's current page. The "source URL" and "access date" below record when ARS last verified each policy.
 
@@ -79,14 +79,14 @@ If the venue is not listed here, the mode halts and asks the user to paste the c
 
 | Field | Value |
 |---|---|
-| Source URL | https://2023.aclweb.org/blog/ACL-2023-policy/ |
-| Access date | 2026-05-24 |
-| Policy summary | ACL requires a dedicated "Limitations" section and allows an optional "Use of AI Assistance" section. Authors must disclose substantive use of AI writing tools. Minor grammar/spell-check tools do not require disclosure. |
-| Required phrasing elements | Must name the tool. Must describe "the extent of use" — was it for drafting, editing, or brainstorming? ACL distinguishes between minor editing and substantive drafting. |
-| Preferred disclosure location | A dedicated **"Use of AI Assistance"** subsection, placed after "Limitations" and before "References" |
-| Prohibited uses | Submitting AI-generated text as the primary intellectual contribution without disclosure |
-| Authorship rule | AI tools cannot be listed as authors |
-| Notes | ACL's "Use of AI Assistance" section is formatted separately from Acknowledgements. The tool should produce both sections if both apply. |
+| Source URL | https://www.aclweb.org/adminwiki/index.php/ACL_Policy_on_Publication_Ethics#Guidelines_for_Generative_Assistance_in_Authorship |
+| Access date | 2026-06-07 |
+| Policy summary | Use of generative AI to create content must be fully disclosed in the **Acknowledgements** section (the policy's own example: "Section 3 was written with inputs from ChatGPT"). Disclosure is graduated by use type: language-only assistance (paraphrasing/polishing) and short-form input assistance (predictive keyboards) do **not** require disclosure; low-novelty text generation and AI-suggested new ideas **do**. AI literature-search tools require no special disclosure but the usual citation-accuracy and thoroughness requirements still apply. Authors are fully responsible for all submitted content. |
+| Required phrasing elements | Name the tool and the specific content it produced (the policy example states the section and the tool). For low-novelty generated text, also affirm the output was checked for accuracy and carries appropriate citations for both the source text and the source idea(s). |
+| Preferred disclosure location | The **Acknowledgements** section (per the ACL Admin Wiki current guidance). The 2023-era separate "Use of AI Assistance" subsection is no longer the canonical location. |
+| Prohibited uses | Listing a generative AI tool as an author. Using automated tools that rephrase existing work as one's own without attribution (treated as plagiarism). Generated text that copies existing work is subject to the plagiarism policy. |
+| Authorship rule | AI tools cannot be listed as authors; ACL does not consider a generative model an entity that can fulfill co-authorship requirements |
+| Notes | Source is the org-wide ACL Admin Wiki policy (ACL Exec-approved, current through 2025), which ARR / EMNLP 2026 link to for current paper-integrity guidance. Supersedes the 2023 ACL conference blog URL (still live but stale: it pointed disclosure at a dedicated subsection rather than Acknowledgements). |
 
 ---
 
@@ -94,14 +94,14 @@ If the venue is not listed here, the mode halts and asks the user to paste the c
 
 | Field | Value |
 |---|---|
-| Source URL | https://2026.emnlp.org/calls/main_conference_papers/ (follows ACL policy) |
-| Access date | 2026-05-23 |
-| Policy summary | EMNLP follows the ACL policy. Same requirements apply. |
+| Source URL | https://2026.emnlp.org/paper-integrity-policy/ (refers authors to ACL's generative-authorship guidelines; canonical text at the ACL Admin Wiki — see ACL row) |
+| Access date | 2026-06-07 |
+| Policy summary | For AI-assistance disclosure, EMNLP refers authors to ACL's generative-authorship guidelines. Same requirements apply. See ACL row. |
 | Required phrasing elements | Same as ACL |
-| Preferred disclosure location | Same as ACL: **"Use of AI Assistance"** subsection |
+| Preferred disclosure location | Same as ACL: the **Acknowledgements** section |
 | Prohibited uses | Same as ACL |
 | Authorship rule | Same as ACL |
-| Notes | EMNLP is co-located with ACL and adopts ACL's policies wholesale. Any update to ACL policy applies here. |
+| Notes | EMNLP 2026 maintains its own Paper Integrity Policy page that refers authors to ACL's generative-authorship guidelines for this issue (and carries additional EMNLP/ARR-specific integrity policies beyond AI disclosure). The canonical source for the AI-disclosure rules below is the ACL Admin Wiki (see ACL row). |
 
 ---
 


### PR DESCRIPTION
## What

Regrounds the ACL and EMNLP AI-disclosure policy rows in `academic-paper/references/venue_disclosure_policies.md` from the 2023 ACL conference blog to ACL's current Exec-approved Admin Wiki policy, and fixes a mirrored mention in `disclosure_mode_protocol.md`.

Closes #242.

## Why

#242 (filed 2026-05-24) flagged that the ACL Admin Wiki is a more recent, more authoritative canonical than the 2023 blog, but was blocked on two concerns that no longer hold:

1. **"Admin Wiki returns 418 to automated verifiers."** Re-verified 2026-06-07: the Admin Wiki returns **HTTP 200** via browser navigation with the full "Guidelines for Generative Assistance in Authorship" section present. The 418 was a curl-UA challenge, not a stable block.
2. **"Humans-vs-tooling URL audience tension."** The repo has **no CI link-checker** (8 workflows, none fetch this URL), so there is no automated verifier to optimize the URL choice against.

The pre-existing ACL row content had also **drifted from current policy**: it said disclosure goes in a dedicated "Use of AI Assistance" subsection, but the current ACL guidance places it in the **Acknowledgements** section.

## Changes

- **ACL row**: Source URL → Admin Wiki anchor; access date 2026-06-07; all content fields regrounded verbatim / closely-paraphrased from the first-party wiki text. Disclosure stated per the wiki's graduated clauses a–f (language-only + short-form not disclosed; literature search no special disclosure but normal citation-accuracy rules apply; low-novelty text + AI-suggested ideas disclosed).
- **EMNLP sibling row**: Source URL → EMNLP 2026 Paper Integrity Policy page (first-party verified, HTTP 200), which refers authors to ACL's generative-authorship guidelines; consolidated to "see ACL row" rather than duplicating.
- **disclosure_mode_protocol.md**: aligned the ACL example prose to Acknowledgements (was mirroring the old subsection wording).
- Top snapshot date clarified as the v1 build date; per-row access dates record re-verification.

## Verification

- First-party: ACL Admin Wiki + EMNLP 2026 Paper Integrity Policy both fetched and read (HTTP 200), content quoted into the rows.
- Lint: `check_policy_anchor_table.py` PASS; 72 disclosure tests PASS.
- Independent cross-model review against the first-party sources corrected two fluent-wrongness overstatements before this PR (literature-search no-disclosure bucket; EMNLP "adopts wholesale").
- No code, schema, or executable logic touched. PII / boundary scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
