### PR TITLE
docs: note Windows symlink install caveat

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -201,6 +201,26 @@ The four skills (`deep-research`, `academic-paper`, `academic-paper-reviewer`, `
 
 **Strongly recommended: open auto-update.** Open the `/plugin` UI, find `academic-research-skills`, and toggle auto-update on. ARS releases roughly every 1–2 weeks; auto-update keeps you in sync without manual refreshes. To refresh manually: `/plugin update academic-research-skills`. (`/plugin marketplace update academic-research-skills` only refreshes the marketplace source list, not the installed plugin itself.)
 
+**Windows / zip-download symlink note:** the plugin surface includes three top-level agent entrypoints under `agents/`:
+
+- `agents/synthesis_agent.md`
+- `agents/research_architect_agent.md`
+- `agents/report_compiler_agent.md`
+
+These are relative symlinks into `deep-research/agents/` so the hardened downstream-agent prompts have one source of truth. Use the plugin marketplace install above, WSL, or a Git checkout with symlink support enabled. Avoid GitHub's **Download ZIP** path for plugin execution, and avoid Windows checkouts where symlinks are disabled (`core.symlinks=false`): those environments can materialize each entrypoint as a one-line text file containing only the target path, which breaks agent discovery silently.
+
+Quick local check:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+for path in Path("agents").glob("*_agent.md"):
+    print(path, "symlink" if path.is_symlink() else "regular file")
+PY
+```
+
+If those files are not symlinks, reinstall through the plugin marketplace, use WSL, or enable Windows Developer Mode + `git config --global core.symlinks true` and reclone the repository.
+
 **Plugin platform scope:**
 - ✅ Claude Code CLI / VS Code extension / JetBrains extension — full support
 - ❌ claude.ai web / Claude for Work / Anthropic API direct calls — plugins not supported; use Method 1 / 2 / 3 below


### PR DESCRIPTION
## Summary
- Document the Windows / ZIP-download caveat for the three top-level plugin agent symlinks under `agents/`.
- Add a quick local check that shows whether the three entrypoints materialized as symlinks or regular files.
- Point users toward plugin marketplace install, WSL, or Windows symlink-enabled Git checkouts.

## Motivation
On Windows checkouts without symlink support, and in GitHub ZIP downloads, the relative symlinks in `agents/` can materialize as one-line text files containing only the target path. That silently breaks plugin agent discovery. This PR follows the issue's lower-risk option: document the constraint clearly instead of changing the source-of-truth symlink layout.

Closes #413

## Verification
- Ran `git diff --check`.
- Checked that `docs/SETUP.md` includes the three affected agent paths, the `core.symlinks=false` caveat, and the Windows Developer Mode remediation.

## Risk
Docs-only change. No plugin packaging or agent prompt files are changed.
