### PR TITLE
fix(#448): anchor infra self-protection on plugin root, not the user's project

### DIFF
--- a/docs/design/2026-06-16-448-infra-protection-plugin-root-scope-spec.md
+++ b/docs/design/2026-06-16-448-infra-protection-plugin-root-scope-spec.md
@@ -1,0 +1,119 @@
+# #448 — Scope infra self-protection to the plugin root, not the user's project
+
+**Status:** spec for the fix branch `fix/448-infra-protection-plugin-root`
+**Affects:** `scripts/ars_write_scope_guard.py` (the #134 write-scope guard), its tests.
+**Eval impact:** none (no scoring / generation / gold-set change).
+
+## Problem
+
+Issue #448 (two independent external reporters: `philpav`, `herman925`): after installing
+the ARS plugin, Claude can no longer edit the user's own project-root `CLAUDE.md`.
+
+### Root cause (first-party verified — codex ran the decision function)
+
+`scripts/ars_write_scope_guard.py` is a PreToolUse hook. Step 2 of `evaluate_decision`
+denies any write whose normalized path matches `INFRA_PROTECTED_GLOBS` **unconditionally**
+— before agent gating, so it applies even to the trusted main session:
+
+```python
+if _infra_protected(rel):       # rel is relative to workspace_root
+    return DENY
+```
+
+`workspace_root = os.environ.get("CLAUDE_PROJECT_DIR") or payload.cwd or os.getcwd()`.
+
+Under a plugin install, `CLAUDE_PROJECT_DIR` is the **user's project**, not the ARS plugin
+directory (`CLAUDE_PLUGIN_ROOT`). `INFRA_PROTECTED_GLOBS` carries `"CLAUDE.md"` and
+`".claude/CLAUDE.md"` to protect ARS's *own* repo CLAUDE.md (which describes the guard
+binding) from being edited by an agent. But matched against the *user's* project root, the
+user's own `CLAUDE.md` matches and is denied — even from the main session. That is the bug.
+
+### Scope is wider than `CLAUDE.md`
+
+`CLAUDE.md` is merely the first entry users hit. The real defect is a **root-boundary
+error**: Step 2 matches *plugin* infra filenames against *user-project* paths. Other infra
+entries that can plausibly also exist in a user repo — `hooks/hooks.json`, `hooks/*.sh`,
+`.claude-plugin/plugin.json`, and especially `shared/agents/*.md` — would be misfired the
+same way. The fix must address the boundary, not just `CLAUDE.md`.
+
+## Design (Fix C — dual root)
+
+The two enforcement surfaces have **different anchors**, and conflating them is the bug:
+
+- **Bucket-A phase-scope** (Step 4) fences the 23 single-phase agents to *their own
+  phaseN_ dir inside the user's project*. Anchor: `workspace_root` (= `CLAUDE_PROJECT_DIR`).
+  **Unchanged.**
+- **Infra self-protection** (Step 2) protects *the ARS plugin's own enforcement files* from
+  tampering. Those files live under the plugin install dir. Anchor: **`plugin_root`**.
+
+### Changes
+
+1. `evaluate_decision(payload, manifest, workspace_root, plugin_root)` gains a `plugin_root`
+   parameter (pure function, fully testable). `plugin_root` may be `None` (callers that
+   cannot determine it — see #4) → infra protection still runs against `workspace_root` as
+   the conservative fallback (preserves the pre-fix protective behavior when the plugin and
+   project root coincide, e.g. ARS developing ARS).
+
+2. Step 2 becomes plugin-root-scoped. Resolve the write target's real absolute path once.
+   It is an infra target **iff** it resolves inside `plugin_root` AND its plugin-root-relative
+   path matches `INFRA_PROTECTED_GLOBS`. A target outside `plugin_root` (the normal case for
+   a user project where plugin_root ≠ workspace_root) is never an infra target.
+
+3. When `plugin_root == workspace_root` (ARS repo developing itself, or fallback), behavior
+   is **byte-equivalent to pre-fix**: every infra glob still matches at the workspace root,
+   so the guard still protects its own files during ARS development. The fix only *narrows*
+   the false-positive on a *separate* user project — it does not loosen self-protection on
+   the home turf.
+
+4. `main()` computes `plugin_root` from `os.environ.get("CLAUDE_PLUGIN_ROOT")`, else
+   `Path(__file__).resolve().parents[1]` (scripts/ → repo root; `.claude-plugin/plugin.json`
+   lives there, confirming it is the plugin root). This is robust for both install tracks
+   (plugin via `CLAUDE_PLUGIN_ROOT`; git-clone+symlink via the file location).
+
+### Why not Fix A (remove CLAUDE.md from infra, deny only for Bucket A)
+
+A only patches `CLAUDE.md`; the same root-boundary defect remains for `hooks/*.sh`,
+`shared/agents/*.md`, etc. in a user project. It treats the symptom. (codex concurred.)
+
+### Why not Fix B (fingerprint the ARS repo by a sibling file)
+
+Brittle: false positives in vendored/copied projects, false negatives if the layout moves,
+undefined in monorepos / nested ARS checkouts, and extra filesystem work on the hot path.
+It also treats a symptom rather than the boundary. (codex concurred.)
+
+## Threat-model check (does Fix C reopen the guard-disable path?)
+
+The infra protection exists so a Bucket A agent cannot edit ARS's own enforcement files to
+neuter the guard. Under Fix C those files are still protected because they resolve inside
+`plugin_root`. A Bucket A agent in a user project:
+
+- Cannot write outside its `phaseN_` dir (Step 4, unchanged) — so it cannot reach a
+  user-project-root `CLAUDE.md` anyway.
+- Cannot run Bash at all (wholesale deny, unchanged).
+- Cannot reach the plugin's own files unless they happen to sit inside a phase dir (they do
+  not).
+
+So Fix C does not reopen any real attack path. The only behavior it *changes* is: the **main
+session** (and Bucket B/C/D) in a **user project** may now edit that project's own
+`CLAUDE.md` / `hooks/*.sh` / `shared/agents/*.md` — which they always should have been able
+to, and which they could already do via Bash regardless.
+
+## Test plan (red → green)
+
+New cases in `scripts/test_ars_write_scope_guard.py`, all with `plugin_root != workspace_root`:
+
+1. **RED before fix:** main session writes `<workspace>/CLAUDE.md` with
+   `plugin_root=<elsewhere>` → must be ALLOW (pre-fix: DENY).
+2. main session writes `<workspace>/.claude/CLAUDE.md` → ALLOW.
+3. main session writes `<workspace>/shared/agents/foo.md` → ALLOW (user project collision).
+4. main session writes `<workspace>/hooks/hooks.json` → ALLOW (user project).
+5. **Self-protection preserved:** any actor writes `<plugin_root>/CLAUDE.md` (target inside
+   plugin root) → DENY. (Set `workspace_root == plugin_root` to model ARS-on-ARS, OR pass a
+   target that resolves into plugin_root.)
+6. **Self-protection preserved:** write `<plugin_root>/scripts/ars_write_scope_guard.py` → DENY.
+7. **Fallback:** `plugin_root=None` with target `<workspace>/CLAUDE.md` → DENY (conservative,
+   == pre-fix).
+8. **Bucket A unchanged:** bucket-A agent writing its own `phase2_x/notes.md` → ALLOW;
+   writing `phase3_x/notes.md` → DENY (phase-scope intact).
+
+All existing tests must still pass (the manifest-driven phase-scope behavior is untouched).

--- a/scripts/ars_write_scope_guard.py
+++ b/scripts/ars_write_scope_guard.py
@@ -47,6 +47,7 @@ import fnmatch
 import json
 import os
 import sys
+from pathlib import Path
 
 MANIFEST_FILENAME = "ars_phase_scope_manifest.json"
 
@@ -80,12 +81,17 @@ INFRA_PROTECTED_GLOBS = [
     "**/check_v3_10_134_write_scope.py",  # the three-way name cross-check lint
     "check_v3_10_134_write_scope.py",
     # Agent definition files: the agent_type==name binding lives in their frontmatter;
-    # renaming an agent out of the manifest would fail the guard open.
+    # renaming an agent out of the manifest would fail the guard open. Covers the per-skill
+    # source dirs, the shared dir, AND the top-level plugin-shipped `agents/` dir (the
+    # #413-materialized byte-identical copies — these carry the same name binding and were
+    # previously unprotected; closed in #448 when the plugin-root anchoring re-established
+    # which files count as plugin infra).
     "deep-research/agents/*.md",
     "academic-paper/agents/*.md",
     "academic-paper-reviewer/agents/*.md",
     "academic-pipeline/agents/*.md",
     "shared/agents/*.md",
+    "agents/*.md",
     ".claude/CLAUDE.md",
     "CLAUDE.md",
 ]
@@ -193,9 +199,46 @@ def _matches_any(rel_path, globs):
     return False
 
 
-def _infra_protected(rel_path):
-    """Step 2 — is the normalized target part of the enforcement surface?"""
-    return _matches_any(rel_path, INFRA_PROTECTED_GLOBS)
+def _infra_protected_target(raw_path, cwd, plugin_root):
+    """Step 2 — is the write target one of the ARS plugin's OWN enforcement files?
+
+    #448 root-cause fix: infra self-protection must be anchored to the PLUGIN root, not
+    the user's PROJECT root. The two enforcement surfaces have different anchors:
+      * Bucket A phase-scope (Step 4) fences agents to their phaseN_ dir inside the USER'S
+        project — anchored on workspace_root (= CLAUDE_PROJECT_DIR).
+      * Infra self-protection (here) protects the ARS plugin's own files from tampering —
+        those live under the plugin install dir, so it MUST be anchored on plugin_root.
+    Conflating them was the bug: matching the plugin's infra filenames (`CLAUDE.md`,
+    `hooks/*.sh`, `shared/agents/*.md`, ...) against a user PROJECT path denied the user's
+    own same-named files — even from the trusted main session.
+
+    A target is an infra target IFF it resolves INSIDE plugin_root AND its plugin-root-
+    relative path matches INFRA_PROTECTED_GLOBS. A target outside plugin_root (the normal
+    case in a user project where plugin_root != workspace_root) is never an infra target.
+
+    A None plugin_root here returns False ("no infra root known -> not infra-protected").
+    evaluate_decision never calls in with None — it substitutes workspace_root first — so
+    this is a pure defensive guard, not a path any real caller exercises.
+    """
+    if not plugin_root:
+        return False
+    # Resolve the target the SAME way _normalize_target does (realpath, tolerant of a
+    # not-yet-created leaf), but anchored on plugin_root instead of workspace_root.
+    rp = raw_path
+    if not os.path.isabs(rp):
+        rp = os.path.join(cwd, rp)
+    normalized = os.path.realpath(rp)
+    real_plugin = os.path.realpath(plugin_root)
+    try:
+        common = os.path.commonpath([normalized, real_plugin])
+    except ValueError:
+        return False  # different drives -> cannot be inside plugin root
+    if common != real_plugin:
+        return False  # target resolves OUTSIDE the plugin root -> not an infra file
+    rel = os.path.relpath(normalized, real_plugin)
+    if rel == ".":
+        return False  # the plugin root dir itself is not an enumerated infra FILE
+    return _matches_any(rel, INFRA_PROTECTED_GLOBS)
 
 
 def _allow_unconstrained(agent_type):
@@ -222,20 +265,35 @@ def _extract_structured_target(tool_input):
     return fp if isinstance(fp, str) and fp else None
 
 
-def evaluate_decision(payload, manifest, workspace_root):
+def evaluate_decision(payload, manifest, workspace_root, plugin_root=None):
     """Pure decision function implementing the spec §3.2 logic (Bash policy per §7, shipped).
 
     Returns a dict: {"decision": "allow"|"deny", "reason": str, ...advisory flags}.
 
     Two enforcement paths:
-      * Structured tools (Write/Edit/MultiEdit) — deterministic write-scope: normalize the
-        single top-level file_path FIRST, then infra self-protection, then Bucket A glob.
+      * Structured tools (Write/Edit/MultiEdit) — deterministic write-scope: extract the
+        single top-level file_path, run infra self-protection FIRST (anchored on plugin_root,
+        #448), then normalize against workspace_root for the escape check, then Bucket A glob.
       * Bash — DENY ALL for a Bucket A agent (spec §3.2 Step-4 hardening: neither a denylist
         of "mutation-capable" Bash nor an allowlist of "read-only" Bash is sound, because
         neither property is stable across commands/flags/env/versions; only all-deny reaches
         zero fail-open by construction). The agent uses the Grep/Glob tools for search and the
         structured tools for writes. Non-Bucket-A Bash passes through.
+
+    plugin_root (#448): the ARS plugin install dir, used to anchor infra self-protection
+    (Step 2). main() ALWAYS supplies a concrete root (CLAUDE_PLUGIN_ROOT or the resolved
+    repo root), so the None default exists only for the ARS-on-ARS unit tests and for any
+    caller that genuinely cannot determine a plugin root.
+
+    When None, infra protection falls back to workspace_root. This is correct ONLY when the
+    plugin and the workspace are the same tree (ARS developing ARS): it then reproduces the
+    pre-#448 behavior byte-for-byte. It is NOT a safe default under a real plugin install
+    (plugin_root != workspace_root) — there it would both re-deny the user's own CLAUDE.md
+    and FAIL to protect plugin infra (those files are mere workspace escapes). So a real
+    runtime caller MUST pass plugin_root; do not rely on this fallback off the home turf.
     """
+    if not plugin_root:
+        plugin_root = workspace_root
     # The pure core defends itself too — not only main() — so a non-dict payload (`[]`,
     # null, a string) passed straight to evaluate_decision can't crash on `.get` (review).
     if not isinstance(payload, dict):
@@ -282,6 +340,27 @@ def evaluate_decision(payload, manifest, workspace_root):
                        "fail-open. Re-verify the tool_input shape."),
             "schema_drift_advisory": True,
         }
