### PR TITLE
feat(#377): version-consistency lint for SKILL.md last_updated

### DIFF
--- a/scripts/check_spec_consistency.py
+++ b/scripts/check_spec_consistency.py
@@ -83,8 +83,23 @@ def check_claude_md() -> None:
         expect_absent(rel_path, forbidden)
 
 
-def check_reviewer_version_block() -> None:
-    rel_path = "academic-paper-reviewer/SKILL.md"
+# All four skills carry the same frontmatter (`version` / `last_updated`) + Version-Info-table
+# (`| Skill Version |` / `| Last Updated |`) pair. Pre-#377 only the reviewer was policed.
+_SKILL_VERSION_PATHS = (
+    "academic-pipeline/SKILL.md",
+    "academic-paper/SKILL.md",
+    "academic-paper-reviewer/SKILL.md",
+    "deep-research/SKILL.md",
+)
+
+# The single skill whose `version` tracks the suite version. The other three move independently,
+# so only this one's date is sanity-checked against the release (CHANGELOG) in #377(b).
+_SUITE_SKILL_PATH = "academic-pipeline/SKILL.md"
+
+
+def _parse_skill_version_block(rel_path: str) -> tuple[str, str, str, str] | None:
+    """Return (frontmatter_version, frontmatter_last_updated, table_version, table_last_updated)
+    for a SKILL.md, or None (after recording an error) if any surface is unparseable."""
     text = read(rel_path)
     frontmatter_match = re.search(
         r'metadata:\s*[\s\S]*?\n\s+version:\s"([^"]+)"\n\s+last_updated:\s"([^"]+)"',
@@ -92,25 +107,80 @@ def check_reviewer_version_block() -> None:
     )
     if not frontmatter_match:
         fail(f"{rel_path}: could not parse frontmatter version/last_updated")
-        return
-    version, last_updated = frontmatter_match.groups()
+        return None
 
     version_block_match = re.search(r"\| Skill Version \| ([^|]+) \|", text)
     updated_block_match = re.search(r"\| Last Updated \| ([^|]+) \|", text)
     if not version_block_match or not updated_block_match:
         fail(f"{rel_path}: missing Version Info table rows")
+        return None
+
+    version, last_updated = frontmatter_match.groups()
+    return (
+        version,
+        last_updated,
+        version_block_match.group(1).strip(),
+        updated_block_match.group(1).strip(),
+    )
+
+
+def check_skill_version_blocks() -> None:
+    """#377(a): for ALL FOUR SKILL.md, the frontmatter version/last_updated must match the
+    Version-Info-table rows (an internal per-file consistency check)."""
+    for rel_path in _SKILL_VERSION_PATHS:
+        parsed = _parse_skill_version_block(rel_path)
+        if parsed is None:
+            continue
+        version, last_updated, version_block, updated_block = parsed
+        if version != version_block:
+            fail(
+                f"{rel_path}: frontmatter version {version!r} does not match Version Info block {version_block!r}"
+            )
+        if last_updated != updated_block:
+            fail(
+                f"{rel_path}: frontmatter last_updated {last_updated!r} does not match Version Info block {updated_block!r}"
+            )
+
+
+def _latest_changelog_date() -> str | None:
+    """Parse the date of the latest release entry in CHANGELOG.md. The file follows
+    Keep-a-Changelog convention — entries are reverse-chronological under a leading
+    dateless `## [Unreleased]` header — so the FIRST date-bearing
+    `## [X.Y.Z] - YYYY-MM-DD` header is the latest release. `## [Unreleased]` carries no
+    `- YYYY-MM-DD` suffix and so never matches this date-bearing pattern."""
+    match = re.search(rf"^## \[{_VERSION}\] - (\d{{4}}-\d{{2}}-\d{{2}})", read("CHANGELOG.md"), re.M)
+    return match.group(1) if match else None
+
+
+def check_suite_skill_date_sanity() -> None:
+    """#377(b): the suite-tracking skill's `last_updated` must NOT predate the latest CHANGELOG
+    entry date — a release that bumps the suite version but forgets the date fails here.
+
+    Scope is deliberately narrow: only `academic-pipeline/SKILL.md` (the suite-tracking skill) is
+    date-checked. `academic-paper` / `academic-paper-reviewer` / `deep-research` version
+    independently and legitimately keep their own earlier last-change dates, so forcing
+    release-date alignment on them would be wrong (#377 out-of-scope)."""
+    # check_skill_version_blocks() runs first and already parses the suite SKILL. If it recorded
+    # an error for that file (unparseable frontmatter/table), skip rather than re-report the same
+    # root cause from a second re-parse here.
+    if any(e.startswith(f"{_SUITE_SKILL_PATH}:") for e in ERRORS):
         return
 
-    version_block = version_block_match.group(1).strip()
-    updated_block = updated_block_match.group(1).strip()
+    changelog_date = _latest_changelog_date()
+    if changelog_date is None:
+        fail("CHANGELOG.md: could not parse latest release entry date")
+        return
 
-    if version != version_block:
+    parsed = _parse_skill_version_block(_SUITE_SKILL_PATH)
+    if parsed is None:
+        return
+    last_updated = parsed[1]
+
+    # ISO-8601 dates compare correctly as strings (zero-padded, fixed-width).
+    if last_updated < changelog_date:
         fail(
-            f"{rel_path}: frontmatter version {version!r} does not match Version Info block {version_block!r}"
-        )
-    if last_updated != updated_block:
-        fail(
-            f"{rel_path}: frontmatter last_updated {last_updated!r} does not match Version Info block {updated_block!r}"
+            f"{_SUITE_SKILL_PATH}: last_updated {last_updated!r} predates latest CHANGELOG entry "
+            f"date {changelog_date!r} — the suite version bumped but the skill date is stale"
         )
 
 
@@ -532,7 +602,8 @@ def check_reference_docs() -> None:
 def main() -> int:
     check_mode_registry()
     check_claude_md()
-    check_reviewer_version_block()
+    check_skill_version_blocks()
+    check_suite_skill_date_sanity()
     check_pipeline_docs()
     check_architecture_component_version()
     check_readme_sections()

--- a/scripts/test_check_spec_consistency.py
+++ b/scripts/test_check_spec_consistency.py
@@ -517,5 +517,314 @@ class TestArchitectureComponentVersion(unittest.TestCase):
             )
 
 
