### PR TITLE
Add Zenodo DOI (#434)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,7 +29,6 @@ keywords:
 license: CC-BY-NC-4.0
 version: 3.12.1
 date-released: 2026-06-15
-# After enabling Zenodo, add the concept DOI here so GitHub's
-# "Cite this repository" button and downstream tools resolve to a
-# permanent identifier, e.g.:
-# doi: 10.5281/zenodo.XXXXXXX
+# Zenodo concept DOI — represents all versions, always resolves to the latest.
+# (The v3.12.1 version DOI is 10.5281/zenodo.20696615.)
+doi: 10.5281/zenodo.20696614

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -76,5 +76,5 @@ These reflect our policy intent. See the [CC BY-NC 4.0 license](https://creative
 If you use ARS in your research, please cite it:
 
 ```
-Wu, C.-I. (2026). Academic Research Skills for Claude Code (Version 3.12.1) [Computer software]. https://github.com/Imbad0202/academic-research-skills
+Wu, C.-I. (2026). Academic Research Skills for Claude Code (Version 3.12.1) [Computer software]. Zenodo. https://doi.org/10.5281/zenodo.20696615
 ```

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,6 +1,7 @@
 # Claude Code 向け Academic Research Skills
 
 [![Version](https://img.shields.io/badge/version-v3.12.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.12.1)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20696614.svg)](https://doi.org/10.5281/zenodo.20696614)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Academic Research Skills for Claude Code
 
 [![Version](https://img.shields.io/badge/version-v3.12.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.12.1)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20696614.svg)](https://doi.org/10.5281/zenodo.20696614)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Academic Research Skills for Claude Code
 
 [![Version](https://img.shields.io/badge/version-v3.12.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.12.1)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20696614.svg)](https://doi.org/10.5281/zenodo.20696614)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,7 @@
 # Academic Research Skills for Claude Code
 
 [![Version](https://img.shields.io/badge/version-v3.12.1-blue)](https://github.com/Imbad0202/academic-research-skills/releases/tag/v3.12.1)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20696614.svg)](https://doi.org/10.5281/zenodo.20696614)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](https://creativecommons.org/licenses/by-nc/4.0/)
 [![Sponsor](https://img.shields.io/badge/sponsor-Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/crucify020v)
 


### PR DESCRIPTION
Closes #434.

Zenodo archived the v3.12.1 release and minted DOIs. This wires the right DOI per use case.

## Changes

- **CITATION.cff** — `doi: 10.5281/zenodo.20696614` (the **concept DOI**: represents all versions, always resolves to the latest, so it needs no edit on future releases). Drives GitHub's "Cite this repository" button.
- **README badge ×4** (EN / zh-TW / zh-CN / ja-JP) — the same concept-DOI Zenodo badge, added in lockstep after the Version badge.
- **POSITIONING citation** — `https://doi.org/10.5281/zenodo.20696615` (the **version DOI**, pinning Version 3.12.1 specifically — the academically precise reference for a cited version), routed through Zenodo instead of the bare GitHub URL.

## Verification

- First-party DOI check (via browse): the DOI resolves to the ARS Zenodo record — title "Academic Research Skills for Claude Code", author Wu, Cheng-I, version v3.12.1, repo URL match.
- `check_version_consistency.py` green; four-language badges in sync.

This completes the #434 request (CITATION.cff shipped earlier in #440; Zenodo enablement + DOI wiring here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)