+    # --- Step 2: infrastructure self-protection (anchored on plugin_root). RUNS FIRST,
+    #     BEFORE the user-workspace escape check. ---
+    # #448: anchored on the PLUGIN root, not the user's PROJECT root. Two reasons it must
+    # precede the escape check:
+    #   (a) Under a plugin install, the plugin's own files live OUTSIDE the user workspace,
+    #       so they are "escaped" relative to workspace_root — the escape branch would let a
+    #       main-session write to them through. Checking infra first keeps them protected
+    #       wherever they physically sit.
+    #   (b) A target inside the USER's project that merely shares a filename with an ARS infra
+    #       file (the user's own CLAUDE.md / hooks/*.sh / shared/agents/*.md) resolves OUTSIDE
+    #       plugin_root, so _infra_protected_target returns False and it is left to Step 3/4 —
+    #       which is exactly the #448 fix.
+    # _infra_protected_target resolves the target on its own (realpath, anchored on
+    # plugin_root) so it is correct regardless of the workspace-relative `escaped` flag.
+    if _infra_protected_target(raw, cwd, plugin_root):
+        return {
+            "decision": "deny",
+            "reason": (f"ARS scope guard: {raw} is part of the ARS plugin's enforcement "
+                       "infrastructure and may not be written by any agent."),
+        }
+
     rel, escaped = _normalize_target(raw, cwd, workspace_root)
     if escaped:
         # The escape / path-traversal deny is a BUCKET A FENCE, not a global one (#302).