+# --- #377: SKILL.md frontmatter↔table consistency (all 4) + suite-skill date sanity ---
+
+# Minimal SKILL.md carrying the version-bearing surfaces the #377 check polices: a
+# `metadata:` frontmatter block with `version` / `last_updated`, and a Version-Info table
+# with `| Skill Version |` / `| Last Updated |` rows. Mirrors the real four SKILL.md shape.
+SKILL_TEMPLATE = """\
+---
+name: {name}
+metadata:
+  version: "{fm_ver}"
+  last_updated: "{fm_date}"
+---
+
+# {name}
+
+Body.
+
+## Version Info
+
+| Field | Value |
+|-------|-------|
+| Skill Version | {tbl_ver} |
+| Last Updated | {tbl_date} |
+"""
+
+# The four SKILL.md paths the generalized check must cover, with their real independent
+# versions/dates. `academic-pipeline` tracks the suite; the other three move independently.
+_SKILL_FIXTURES = {
+    "academic-pipeline": ("3.12.0", "2026-06-08"),
+    "academic-paper": ("3.2.0", "2026-06-01"),
+    "academic-paper-reviewer": ("1.10.0", "2026-06-01"),
+    "deep-research": ("2.9.4", "2026-05-18"),
+}
+
+
+def _write_skill_fixtures(root: Path, overrides: dict | None = None) -> None:
+    """Write all four SKILL.md with frontmatter == table by default. `overrides` maps a
+    skill dir to a partial dict of {fm_ver, fm_date, tbl_ver, tbl_date} to introduce drift."""
+    overrides = overrides or {}
+    for skill, (ver, date) in _SKILL_FIXTURES.items():
+        fields = {"fm_ver": ver, "fm_date": date, "tbl_ver": ver, "tbl_date": date}
+        fields.update(overrides.get(skill, {}))
+        (root / skill).mkdir(parents=True, exist_ok=True)
+        (root / skill / "SKILL.md").write_text(
+            SKILL_TEMPLATE.format(name=skill, **fields), encoding="utf-8"
+        )
+
+
+class TestSkillVersionTableConsistency(unittest.TestCase):
+    """#377(a): frontmatter version/last_updated ↔ Version-Info table for ALL FOUR SKILL.md
+    (pre-#377 only academic-paper-reviewer was checked)."""
+
+    def setUp(self) -> None:
+        self._orig_root = csc.ROOT
+        self._orig_errors = list(csc.ERRORS)
+        csc.ERRORS.clear()
+
+    def tearDown(self) -> None:
+        csc.ROOT = self._orig_root
+        csc.ERRORS.clear()
+        csc.ERRORS.extend(self._orig_errors)
+
+    def test_all_four_aligned_passes(self) -> None:
+        """All four SKILL.md with frontmatter matching their table → no errors."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_skill_fixtures(root)
+
+            csc.check_skill_version_blocks()
+
+            self.assertEqual(
+                csc.ERRORS, [], msg=f"unexpected errors on aligned fixtures: {csc.ERRORS!r}"
+            )
+
+    def test_table_date_drift_in_non_reviewer_skill_fails(self) -> None:
+        """The exact #377 root cause: a SKILL whose frontmatter date is bumped but whose table
+        date is left stale must fail — and crucially for a skill OTHER than reviewer (which is
+        the only one the pre-#377 check covered)."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_skill_fixtures(
+                root, overrides={"academic-pipeline": {"tbl_date": "2026-06-01"}}
+            )
+
+            csc.check_skill_version_blocks()
+
+            self.assertTrue(
+                any(
+                    "academic-pipeline/SKILL.md" in e and "2026-06-08" in e and "2026-06-01" in e
+                    for e in csc.ERRORS
+                ),
+                msg=f"expected frontmatter↔table date drift error in: {csc.ERRORS!r}",
+            )
+
+    def test_table_version_drift_fails(self) -> None:
+        """A version (not date) drift between frontmatter and table also fails — for a third
+        skill (deep-research) to prove the check is not reviewer-specific."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_skill_fixtures(
+                root, overrides={"deep-research": {"tbl_ver": "2.9.3"}}
+            )
+
+            csc.check_skill_version_blocks()
+
+            self.assertTrue(
+                any(
+                    "deep-research/SKILL.md" in e and "2.9.4" in e and "2.9.3" in e
+                    for e in csc.ERRORS
+                ),
+                msg=f"expected frontmatter↔table version drift error in: {csc.ERRORS!r}",
+            )
+
+    def test_missing_table_rows_fails(self) -> None:
+        """A SKILL.md that loses its Version-Info table rows must surface rather than silently
+        pass on an empty match."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_skill_fixtures(root)
+            (root / "academic-paper" / "SKILL.md").write_text(
+                '---\nname: academic-paper\nmetadata:\n  version: "3.2.0"\n'
+                '  last_updated: "2026-06-01"\n---\n\nNo version table here.\n',
+                encoding="utf-8",
+            )
+
+            csc.check_skill_version_blocks()
+
+            self.assertTrue(
+                any("academic-paper/SKILL.md" in e and "Version Info" in e for e in csc.ERRORS),
+                msg=f"expected missing-table-rows error in: {csc.ERRORS!r}",
+            )
+
+
+# Minimal CHANGELOG whose latest entry date is the parameter; the suite-date-sanity check
+# compares academic-pipeline/SKILL.md last_updated against this. Two prior entries so the
+# "latest" selection (first `## [X.Y.Z]` after [Unreleased]) is exercised, not just sole-entry.
+CHANGELOG_TEMPLATE = """\
+# Changelog
+
+## [Unreleased]
+
+## [{latest_ver}] - {latest_date} — latest real entry
+
+## [3.11.1] - 2026-06-06 — prior patch
+
+## [3.11.0] - 2026-06-04 — prior minor
+"""
+
+
+def _write_date_sanity_fixtures(
+    root: Path, *, changelog_date: str, pipeline_date: str, changelog_ver: str = "3.12.0"
+) -> None:
+    """Write a CHANGELOG with a known latest-entry date + four SKILL.md where only
+    academic-pipeline's last_updated is the variable under test."""
+    (root / "CHANGELOG.md").write_text(
+        CHANGELOG_TEMPLATE.format(latest_ver=changelog_ver, latest_date=changelog_date),
+        encoding="utf-8",
+    )
+    _write_skill_fixtures(
+        root,
+        overrides={
+            "academic-pipeline": {"fm_date": pipeline_date, "tbl_date": pipeline_date}
+        },
+    )
+
+
+class TestSuiteSkillDateSanity(unittest.TestCase):
+    """#377(b): academic-pipeline/SKILL.md last_updated must be >= the latest CHANGELOG entry
+    date. The other three SKILL.md version independently and are NOT date-policed here."""
+
+    def setUp(self) -> None:
+        self._orig_root = csc.ROOT
+        self._orig_errors = list(csc.ERRORS)
+        csc.ERRORS.clear()
+
+    def tearDown(self) -> None:
+        csc.ROOT = self._orig_root
+        csc.ERRORS.clear()
+        csc.ERRORS.extend(self._orig_errors)
+
+    def test_pipeline_date_equal_to_changelog_passes(self) -> None:
+        """last_updated == latest CHANGELOG date → fine (the normal aligned-release case)."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_date_sanity_fixtures(
+                root, changelog_date="2026-06-08", pipeline_date="2026-06-08"
+            )
+
+            csc.check_suite_skill_date_sanity()
+
+            self.assertEqual(
+                csc.ERRORS, [], msg=f"unexpected errors on aligned date: {csc.ERRORS!r}"
+            )
+
+    def test_pipeline_date_after_changelog_passes(self) -> None:
+        """last_updated strictly AFTER the latest CHANGELOG date is allowed — a post-release
+        doc touch legitimately advances the date past the release entry."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_date_sanity_fixtures(
+                root, changelog_date="2026-06-08", pipeline_date="2026-06-10"
+            )
+
+            csc.check_suite_skill_date_sanity()
+
+            self.assertEqual(
+                csc.ERRORS, [], msg=f"a later last_updated must pass, got: {csc.ERRORS!r}"
+            )
+
+    def test_pipeline_date_before_changelog_fails(self) -> None:
+        """The exact v3.12.0 drift: suite version bumped, last_updated left at the prior release
+        date (earlier than the latest CHANGELOG entry) → must fail."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_date_sanity_fixtures(
+                root, changelog_date="2026-06-08", pipeline_date="2026-06-01"
+            )
+
+            csc.check_suite_skill_date_sanity()
+
+            self.assertTrue(
+                any(
+                    "academic-pipeline/SKILL.md" in e
+                    and "2026-06-01" in e
+                    and "2026-06-08" in e
+                    for e in csc.ERRORS
+                ),
+                msg=f"expected stale-suite-date error in: {csc.ERRORS!r}",
+            )
+
+    def test_date_check_is_bound_to_suite_path_only(self) -> None:
+        """Out-of-scope guard (#377): the date check polices ONLY `_SUITE_SKILL_PATH`. To prove
+        this is genuine scoping and not a vacuous pass, the test demonstrates that the SAME early
+        date is ignored when carried by an independent skill but flagged when carried by whatever
+        path `_SUITE_SKILL_PATH` names — i.e. repointing the constant repoints the policing.
+
+        Fixture: pipeline date is current (2026-06-08, == CHANGELOG); academic-paper carries an
+        early date (2026-06-01 < CHANGELOG). With the real constant the early academic-paper date
+        is NOT flagged; after repointing the constant AT academic-paper, that exact same early
+        date IS flagged. If the check ever fanned out across all four skills, the first assertion
+        would already fail."""
+        orig_suite_path = csc._SUITE_SKILL_PATH
+        try:
+            with TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                csc.ROOT = root
+                _write_date_sanity_fixtures(
+                    root, changelog_date="2026-06-08", pipeline_date="2026-06-08"
+                )
+                # academic-paper keeps its default early date (2026-06-01) from _write_skill_fixtures.
+
+                # Real constant → only pipeline policed; academic-paper's early date is ignored.
+                csc.check_suite_skill_date_sanity()
+                self.assertEqual(
+                    csc.ERRORS, [],
+                    msg=f"independent-skill early date must not be policed, got: {csc.ERRORS!r}",
+                )
+
+                # Repoint the constant at academic-paper → its early date is now the policed one.
+                csc.ERRORS.clear()
+                csc._SUITE_SKILL_PATH = "academic-paper/SKILL.md"
+                csc.check_suite_skill_date_sanity()
+                self.assertTrue(
+                    any(
+                        "academic-paper/SKILL.md" in e and "2026-06-01" in e and "2026-06-08" in e
+                        for e in csc.ERRORS
+                    ),
+                    msg=f"repointed suite path must police academic-paper's early date: {csc.ERRORS!r}",
+                )
+        finally:
+            csc._SUITE_SKILL_PATH = orig_suite_path
+
+    def test_malformed_suite_skill_does_not_double_report(self) -> None:
+        """When the suite SKILL.md is unparseable, check_skill_version_blocks() already records the
+        error; check_suite_skill_date_sanity() must NOT re-report the same root cause from its own
+        re-parse. Drives both checks in order (as main() does) and asserts a single pipeline error."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csc.ROOT = root
+            _write_date_sanity_fixtures(
+                root, changelog_date="2026-06-08", pipeline_date="2026-06-08"
+            )
+            # Strip the suite SKILL's Version-Info table rows so it fails to parse.
+            pipeline_skill = root / "academic-pipeline" / "SKILL.md"
+            text = pipeline_skill.read_text(encoding="utf-8")
+            pipeline_skill.write_text(
+                text.replace("| Skill Version | 3.12.0 |", "").replace(
+                    "| Last Updated | 2026-06-08 |", ""
+                ),
+                encoding="utf-8",
+            )
+
+            csc.check_skill_version_blocks()
+            csc.check_suite_skill_date_sanity()
+
+            pipeline_errors = [e for e in csc.ERRORS if "academic-pipeline/SKILL.md" in e]
+            self.assertEqual(
+                len(pipeline_errors), 1,
+                msg=f"expected exactly one pipeline error, got {len(pipeline_errors)}: {pipeline_errors!r}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #377.

Backstop for the v3.12.0 drift where `academic-pipeline/SKILL.md` bumped its `version` but left `last_updated` at the prior release date — caught only by an independent review pass, not by CI.

## What changed

Two lint checks in `scripts/check_spec_consistency.py`, both deliberately narrow per the issue scope:

**(a) `check_skill_version_blocks()`** — generalizes the pre-#377 reviewer-only frontmatter↔table consistency check to **all four** `SKILL.md`. Each file's frontmatter `version`/`last_updated` must match its Version-Info-table rows. The old `check_reviewer_version_block()` is refactored into a shared `_parse_skill_version_block()` helper + a four-path loop (original reviewer-check semantics preserved).

**(b) `check_suite_skill_date_sanity()`** — for `academic-pipeline/SKILL.md` **only** (the suite-tracking skill), `last_updated` must not predate the latest CHANGELOG release entry date. The other three skills version independently and keep their own earlier last-change dates — **deliberately not** date-policed (forcing release-date alignment there would be wrong, per the issue's explicit out-of-scope note).

## Tests (TDD + mutation)

- 9 fixture-driven tests (`ROOT`-monkeypatched, following the existing `_write_architecture_fixture` pattern).
- Stale suite-skill date fails; date equal-to / after the CHANGELOG passes.
- **Scope guard is non-vacuous**: `test_date_check_is_bound_to_suite_path_only` proves the date check polices only `_SUITE_SKILL_PATH` by repointing the constant and showing the policing follows it — mutation-verified that fanning the check across all four skills makes the guard's first assertion RED.
- `test_malformed_suite_skill_does_not_double_report` covers the de-dup short-circuit (an unparseable suite SKILL is reported once, not twice).

## Wiring

No new workflow step — `spec-consistency.yml` already runs `check_spec_consistency.py` (lint) and `python3 -m unittest scripts.test_check_spec_consistency` (tests); both now exercise the new checks. CI pytest manifest drift-guard unchanged.

## Acceptance (per #377)

- [x] frontmatter↔table consistency for all four SKILL.md
- [x] fails when `academic-pipeline/SKILL.md` `last_updated` predates the latest CHANGELOG date
- [x] independent skills with their own earlier dates pass (out-of-scope guard)
- [x] mutation-tested non-vacuous
- [x] wired into the existing spec-consistency CI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
