### PR TITLE
fix: agent-count claim lint (#414) + announce-hook routing drift (#415)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "academic-research-skills",
   "version": "3.12.0",
-  "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 38-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.10 triangulation policy layer, v3.11 deterministic citation verification gate (#182).",
+  "description": "Production-grade academic research pipeline for Claude Code: research → write → review → revise → finalize. 4 skills, 35+ modes, 39-agent ensemble, v3.7.3 + v3.8 L3 claim-faithfulness gate, v3.9.0 cross-index triangulation, v3.10 triangulation policy layer, v3.11 deterministic citation verification gate (#182).",
   "author": {
     "name": "Cheng-I Wu",
     "url": "https://github.com/Imbad0202"

--- a/scripts/announce-ars-loaded.sh
+++ b/scripts/announce-ars-loaded.sh
@@ -54,15 +54,15 @@ fi
 # ---------------------------------------------------------------------------
 case "${SOURCE}" in
   compact|resume)
-    ANNOUNCE="ARS plugin still loaded after ${SOURCE}. Slash commands: /ars-full /ars-plan /ars-outline /ars-revision /ars-revision-coach /ars-abstract /ars-lit-review /ars-reviewer /ars-format-convert /ars-citation-check /ars-disclosure /ars-mark-read /ars-unmark-read. Plugin agents: synthesis_agent, research_architect_agent, report_compiler_agent."
+    ANNOUNCE="ARS plugin still loaded after ${SOURCE}. Slash commands: /ars-full /ars-plan /ars-outline /ars-revision /ars-revision-coach /ars-abstract /ars-lit-review /ars-reviewer /ars-format-convert /ars-citation-check /ars-disclosure /ars-mark-read /ars-unmark-read /ars-cache-invalidate. Plugin agents: synthesis_agent, research_architect_agent, report_compiler_agent."
     ;;
   startup|clear|*)
     ANNOUNCE="ARS (academic-research-skills) plugin loaded.
 
-Slash commands (13) — model routing pinned in frontmatter:
-  /ars-full              opus    Full pipeline (research → write → review → revise → finalize)
-  /ars-revision-coach    opus    Parse reviewer comments → Revision Roadmap + Response Letter skeleton
-  /ars-reviewer          opus    academic-paper-reviewer full mode — simulated peer-review panel
+Slash commands (14) — light modes pin sonnet in frontmatter; the three heavy modes inherit the session model (the v3.7.0 opus floor was retired in the 2026-06 harness pass):
+  /ars-full              inherit Full pipeline (research → write → review → revise → finalize)
+  /ars-revision-coach    inherit Parse reviewer comments → Revision Roadmap + Response Letter skeleton
+  /ars-reviewer          inherit academic-paper-reviewer full mode — simulated peer-review panel
   /ars-plan              sonnet  Socratic chapter-by-chapter planning
   /ars-outline           sonnet  Detailed outline + evidence map (no full draft)
   /ars-revision          sonnet  Revised draft + R&R responses
@@ -73,6 +73,7 @@ Slash commands (13) — model routing pinned in frontmatter:
   /ars-disclosure        sonnet  Venue-specific AI-usage disclosure statement
   /ars-mark-read         sonnet  Record human-read signal for one or more citation keys
   /ars-unmark-read       sonnet  Rescind a prior human-read mark for one or more citation keys
+  /ars-cache-invalidate  sonnet  Drop cached verification rows for one or more citation keys
 
 Plugin agents (3, v3.6.7-hardened, model: inherit) — dispatched by ARS pipeline:
   synthesis_agent             Cross-source integration, contradiction resolution, gap analysis

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -20,6 +20,10 @@ Invariants enforced:
   7. Every version-bearing H2 heading in docs/<name>.md has a matching
      version-bearing H2 (same version) in docs/<name>.zh-TW.md and vice versa.
      Plain headings may differ — only version TAGS must stay in lockstep.
