### PR TITLE
chore: gitignore local tooling scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 
 # Private ROADMAP is intentionally gitignored and maintained outside this public repo
 ROADMAP.md
+
+# Local tooling scratch directory (not part of the project)
+.gstack/


### PR DESCRIPTION
## What

Adds `.gstack/` to `.gitignore`.

## Why

A local tooling scratch directory can appear at the repo root during development. Without this entry it would land in the public tree on the next commit by anyone running that tooling. Preventive hygiene — the directory is not currently tracked, so no `git rm --cached` is needed.

Split out of #364 (kept that PR single-topic).

## [skip-closes-check]

Justification: pure repo-hygiene change with no corresponding issue. Adds a single `.gitignore` entry to prevent a local scratch directory from being committed to the public tree. There is no stated problem to trace to beyond the hygiene itself; opening an issue solely to satisfy the gate would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