@@ -291,11 +370,9 @@ def evaluate_decision(payload, manifest, workspace_root):
         # the workspace root and MUST be allowed — fencing it here contradicted the Step-3
         # "unconstrained by Slice 1" gate below. So: only a Bucket A agent is denied for an
         # escape; a non-Bucket-A actor falls through to the Step-3 allow.
-        #   Infra self-protection is intentionally NOT consulted on an escaped path: an escape
-        # means the resolved real path is OUTSIDE the workspace, and every INFRA_PROTECTED_GLOB
-        # is workspace-relative, so an escaped target can never be an infra target. (A symlink
-        # that resolves back INTO the workspace yields escaped=False — see _normalize_target —
-        # so infra protection still runs for it below.)
+        #   Infra self-protection already ran above (anchored on plugin_root), so an escaped
+        # target that is an ARS plugin file was already denied; what remains here is a genuine
+        # non-infra escape (e.g. a sibling worktree), correctly allowed for non-Bucket-A.
         if is_bucket_a:
             return {
                 "decision": "deny",
@@ -303,14 +380,6 @@ def evaluate_decision(payload, manifest, workspace_root):
                            "workspace root (path traversal) — denied."),
             }
         return _allow_unconstrained(agent_type)
-
-    # --- Step 2: infrastructure self-protection (unconditional, on the normalized path). ---
-    if _infra_protected(rel):
-        return {
-            "decision": "deny",
-            "reason": (f"ARS scope guard: {rel} is part of the enforcement "
-                       "infrastructure and may not be written by any agent."),
-        }
 
     # --- Step 3: agent gating. ---
     if not is_bucket_a:
@@ -377,8 +446,19 @@ def main():
         print(render_hook_output({"decision": "allow", "reason": ""}))
         return 0
 
-    # Workspace root: prefer CLAUDE_PROJECT_DIR, else the payload cwd.
+    # Workspace root: prefer CLAUDE_PROJECT_DIR, else the payload cwd. This anchors the
+    # Bucket A phase-scope check (Step 4) to the USER'S project.
     workspace_root = os.environ.get("CLAUDE_PROJECT_DIR") or payload.get("cwd") or os.getcwd()
+
+    # Plugin root (#448): anchors infra self-protection (Step 2) to the ARS plugin's OWN
+    # files, NOT the user's project. CLAUDE_PLUGIN_ROOT is set on a plugin install; the
+    # git-clone+symlink track has no such env var, so fall back to this script's repo root
+    # (scripts/ -> repo root, where .claude-plugin/plugin.json lives). Use resolve() (NOT
+    # abspath) so a symlinked script / scripts dir — the norm for the ~/.claude/skills
+    # symlink install track — resolves to the REAL plugin tree, not the symlink's location
+    # (abspath would not follow the symlink and compute the wrong root).
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT") or str(
+        Path(__file__).resolve().parents[1])
 
     try:
         manifest = _load_manifest()
@@ -388,7 +468,7 @@ def main():
         print(render_hook_output({"decision": "allow", "reason": ""}))
         return 0
 