+  8. The plugin.json description's "N-agent" claim (when present) equals the
+     number of unique *_agent.md files in the tree — symlinks resolved so the
+     agents/ plugin aliases do not double-count (#414: the advertised number
+     had silently drifted from the tree).
 
 Runs from repo root by default; `--path` lets tests point at a fake tree.
 """
@@ -72,6 +76,9 @@ H2_RE = re.compile(r"^##\s+(.*?)\s*$", re.MULTILINE)
 H2_VERSION_RE = re.compile(r"(?<![\w.])v" + _VSEG + r"(?![\d.\-A-Za-z])")
 
 NON_VERSION_CHANGELOG_TOKENS = frozenset({"Unreleased"})
+
+# Invariant 8: the outward-facing agent-count claim, e.g. "38-agent ensemble".
+AGENT_CLAIM_RE = re.compile(r"(\d+)-agent")
 
 PIPELINE_SKILL_NAME = "academic-pipeline"
 
@@ -251,6 +258,10 @@ def check(root: Path) -> list[str]:
     # suite version; pairs each docs/*.md with its docs/*.zh-TW.md sibling).
     errors.extend(_check_zhtw_heading_parity(root))
 
+    # Invariant 8: plugin.json "N-agent" description claim equals the tree's
+    # unique *_agent.md count (independent of suite version).
+    errors.extend(_check_agent_count_claim(root))
+
     return errors
 
 
@@ -405,6 +416,41 @@ def _check_zhtw_heading_parity(root: Path) -> list[str]:
                 f"{en.name} — version drift"
             )
     return errors
+
+
+def _check_agent_count_claim(root: Path) -> list[str]:
+    """Invariant 8 (#414): when plugin.json's description advertises an
+    "N-agent" count, N must equal the number of unique *_agent.md files in
+    the tree. Symlinks are resolved before counting so the agents/ plugin
+    aliases of deep-research agents count once. Missing/malformed manifest or
+    a description without a count claim is NOT an invariant-8 error — the
+    manifest problems are invariant 4's to report, and the claim is optional
+    (only a stated number must be true)."""
+    plugin_json = root / ".claude-plugin" / "plugin.json"
+    if not plugin_json.is_file():
+        return []
+    try:
+        data = json.loads(plugin_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError):
+        return []
+    description = data.get("description")
+    if not isinstance(description, str):
+        return []
+    m = AGENT_CLAIM_RE.search(description)
+    if m is None:
+        return []
+    claimed = int(m.group(1))
+    actual = len({
+        p.resolve()
+        for p in root.rglob("*_agent.md")
+        if ".git" not in p.parts
+    })
+    if claimed != actual:
+        return [
+            f"{plugin_json}: description claims {claimed}-agent but the tree "
+            f"has {actual} unique *_agent.md files (symlinks deduplicated)"
+        ]
+    return []
 
 
 def main() -> int:

--- a/scripts/test_check_version_consistency.py
+++ b/scripts/test_check_version_consistency.py
@@ -80,13 +80,20 @@ def _write_changelog(
     )
 
 
-def _write_plugin_manifests(root: Path, version: str) -> None:
-    """Fixture .claude-plugin/{plugin,marketplace}.json at `version` (invariant 4)."""
+def _write_plugin_manifests(
+    root: Path, version: str, description: str | None = None
+) -> None:
+    """Fixture .claude-plugin/{plugin,marketplace}.json at `version` (invariant 4).
+    `description` (when given) lands in plugin.json for the invariant-8
+    "N-agent" claim tests."""
     import json
     plugin_dir = root / ".claude-plugin"
     plugin_dir.mkdir(parents=True, exist_ok=True)
+    plugin_obj: dict[str, str] = {"name": "fixture", "version": version}
+    if description is not None:
+        plugin_obj["description"] = description
     (plugin_dir / "plugin.json").write_text(
-        json.dumps({"name": "fixture", "version": version}), encoding="utf-8"
+        json.dumps(plugin_obj), encoding="utf-8"
     )
     (plugin_dir / "marketplace.json").write_text(
         json.dumps({"name": "fixture", "plugins": [{"name": "fixture", "version": version}]}),
@@ -702,6 +709,84 @@ class TestVersionConsistency(unittest.TestCase):
             result = _run(root)
             self.assertEqual(result.returncode, 1, msg=f"stdout={result.stdout!r}")
             self.assertIn("3.4.0", result.stdout)
+
+
+class TestAgentCountClaim(unittest.TestCase):
+    """Invariant 8 (#414): plugin.json description "N-agent" claim equals the
+    tree's unique *_agent.md count (symlinks resolved, not double-counted)."""
+
+    @staticmethod
+    def _write_agents(root: Path, names: list[str]) -> None:
+        agents_dir = root / "deep-research" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (agents_dir / f"{name}_agent.md").write_text(
+                f"# {name}\n", encoding="utf-8"
+            )
+
+    def test_agent_claim_drift_fails(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            _write_plugin_manifests(
+                root, "3.5.0", description="fixture, 3-agent ensemble, more"
+            )
+            self._write_agents(root, ["alpha", "beta"])
+            result = _run(root)
+            self.assertEqual(result.returncode, 1, msg=f"stdout={result.stdout!r}")
+            self.assertIn("3-agent", result.stdout)
+            self.assertIn("2", result.stdout)
+
+    def test_agent_claim_matching_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            _write_plugin_manifests(
+                root, "3.5.0", description="fixture, 2-agent ensemble, more"
+            )
+            self._write_agents(root, ["alpha", "beta"])
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+
+    def test_agent_claim_symlink_alias_not_double_counted(self) -> None:
+        """A symlink alias of a real agent file (the agents/ plugin-dir
+        pattern) resolves to the same target and counts once."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            _write_plugin_manifests(
+                root, "3.5.0", description="fixture, 2-agent ensemble, more"
+            )
+            self._write_agents(root, ["alpha", "beta"])
+            link_dir = root / "agents"
+            link_dir.mkdir()
+            (link_dir / "alpha_agent.md").symlink_to(
+                root / "deep-research" / "agents" / "alpha_agent.md"
+            )
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+
+    def test_no_agent_claim_skips(self) -> None:
+        """A description without an N-agent token is not gated (the claim is
+        optional; only a stated number must be true)."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_aligned_fixture(root)
+            _write_plugin_manifests(
+                root, "3.5.0", description="fixture without a count claim"
+            )
+            self._write_agents(root, ["alpha", "beta"])
+            result = _run(root)
+            self.assertEqual(
+                result.returncode, 0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Two fixes from the external audit issues (both verified against the current tree before fixing):

1. **Agent-count claim drift.** plugin.json advertised "38-agent ensemble"; the tree has 39 unique `*_agent.md` files (42 minus the 3 `agents/` symlink aliases). Number corrected, and a new `check_version_consistency.py` **invariant 8** pins it: when the description carries an "N-agent" claim, N must equal the tree's unique agent-file count (symlinks resolved so plugin aliases never double-count; a description without a count claim is not gated). Closes #414

2. **Announce-hook routing drift.** The hook labeled the three heavy modes `opus` and said "model routing pinned in frontmatter", but the v3.7.0 opus floor was retired in the 2026-06 harness pass — those commands inherit the session model and carry no pin. The table now says `inherit` with the light/heavy split stated precisely. Also found while fixing: the hook claimed 13 slash commands while `commands/` has 14 (`/ars-cache-invalidate`, added in v3.11, was missing from both announce variants); added. `docs/PERFORMANCE.md` needed no change — it already carries the "measured on Opus 4.x … April 2026, order-of-magnitude anchors" stamp the report asked for. Closes #415

## Tests

TDD on invariant 8: drift-fires, matching-passes, symlink-dedup, no-claim-skips. The new lint caught the real 38-vs-39 drift on the actual tree before the number was corrected (mutation evidence). Full suite: 2535 passed / 3 skipped / 1 xfailed. Hook smoke-tested via stdin SessionStart payload; `check_version_consistency.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
