### PR TITLE
docs: add GitHub Copilot repository instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+---
+title: Academic Research Skills
+description: AI-augmented academic research pipeline with integrity verification
+version: 3.13.0
+license: CC BY-NC 4.0
+---
+
+# Academic Research Skills for GitHub Copilot
+
+AI-augmented research pipeline for academic writing, literature review, and peer review.
+
+**Core principle:** AI is your copilot, not the pilot. Humans focus on substantive decisions; AI handles grunt work (references, formatting, verification).
+
+## Quick Start
+
+Try `/ars-plan` — describe your paper, get Socratic structure guidance.
+
+**Key commands:** `/ars-lit-review`, `/ars-outline`, `/ars-full`, `/ars-reviewer`, `/ars-citation-check`
+
+## Setup & Installation
+
+→ **[SETUP.md](../docs/SETUP.md)** for plugin, local symlink, API keys, and optional tools
+
+## Architecture & Components
+
+- **Deep Research** — 13-agent team, PRISMA support, intent detection
+- **Paper Writing** — 12-agent pipeline, style calibration, citation verification
+- **Peer Review** — 7-agent multi-perspective review, quality rubrics
+- **Pipeline** — 10-stage orchestration, claim verification, material passports
+
+→ **[ARCHITECTURE.md](../docs/ARCHITECTURE.md)** for full flow diagrams and dependency graph
+
+## Integrity & Safety
+
+Addresses AI research failure modes (Kong et al. 2026, arXiv:2605.18661):
+- 7-mode blocking checklist for common AI failures
+- Claim-level audits with locator anchors
+- Trust-chain frontmatter for provenance
+- FNR/FPR calibration on custom measures
+
+⚠️ **Permission modes:** for unattended pipeline runs, Auto mode is the recommended setting (a server-side classifier still gates dangerous escalations). `--dangerously-skip-permissions` removes all safety checks and is only appropriate for isolated, no-internet sandboxes. See [PERFORMANCE.md](../docs/PERFORMANCE.md#recommended-claude-code-settings) for full context before changing modes.
+
+## Contributing
+
+→ **[CONTRIBUTING.md](../CONTRIBUTING.md)** for PR workflow, acceptance criteria, development guidelines
+
+## Docs
+
+| Topic | Link |
+|-------|------|
+| **Setup & Installation** | [SETUP.md](../docs/SETUP.md) |
+| **Architecture** | [ARCHITECTURE.md](../docs/ARCHITECTURE.md) |
+| **Performance & Costs** | [PERFORMANCE.md](../docs/PERFORMANCE.md) |
+| **Design Philosophy** | [POSITIONING.md](../POSITIONING.md) |
+| **Contributing** | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| **Citation** | [CITATION.cff](../CITATION.cff) |
+
+## License
+
+CC BY-NC 4.0 (non-commercial use) • DOI: [10.5281/zenodo.20696614](https://doi.org/10.5281/zenodo.20696614)
+
+---
+
+**This tool helps you write *better*, not helps you hide that you used AI. Integrity is non-negotiable.**


### PR DESCRIPTION
## Summary

Adds a thin `.github/copilot-instructions.md` so GitHub Copilot users and contributors are oriented to the authoritative docs (SETUP / ARCHITECTURE / PERFORMANCE / POSITIONING / CONTRIBUTING) instead of duplicating their content. Surfaces the integrity-and-safety posture and the recommended permission mode.

`[skip-closes-check]` — no tracking issue: this is the adoption of an unsolicited external contribution (#457), not a fix for a filed issue.

## Attribution

This is a local rebuild of #457 by @SID-6921, who did the original design and content. Their authorship is preserved via `Co-Authored-By` on the commit. Rebuilt locally rather than merged directly so the corrections below land in a single clean commit on top of current `main`.

## What changed vs #457

- **Dropped** the stray `pr_description.txt` that was committed to the repo root.
- **Version**: frontmatter now reads the current suite version `3.13.0` (was `3.12.1`, which matched no released version).
- **Command names**: replaced commands that don't exist (`/ars-write`, `/ars-pipeline`, `/ars-deep-research`, `/ars-review`) with the real ones (`/ars-full`, `/ars-reviewer`, etc.).
- **Doc links**: fixed all links to resolve from `.github/` (`../docs/X.md`); the original paths would have 404'd from that directory.
- **Permission-mode guidance**: realigned with the Auto-mode recommendation shipped in #464 — Auto mode is the recommended setting for unattended runs; `--dangerously-skip-permissions` is sandbox-only. (The original still framed Skip Permissions as the path for "trusted environments".)

## Review

Independently reviewed by codex (gpt-5.5), which caught the `/ars-reviewer` command name and the `3.13.0` suite version before this PR was opened. Both fixed.

## Verification

- All 6 referenced slash commands resolve to a real `commands/*.md`.
- All 6 doc-link targets resolve from `.github/`; the PERFORMANCE.md anchor matches a real heading.
- `scripts/check_version_consistency.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)