### PR TITLE
Add teaching-side companion link (Teaching Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ ARS Stage 2 WRITE     →  write paper with verified experiment results
 
 **Stage 1 intake declaration (#260)**: at Stage 1, ARS detects whether the run will carry experiment-backed claims and sets a fail-closed `experiment_intake_declaration` on the Material Passport. If you ran experiments externally, the scholar enters one `experiment_provenance[]` entry per experiment (`experiment_id`, nested `repro_lock`, `planned_vs_executed[]`, `negative_results[]`, `known_limitations[]`) and the declaration is set to `experiments_declared`; if not, it is set to `no_experiments_declared`. The declaration is **required on every post-#260 passport** — a run that touches no experiments still declares `no_experiments_declared`, so the integrity gate can never be silently bypassed by a forgotten provenance block. The `experiment_id`s are frozen at this intake point; the writers later reference them via `planned_experiment_ids[]`.
 
+**Teaching-side companion**: [Teaching Skills](https://github.com/YujxZJCN/teaching-skills) applies the ARS architecture (skill ensembles, shared contracts, staged gates, a Course Passport) to the teaching side of academic life — course design → lessons → assessment → delivery → reflection; its `sotl` mode hands classroom-inquiry projects off to ARS deep-research / academic-paper for the publication phase.
+
 ---
 
 ## Usage


### PR DESCRIPTION
As invited in discussion #417 — adds a one-line teaching-side companion reference at the end of the Companion section, matching the experiment-agent slot's framing: what it is, and the SoTL seam where the two suites hand off.

No other changes.