-    decision = evaluate_decision(payload, manifest, workspace_root)
+    decision = evaluate_decision(payload, manifest, workspace_root, plugin_root)
 
     # Surface fail-loud advisories to stderr (visible to the user/transcript), never silent.
     if decision.get("absent_agent_type_advisory"):

--- a/scripts/test_ars_write_scope_guard.py
+++ b/scripts/test_ars_write_scope_guard.py
@@ -2,16 +2,18 @@
 
 Spec: docs/design/2026-06-01-ars-134-conductor-rescope-deterministic-write-guard-spec.md (§3.4).
 
-The hook's testable core is `evaluate_decision(payload, manifest, workspace_root)`,
-a pure function returning a decision dict {"decision": "allow"|"deny", "reason": str}.
-`main()` only wires stdin -> evaluate_decision -> stdout JSON and is not unit-tested here
-(the decision logic is what matters; the I/O shell is a thin adapter verified by the
-hooks.json wiring + spec §3.2 first-party-verified deny schema).
+The hook's testable core is `evaluate_decision(payload, manifest, workspace_root,
+plugin_root=None)`, a pure function returning a decision dict {"decision": ..., "reason": ...}.
+`main()` only wires stdin -> evaluate_decision -> stdout JSON (now also covered by
+MainPluginRootComputationTest, which exercises the CLAUDE_PLUGIN_ROOT plumbing #448 added).
 
-Decision semantics under test (spec §3.2 strict-order 4-step logic):
-  Step 1: normalize the write target FIRST (absolute resolve + symlink resolve +
-          workspace commonpath + traversal deny -> workspace-root-relative canonical).
-  Step 2: infrastructure self-protection (unconditional, on normalized path).
+Decision semantics under test (spec §3.2 logic, amended by #448 dual-root anchoring):
+  Step 2: infrastructure self-protection — RUNS FIRST, anchored on plugin_root (NOT the
+          workspace): a target is infra IFF it resolves inside the ARS plugin install dir
+          AND its plugin-relative path matches INFRA_PROTECTED_GLOBS. A user-project file
+          that merely shares a filename (their own CLAUDE.md, hooks/*.sh, ...) is NOT infra.
+  Step 1: normalize the write target against workspace_root (absolute + symlink resolve +
+          workspace commonpath + escape detection -> workspace-root-relative canonical).
   Step 3: agent gating (Bucket A agent_type -> enforce allowed_write_globs;
           absent/non-Bucket-A -> allow, but fail-loud-log absent agent_type write).
   Step 4: tool-specific (Write/Edit/MultiEdit single top-level file_path;
@@ -31,6 +33,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # scripts/ -> repo root
 
 import ars_write_scope_guard as guard  # noqa: E402
 
@@ -173,7 +176,10 @@ class WriteScopeGuardTest(unittest.TestCase):
         p2 = payload("Bash", {"command": "rm x"}, cwd=self.ws)  # no agent_type (main session)
         self.assertEqual(self.decide(p2)["decision"], "allow")
 
-    # --- Step 2: infrastructure self-protection (unconditional) ---
+    # --- Step 2: infrastructure self-protection (anchored on plugin_root; these tests use
+    #     the 3-arg fallback where plugin_root collapses to workspace_root, so the plugin's
+    #     own infra files sit at the workspace root and are denied for EVERY actor. The
+    #     plugin_root != workspace_root cases live in PluginRootInfraScopeTest.) ---
 
     def test_infra_hooks_json_denied_for_every_agent(self):
         for at in ("bibliography_agent", "synthesis_agent", "formatter_agent", "broad_test_agent"):
@@ -266,7 +272,10 @@ class WriteScopeGuardTest(unittest.TestCase):
                         "absent agent_type write must surface a fail-loud advisory, not silently no-op")
 
     def test_absent_agent_type_still_denied_for_infra(self):
-        # Even the main session may not clobber infrastructure (Step 2 unconditional).
+        # Even the main session may not clobber the PLUGIN's own infra. Here the 3-arg
+        # fallback puts plugin_root == workspace_root, so hooks/hooks.json IS a plugin infra
+        # file and is denied regardless of actor (the #448 carve-out only spares a SEPARATE
+        # user project's same-named file — see PluginRootInfraScopeTest).
         p = payload("Write",
                     {"file_path": os.path.join(self.ws, "hooks/hooks.json"), "content": "x"},
                     cwd=self.ws)  # no agent_type
@@ -517,6 +526,218 @@ class MalformedPayloadTest(unittest.TestCase):
         d = self.decide(p)
         self.assertEqual(d["decision"], "deny")
         self.assertTrue(d.get("schema_drift_advisory"))
+
+
+class PluginRootInfraScopeTest(unittest.TestCase):
+    """#448 — infra self-protection is anchored on the PLUGIN root, not the user's PROJECT
+    root. Under a plugin install the two differ; the user's own project files that happen to
+    share a filename with an ARS infra file (CLAUDE.md, hooks/*.sh, shared/agents/*.md, ...)
+    must NOT be denied. The ARS plugin's OWN files stay protected.
+    """
+
+    def setUp(self):
+        # Two DISTINCT roots: a user project and a separate plugin install dir.
+        self._proj = tempfile.TemporaryDirectory()
+        self._plugin = tempfile.TemporaryDirectory()
+        self.ws = os.path.realpath(self._proj.name)        # user project (workspace_root)
+        self.plugin = os.path.realpath(self._plugin.name)  # ARS plugin install (plugin_root)
+        for d in ("phase2_investigation", ".claude", "hooks", "shared/agents"):
+            os.makedirs(os.path.join(self.ws, d), exist_ok=True)
+        for d in ("scripts", "hooks", ".claude", "shared/agents", "agents"):
+            os.makedirs(os.path.join(self.plugin, d), exist_ok=True)
+
+    def tearDown(self):
+        self._proj.cleanup()
+        self._plugin.cleanup()
+
+    def decide_in_project(self, p):
+        # workspace = user project; plugin_root = the separate ARS install.
+        return guard.evaluate_decision(p, TEST_MANIFEST, self.ws, self.plugin)
+
+    # --- the reported bug: user's own CLAUDE.md must be writable by the main session ---
+
+    def test_user_project_root_claude_md_allowed_main_session(self):
+        # This is exactly #448. Pre-fix this was DENY; post-fix it must be ALLOW.
+        p = payload("Write", {"file_path": os.path.join(self.ws, "CLAUDE.md"), "content": "x"},
+                    cwd=self.ws)  # no agent_type = main session
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    def test_user_project_dotclaude_claude_md_allowed_main_session(self):
+        p = payload("Write", {"file_path": os.path.join(self.ws, ".claude/CLAUDE.md"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    def test_user_project_shared_agents_md_allowed(self):
+        # `shared/agents/*.md` is an ARS infra glob but ALSO a plausible user-project path.
+        p = payload("Write", {"file_path": os.path.join(self.ws, "shared/agents/foo.md"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    def test_user_project_hooks_json_allowed(self):
+        p = payload("Write", {"file_path": os.path.join(self.ws, "hooks/hooks.json"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    def test_user_project_hooks_sh_allowed(self):
+        p = payload("Write", {"file_path": os.path.join(self.ws, "hooks/install.sh"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    # --- self-protection PRESERVED: the plugin's OWN files stay denied ---
+
+    def test_plugin_own_claude_md_denied(self):
+        # A write whose target resolves INSIDE the plugin root is still infra-protected.
+        p = payload("Write", {"file_path": os.path.join(self.plugin, "CLAUDE.md"), "content": "x"},
+                    cwd=self.ws)
+        d = self.decide_in_project(p)
+        self.assertEqual(d["decision"], "deny")
+        self.assertIn("infrastructure", d["reason"])
+
+    def test_plugin_own_guard_script_denied(self):
+        p = payload("Write",
+                    {"file_path": os.path.join(self.plugin, "scripts/ars_write_scope_guard.py"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_plugin_own_hooks_json_denied(self):
+        p = payload("Write", {"file_path": os.path.join(self.plugin, "hooks/hooks.json"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_plugin_own_shared_agents_md_denied(self):
+        p = payload("Write", {"file_path": os.path.join(self.plugin, "shared/agents/bar.md"), "content": "x"},
+                    cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_plugin_own_toplevel_agents_md_denied(self):
+        # The #413-materialized top-level agents/*.md carry the agent_type==name binding too;
+        # #448 added `agents/*.md` to the infra globs. A user-project agents/foo.md is still
+        # allowed (covered by no deny test -> it falls through to Step 3 allow); only the
+        # PLUGIN's own copy is protected.
+        p = payload("Write", {"file_path": os.path.join(self.plugin, "agents/synthesis_agent.md"),
+                              "content": "x"}, cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_user_project_toplevel_agents_md_allowed(self):
+        # The mirror: a user's OWN agents/foo.md (inside their project, outside plugin_root)
+        # must remain writable — the #448 carve-out applies to agents/*.md too.
+        os.makedirs(os.path.join(self.ws, "agents"), exist_ok=True)
+        p = payload("Write", {"file_path": os.path.join(self.ws, "agents/my_agent.md"),
+                              "content": "x"}, cwd=self.ws)
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    # --- fallback: plugin_root=None -> conservative pre-fix behavior (workspace-anchored) ---
+
+    def test_fallback_none_plugin_root_protects_workspace_infra(self):
+        # When the caller passes no plugin_root, infra protection falls back to the
+        # workspace root (== pre-#448 behavior, the ARS-on-ARS home-turf case).
+        p = payload("Write", {"file_path": os.path.join(self.ws, "CLAUDE.md"), "content": "x"},
+                    cwd=self.ws)
+        d = guard.evaluate_decision(p, TEST_MANIFEST, self.ws)  # 3-arg: plugin_root defaults None
+        self.assertEqual(d["decision"], "deny")
+
+    # --- Bucket A phase-scope is UNCHANGED by the dual-root split ---
+
+    def test_bucket_a_phase_scope_unaffected_allow(self):
+        p = payload("Write",
+                    {"file_path": os.path.join(self.ws, "phase2_investigation/bib.md"), "content": "x"},
+                    cwd=self.ws, agent_type="bibliography_agent")
+        self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+
+    def test_bucket_a_cannot_reach_user_claude_md(self):
+        # A Bucket A agent still can't write the user's root CLAUDE.md — not because of infra
+        # protection now, but because it's outside the agent's phase glob (Step 4). The guard
+        # is unchanged for agents; only the main session gained access.
+        p = payload("Write", {"file_path": os.path.join(self.ws, "CLAUDE.md"), "content": "x"},
+                    cwd=self.ws, agent_type="bibliography_agent")
+        d = self.decide_in_project(p)
+        self.assertEqual(d["decision"], "deny")
+        self.assertIn("bibliography_agent", d["reason"])  # phase-scope deny, not infra deny
+
+    # --- dual-root regression variants (codex P2-b): traversal / symlink / Bucket A escape
+    #     toward the plugin's OWN infra, under a real plugin_root != workspace_root install ---
+
+    def test_dual_root_traversal_from_phase_into_plugin_infra_denied(self):
+        # A relative target that escapes the phase dir and `..`-walks all the way into the
+        # plugin tree's hooks/hooks.json. realpath in _infra_protected_target must resolve it
+        # and deny — the infra check runs BEFORE the workspace-escape branch.
+        rel_into_plugin = os.path.relpath(
+            os.path.join(self.plugin, "hooks/hooks.json"),
+            os.path.join(self.ws, "phase2_investigation"))
+        raw = "phase2_investigation/" + rel_into_plugin
+        p = payload("Write", {"file_path": raw, "content": "x"}, cwd=self.ws)  # main session
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_dual_root_symlink_into_plugin_infra_denied(self):
+        # A symlink inside the user workspace pointing at a plugin infra file. realpath
+        # resolves the link to the plugin tree -> infra-protected -> deny.
+        link = os.path.join(self.ws, "sneaky_link.py")
+        target = os.path.join(self.plugin, "scripts/ars_write_scope_guard.py")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w") as fh:
+            fh.write("# real guard\n")
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks unsupported on this platform")
+        p = payload("Write", {"file_path": link, "content": "x"}, cwd=self.ws)  # main session
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_dual_root_bucket_a_escape_toward_plugin_infra_denied(self):
+        # Bucket A agent trying to reach the plugin's own guard script. It is denied — the
+        # infra check fires first; even if it didn't, the escape fence (#302) would catch it.
+        p = payload("Write",
+                    {"file_path": os.path.join(self.plugin, "scripts/ars_write_scope_guard.py"),
+                     "content": "x"},
+                    cwd=self.ws, agent_type="bibliography_agent")
+        self.assertEqual(self.decide_in_project(p)["decision"], "deny")
+
+    def test_dual_root_bucket_a_sibling_worktree_escape_still_allowed_for_main(self):
+        # Sanity: a NON-infra escape (a sibling worktree outside both roots) is still allowed
+        # for the main session — the infra reorder didn't over-deny genuine escapes.
+        sibling = os.path.realpath(os.path.join(self.ws, "..", "sibling_worktree"))
+        os.makedirs(sibling, exist_ok=True)
+        try:
+            p = payload("Write", {"file_path": os.path.join(sibling, "notes.md"), "content": "x"},
+                        cwd=self.ws)  # main session
+            self.assertEqual(self.decide_in_project(p)["decision"], "allow")
+        finally:
+            import shutil
+            shutil.rmtree(sibling, ignore_errors=True)
+
+
+class MainPluginRootComputationTest(unittest.TestCase):
+    """main() must compute plugin_root from CLAUDE_PLUGIN_ROOT, else the resolved repo root
+    (resolve() to follow the ~/.claude/skills symlink install). codex P2-b."""
+
+    def test_plugin_root_from_env(self):
+        import subprocess
+        guard_path = os.path.join(REPO_ROOT, "scripts", "ars_write_scope_guard.py")
+        with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as plug:
+            # Writing the user project's own CLAUDE.md must pass through (no permissionDecision)
+            # when CLAUDE_PLUGIN_ROOT points elsewhere.
+            env = dict(os.environ, CLAUDE_PROJECT_DIR=proj, CLAUDE_PLUGIN_ROOT=plug)
+            inp = json.dumps({"tool_name": "Write", "cwd": proj,
+                              "tool_input": {"file_path": os.path.join(proj, "CLAUDE.md"),
+                                             "content": "x"}})
+            out = subprocess.run([sys.executable, guard_path], input=inp, env=env,
+                                 capture_output=True, text=True)
+            decision = json.loads(out.stdout)
+            self.assertNotIn("permissionDecision", decision["hookSpecificOutput"])
+
+    def test_plugin_own_file_denied_via_env(self):
+        import subprocess
+        guard_path = os.path.join(REPO_ROOT, "scripts", "ars_write_scope_guard.py")
+        with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as plug:
+            os.makedirs(os.path.join(plug, "scripts"))
+            env = dict(os.environ, CLAUDE_PROJECT_DIR=proj, CLAUDE_PLUGIN_ROOT=plug)
+            inp = json.dumps({"tool_name": "Write", "cwd": proj,
+                              "tool_input": {"file_path": os.path.join(plug, "scripts/ars_write_scope_guard.py"),
+                                             "content": "x"}})
+            out = subprocess.run([sys.executable, guard_path], input=inp, env=env,
+                                 capture_output=True, text=True)
+            decision = json.loads(out.stdout)
+            self.assertEqual(decision["hookSpecificOutput"].get("permissionDecision"), "deny")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #448. Two independent users (@philpav, @herman925) reported that after installing ARS as a plugin, Claude could no longer edit their **own project's** `CLAUDE.md`.

**Root cause** (a root-boundary error, not a single bad glob): the #134 write-scope guard lists `CLAUDE.md` — and `hooks/*.sh`, `shared/agents/*.md`, etc. — as infra-protected, but matched them against `CLAUDE_PROJECT_DIR`, which under a plugin install is the **user's project**, not the ARS plugin dir. So Step 2 denied the user's own same-named files to even the trusted main session.

## Fix (dual root)

The two enforcement surfaces have different anchors, and conflating them was the bug:

- **Bucket A phase-scope** (Step 4) — fences agents to their `phaseN_` dir inside the user's project. Anchor: `workspace_root` (= `CLAUDE_PROJECT_DIR`). **Unchanged.**
- **Infra self-protection** (Step 2) — protects the ARS plugin's *own* files. Anchor: new `plugin_root`. A target is infra **iff** it resolves inside `plugin_root` **and** its plugin-relative path matches `INFRA_PROTECTED_GLOBS`. A user-project file that merely shares a filename is left to normal agent gating.

Details:
- `evaluate_decision()` gains `plugin_root`; Step 2 moved to run **before** the workspace-escape check (under a plugin install the plugin's own files are "escaped" relative to the user workspace, so infra must be checked first to stay protected wherever they sit).
- `main()` computes `plugin_root` from `CLAUDE_PLUGIN_ROOT`, else `Path(__file__).resolve().parents[1]` (`resolve()` follows the `~/.claude/skills` symlink install track).
- Added top-level `agents/*.md` to `INFRA_PROTECTED_GLOBS` — the #413-materialized agent copies carry the `agent_type==name` binding but were previously unprotected (a pre-existing gap; closed here since this PR re-reasons about which files are plugin infra).

## Threat model

Fix C does **not** reopen the guard-disable path: the plugin's own enforcement files still resolve inside `plugin_root` and stay denied; a Bucket A agent still can't escape its phase dir or run Bash. The only changed behavior is that the main session (and Bucket B/C/D) in a user project may now edit that project's own `CLAUDE.md` / `hooks/*` / `agents/*` — which they always should have, and could already do via Bash.

## Verification

- 54 guard tests pass, incl. dual-root (`plugin_root != workspace_root`), traversal/symlink-into-plugin-infra, Bucket A escape attempts, and a `main()` subprocess test exercising the `CLAUDE_PLUGIN_ROOT` env plumbing.
- `scripts/check_v3_10_134_write_scope.py` cross-check lint passes.
- End-to-end smoke-tested under a simulated symlink plugin install.
- Cross-model reviewed: codex (design + diff, ran the decision function) and an independent reviewer (caught a docstring ordering drift and the `agents/*.md` gap).

Spec: `docs/design/2026-06-16-448-infra-protection-plugin-root-scope-spec.md`

## Eval impact

No eval impact. (No scoring / generation / gold-set change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)