### PR TITLE
Add CITATION.cff for "Cite this repository" support (#434)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+# This CITATION.cff describes how to cite this specific version of the software.
+# The license field reflects the license of THIS version, not a permanent
+# project-wide commitment — future versions may carry different terms.
+# See https://citation-file-format.github.io/ for the schema.
+cff-version: 1.2.0
+title: Academic Research Skills for Claude Code
+message: >-
+  If you use this software in your research, please cite it
+  using the metadata from this file.
+type: software
+authors:
+  - family-names: Wu
+    given-names: Cheng-I
+repository-code: https://github.com/Imbad0202/academic-research-skills
+url: https://github.com/Imbad0202/academic-research-skills
+abstract: >-
+  A source-available academic research copilot framework for
+  noncommercial scholarly use. A suite of Claude Code skills that
+  assists human researchers through the full research-to-publication
+  pipeline: research, write, integrity-check, review, revise, finalize.
+keywords:
+  - academic-research
+  - claude-code
+  - research-workflow
+  - literature-review
+  - citation-verification
+  - peer-review
+  - scholarly-writing
+license: CC-BY-NC-4.0
+version: 3.12.1
+date-released: 2026-06-15
+# After enabling Zenodo, add the concept DOI here so GitHub's
+# "Cite this repository" button and downstream tools resolve to a
+# permanent identifier, e.g.:
+# doi: 10.5281/zenodo.XXXXXXX


### PR DESCRIPTION
## What

Adds a `CITATION.cff` so GitHub renders a **"Cite this repository"** button in the sidebar and citation tools (Zotero, GitHub API, etc.) can resolve structured metadata. Requested in #434.

## Design notes

- **Mirrors the existing `POSITIONING.md` citation** (Wu, C.-I. / repo URL), bumped to the current suite version **v3.12.1** (POSITIONING still reads v3.8 — a separate doc-alignment fix).
- **License field is version-scoped on purpose.** The file header states the `license:` reflects *this version's* terms, not a permanent project-wide commitment — so future relicensing or dual-licensing (cf. the standing dual-licensing backlog) is not pre-constrained by the citation metadata.
- **Zenodo DOI placeholder.** A commented `doi:` line marks where the Zenodo concept DOI goes once GitHub→Zenodo archiving is enabled (the other half of #434, which needs a manual OAuth step on zenodo.org).

## Validation

- `cff-version: 1.2.0`, required fields present, `license: CC-BY-NC-4.0` (valid SPDX), YAML parses clean.

Closes #434 partially (CITATION.cff half; Zenodo enablement tracked separately in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)