### PR TITLE
Add SkillOpt integration harness for the rq_framing_patterns advisory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ docs/superpowers/
 
 # Python bytecode / pytest cache.
 __pycache__/
+.pytest_cache/
+
+# SkillOpt harness runtime artifacts (tools/skillopt/): the ratio-split
+# materialization and any training checkpoints/outputs are regenerated per run.
+/_generated_splits/
+tools/skillopt/runs/
 
 # Private ROADMAP is intentionally gitignored and maintained outside this public repo
 ROADMAP.md

--- a/tools/skillopt/README.md
+++ b/tools/skillopt/README.md
@@ -1,0 +1,119 @@
+# ARS × SkillOpt integration harness
+
+Wire [Microsoft **SkillOpt**](https://github.com/microsoft/SkillOpt) onto ARS's
+existing `rq_framing_patterns` gold set so the **Socratic wording-pattern
+advisory** (Kong #257) can be *trained as a natural-language skill* and gated on
+held-out validation — the same way SkillOpt trains any agent skill: rollout →
+reflect → bounded edit → validation gate → `best_skill.md`.
+
+> **Status: harness only.** This directory ships the integration plumbing and a
+> seed skill. It does **not** ship a trained skill or modify any `SKILL.md`.
+> Running an optimization (which spends model budget) and proposing a trained
+> skill is a separate, maintainer-gated step — see [Scope & next steps](#scope--next-steps).
+
+## Why this exists (honest framing)
+
+ARS already detects AI-typical research-question wording with a **deterministic
+regex detector** — `scripts/check_rq_framing_patterns.py`, twenty hardcoded shells
+`WP01`–`WP20`. It scores a perfect `balanced_accuracy = 1.000` on the gold set…
+*because the gold set was authored to match those regexes*. That precision is real
+but brittle: any **novel** AI-typical phrasing that no `WP` regex anticipated slips
+through silently.
+
+This harness offers the complementary capability: train a compact **LLM skill**
+that makes the same advisory judgment, measured by the **same metric and the same
+acceptance gate** (FNR < 0.30, FPR < 0.20, balanced accuracy ≥ 0.75). The bet is
+that an LLM skill can generalize to wording the regex can't enumerate while keeping
+false positives on domain-native questions low. SkillOpt is the disciplined way to
+evolve that skill instead of hand-editing a prompt and hoping.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `ars_scoring.py` | **Pure**, no SkillOpt/network/key. Parse `trigger_advisory` from a model answer; score + aggregate vs gold (mirrors ARS's own metric). |
+| `ars_gold_loader.py` | SkillOpt `SplitDataLoader` — reads `evals/gold/rq_framing_patterns/gold_set.json`, normalizes, splits. |
+| `ars_adapter.py` | SkillOpt `EnvAdapter` — single-turn rollout (`chat_target`) + scoring + reflect delegation. |
+| `run_ars_skillopt.py` | Launcher — registers the adapter into SkillOpt's env registry, then delegates to `skillopt-train` / `skillopt-eval`. **No fork of SkillOpt.** |
+| `configs/rq_framing_patterns.yaml` | Self-contained SkillOpt config (Claude backend, small budget). |
+| `skills/rq_framing_patterns/initial.md` | Seed skill — the trainable starting point. |
+| `tests/test_ars_scoring_offline.py` | Zero-API plumbing test over the real gold set. |
+
+## Prerequisites
+
+- `pip install skillopt` (lightweight core: `openai`, `numpy`, `pyyaml`, `httpx`, …).
+- The Claude backend (`backend: claude_chat`) drives your **local Claude CLI**
+  (`claude --print`), so it uses your authenticated `claude` binary rather than a
+  separate metered API key. Optimizer = Opus, target = Sonnet by default (ARS's
+  Opus-for-review / Sonnet-for-execution convention; never Haiku).
+
+## Run
+
+**Offline plumbing test — zero API, zero model calls:**
+
+```bash
+python -m pytest tools/skillopt/tests/test_ars_scoring_offline.py -q
+```
+
+**Train the skill (spends model budget — see the warning below):**
+
+```bash
+# from the ARS repo root (paths in the config are CWD-relative):
+PYTHONPATH=. python tools/skillopt/run_ars_skillopt.py \
+    --config tools/skillopt/configs/rq_framing_patterns.yaml
+```
+
+**Evaluate an already-optimized skill instead of training:**
+
+```bash
+PYTHONPATH=. python tools/skillopt/run_ars_skillopt.py --eval \
+    --config tools/skillopt/configs/rq_framing_patterns.yaml
+```
+
+> ⚠️ **Cost.** Training issues many model calls (epochs × batch × rollouts +
+> optimizer reflection). The shipped config is deliberately small (2 epochs, the
+> 40-item gold set), but it is **not free** — every call goes through your Claude
+> CLI. Start small; scale `train.num_epochs` / `optimizer.learning_rate` only after
+> a smoke run.
+
+## Validate a trained skill against ARS's own harness
+
+A skill SkillOpt produces should be checked by ARS's **independent** tooling, not
+just SkillOpt's internal gate:
+
+```bash
+# ARS's own deterministic checker + the multi-task eval harness:
+PYTHONPATH=. python -m scripts.check_rq_framing_patterns
+PYTHONPATH=. python -m scripts.run_evals --task rq_framing_patterns
+```
+
+A trained skill is only interesting if it clears the same FNR/FPR/balanced-accuracy
+gate the regex detector already clears — ideally while catching held-out wording the
+regex misses.
+
+## Notes & caveats
+
+- **`scripts` package name collision (benign).** Both ARS and SkillOpt expose a
+  top-level `scripts` package. SkillOpt's is a *regular* package (has `__init__.py`);
+  ARS's is a *namespace* dir (no `__init__.py`). Per PEP 420, the regular package
+  wins, so `from scripts import train` resolves to SkillOpt's even with the ARS repo
+  root first on `PYTHONPATH`. Verified; no action needed.
+- **Single skill, not the whole pipeline.** SkillOpt trains one compact skill
+  against one auto-scorable target. This harness targets exactly one ARS measurement
+  task; it does not "optimize ARS."
+- **Gold-set provenance.** The gold set was authored to the regex detector, so the
+  regex baseline is ~1.0 on it. The honest value of an LLM skill is *generalization*
+  to wording outside the 20 shells — best measured on held-out / new items, which is
+  follow-up work.
+- **Version pin.** Built and verified against SkillOpt `v0.1.0` (PyPI). `v0.1.0`
+  marks `EnvAdapter.reflect` abstract with no body, so `ars_adapter.py` implements
+  `reflect` explicitly (delegating to `run_minibatch_reflect`).
+
+## Scope & next steps
+
+Per [`CONTRIBUTING.md`](../../CONTRIBUTING.md), changes to a shipped `SKILL.md` or
+agent definition need an issue + maintainer discussion first. This harness changes
+**none** of those — it is additive tooling, like the existing `evals/` harness. The
+natural follow-up (separate, opt-in, budgeted): run an optimization, validate the
+lift with `scripts/run_evals.py`, and bring before/after evidence to an issue before
+proposing any trained skill for the pipeline.

--- a/tools/skillopt/__init__.py
+++ b/tools/skillopt/__init__.py
@@ -1,0 +1,6 @@
+"""ARS x SkillOpt integration harness.
+
+Wires Microsoft SkillOpt (https://github.com/microsoft/SkillOpt) onto ARS's
+existing rq_framing_patterns gold set so the Socratic wording-pattern advisory can
+be trained as an LLM skill and gated on held-out validation. See README.md.
+"""

--- a/tools/skillopt/ars_adapter.py
+++ b/tools/skillopt/ars_adapter.py
@@ -1,0 +1,209 @@
+"""SkillOpt environment adapter for the ARS rq_framing_patterns advisory.
+
+Trains a compact natural-language *skill* that decides whether ARS's Socratic
+wording-pattern advisory should fire for a proposed research question — the same
+judgment ARS ships today as a fixed regex detector
+(``scripts/check_rq_framing_patterns.py``), but expressed as an LLM skill that can
+generalise to wording the 20 hardcoded shells (WP01-WP20) never anticipated.
+
+The rollout is single-turn: for each gold item we put the (trainable) skill in the
+system prompt behind a fixed output-format contract, ask the target model to judge
+one RQ, parse ``trigger_advisory`` out of the answer, and score it against the gold
+label. Scoring + the metric live in ``ars_scoring.py`` (pure, offline-testable);
+this file is only the SkillOpt-facing glue.
+
+Registered under the env key ``ars_rq_framing_patterns`` by ``run_ars_skillopt.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from skillopt.datasets.base import BatchSpec
+from skillopt.envs.base import EnvAdapter
+from skillopt.gradient.reflect import run_minibatch_reflect
+from skillopt.model import chat_target
+
+from tools.skillopt.ars_gold_loader import ARSRQFramingLoader
+from tools.skillopt.ars_scoring import POSITIVE_LABEL, NEGATIVE_LABEL, score_prediction
+
+# Fixed harness scaffold around the trainable skill. The skill itself is the only
+# part SkillOpt edits; the format contract below is held constant so the optimizer
+# can never "win" by training the output format away.
+_SYSTEM_TEMPLATE = """\
+You are an academic research-question (RQ) wording advisor for the ARS pipeline.
+
+Apply the SKILL below to decide whether the Socratic wording-pattern advisory
+should fire for a single proposed research question. Judge WORDING ONLY: surface
+phrasing, not the idea's quality, novelty, feasibility, or topic. A broad topic
+phrased specifically must NOT trigger; a narrow topic wrapped in a generic
+template shell SHOULD trigger.
+
+=== SKILL ===
+{skill_content}
+=== END SKILL ===
+
+Think briefly, then end your reply with EXACTLY one final line:
+  ADVISORY: YES   -> the RQ uses an AI-typical wording shell; the advisory fires
+  ADVISORY: NO    -> the wording is specific / domain-native; no advisory
+"""
+
+_USER_TEMPLATE = (
+    'Proposed research question:\n"{text}"\n\n'
+    "Does the wording-pattern advisory fire? Give your verdict."
+)
+
+
+class ARSRQFramingAdapter(EnvAdapter):
+    """Environment adapter for the rq_framing_patterns wording advisory."""
+
+    def __init__(
+        self,
+        split_dir: str = "",
+        data_path: str = "",
+        split_mode: str = "ratio",
+        split_ratio: str = "5:2:3",
+        split_seed: int = 42,
+        split_output_dir: str = "",
+        exec_timeout: int = 120,
+        workers: int = 8,
+        analyst_workers: int = 8,
+        failure_only: bool = False,
+        minibatch_size: int = 8,
+        edit_budget: int = 4,
+        seed: int = 42,
+        limit: int = 0,
+        max_completion_tokens: int = 2048,
+    ) -> None:
+        self.exec_timeout = exec_timeout
+        self.workers = workers
+        self.analyst_workers = analyst_workers
+        self.failure_only = failure_only
+        self.minibatch_size = minibatch_size
+        self.edit_budget = edit_budget
+        self.max_completion_tokens = int(max_completion_tokens)
+        self.dataloader = ARSRQFramingLoader(
+            split_dir=split_dir,
+            data_path=data_path,
+            split_mode=split_mode,
+            split_ratio=split_ratio,
+            split_seed=split_seed,
+            split_output_dir=split_output_dir,
+            seed=seed,
+            limit=limit,
+        )
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+    def setup(self, cfg: dict) -> None:
+        super().setup(cfg)
+        self.dataloader.setup(cfg)
+
+    def get_dataloader(self):
+        return self.dataloader
+
+    # ── Batch -> env manager ───────────────────────────────────────────
+    def build_env_from_batch(self, batch: BatchSpec, **kwargs):
+        return list(batch.payload or [])
+
+    def build_train_env(self, batch_size: int, seed: int, **kwargs):
+        batch = self.dataloader.build_train_batch(batch_size=batch_size, seed=seed, **kwargs)
+        return self.build_env_from_batch(batch, **kwargs)
+
+    def build_eval_env(self, env_num: int, split: str, seed: int, **kwargs):
+        batch = self.dataloader.build_eval_batch(env_num=env_num, split=split, seed=seed, **kwargs)
+        return self.build_env_from_batch(batch, **kwargs)
+
+    # ── Rollout ────────────────────────────────────────────────────────
+    def rollout(self, env_manager, skill_content: str, out_dir: str, **kwargs) -> list[dict]:
+        """Classify each RQ under the current skill and score against the gold label.
+
+        Sequential by design: the gold set is tiny (<=40 items) and a model call
+        per item is IO-bound but cheap, so we trade throughput for a small, easy
+        to audit loop. Each model failure degrades to a scored miss rather than
+        crashing the batch.
+        """
+        items: list[dict] = env_manager
+        results: list[dict] = []
+        for item in items:
+            text = item.get("question", "")
+            label = item.get("label", "")
+            system = _SYSTEM_TEMPLATE.format(skill_content=skill_content.strip())
+            user = _USER_TEMPLATE.format(text=text)
+            try:
+                response, _raw = chat_target(
+                    system=system,
+                    user=user,
+                    max_completion_tokens=self.max_completion_tokens,
+                    timeout=self.exec_timeout,
+                )
+            except Exception as exc:  # model/transport failure -> scored miss
+                response = ""
+                score = score_prediction("", label)
+                score["fail_reason"] = f"target_call_error: {type(exc).__name__}: {exc}"
+            else:
+                score = score_prediction(response, label)
+
+            results.append({
+                "id": str(item.get("id", "")),
+                "question": text,
+                "label": label,
+                "task_type": item.get("task_type", label),
+                "predicted_answer": (response or "")[:2000],
+                "hard": score["hard"],
+                "soft": score["soft"],
+                "predicted_trigger": score["predicted_trigger"],
+                "expected_trigger": score["expected_trigger"],
+                "parsed_ok": score["parsed_ok"],
+                "fail_reason": score["fail_reason"],
+            })
+
+        self._dump_records(out_dir, results)
+        return results
+
+    # ── Reflect ────────────────────────────────────────────────────────
+    def reflect(self, results: list[dict], skill_content: str, out_dir: str, **kwargs) -> list[dict | None]:
+        """Turn scored rollouts into skill-edit proposals via the shared analyst.
+
+        Delegates to SkillOpt's standard minibatch reflection (the same path every
+        built-in benchmark uses). v0.1.0 marks ``EnvAdapter.reflect`` abstract with
+        no body, so we implement it explicitly rather than calling ``super()``.
+        """
+        return run_minibatch_reflect(
+            results=results,
+            skill_content=skill_content,
+            prediction_dir=kwargs.get("prediction_dir", os.path.join(out_dir, "predictions")),
+            patches_dir=kwargs.get("patches_dir", os.path.join(out_dir, "patches")),
+            workers=self.analyst_workers,
+            failure_only=self.failure_only,
+            minibatch_size=self.minibatch_size,
+            edit_budget=self.edit_budget,
+            random_seed=kwargs.get("random_seed"),
+            error_system=self.get_error_minibatch_prompt(),
+            success_system=self.get_success_minibatch_prompt(),
+            step_buffer_context=kwargs.get("step_buffer_context", ""),
+            update_mode=getattr(self, "_cfg", {}).get("skill_update_mode", "patch"),
+        )
+
+    @staticmethod
+    def _dump_records(out_dir: str, results: list[dict]) -> None:
+        """Best-effort artifact dump for debugging; never fatal."""
+        if not out_dir:
+            return
+        try:
+            os.makedirs(out_dir, exist_ok=True)
+            with open(os.path.join(out_dir, "rollout_records.jsonl"), "w", encoding="utf-8") as f:
+                for rec in results:
+                    f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        except OSError:
+            pass
+
+    # ── Stratification hint ────────────────────────────────────────────
+    def get_task_types(self) -> list[str]:
+        seen: list[str] = []
+        for item in (self.dataloader.train_items
+                     + self.dataloader.val_items
+                     + self.dataloader.test_items):
+            tt = str(item.get("task_type") or "")
+            if tt and tt not in seen:
+                seen.append(tt)
+        return seen or [POSITIVE_LABEL, NEGATIVE_LABEL]

--- a/tools/skillopt/ars_gold_loader.py
+++ b/tools/skillopt/ars_gold_loader.py
@@ -1,0 +1,83 @@
+"""SkillOpt data loader for the ARS rq_framing_patterns gold set.
+
+Reads ``evals/gold/rq_framing_patterns/gold_set.json`` (the #257 Socratic
+wording-pattern advisory calibration set) and normalises each entry into the
+flat dict shape SkillOpt expects. Supports both SkillOpt split modes:
+
+  * ``split_mode: ratio``    — point ``env.data_path`` at the single gold_set.json
+    and let SkillOpt build a deterministic train/val/test split (recommended;
+    the 40-item set is balanced 20/20).
+  * ``split_mode: split_dir`` — point ``env.split_dir`` at a directory whose
+    train/ val/ test/ subdirs each hold one JSON array of normalised items.
+
+This module imports SkillOpt's ``SplitDataLoader`` base class, so it only loads
+when SkillOpt is installed (``pip install skillopt``). The pure label/scoring
+logic lives in ``ars_scoring.py`` with no such dependency.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skillopt.datasets.base import SplitDataLoader
+
+from tools.skillopt.ars_scoring import NEGATIVE_LABEL, POSITIVE_LABEL, expected_trigger
+
+
+def _normalize_item(raw: dict) -> dict:
+    """Normalise one gold tuple into SkillOpt's item shape.
+
+    Hard requirement is ``id``; we also carry ``question`` (the RQ text the target
+    model classifies), ``label`` / ``ground_truth`` (the gold class), a precomputed
+    ``expected_trigger`` boolean, and ``task_type`` (= label) for stratified
+    sampling.
+    """
+    label = str(raw.get("label") or "").strip()
+    if label not in {POSITIVE_LABEL, NEGATIVE_LABEL}:
+        raise ValueError(
+            f"item {raw.get('id')!r}: invalid label {label!r}; "
+            f"expected {POSITIVE_LABEL!r} or {NEGATIVE_LABEL!r}")
+    text = str(raw.get("text") or raw.get("question") or "").strip()
+    if not text:
+        raise ValueError(f"item {raw.get('id')!r}: missing non-empty text")
+    return {
+        "id": str(raw.get("id") or ""),
+        "question": text,
+        "label": label,
+        "ground_truth": label,
+        "expected_trigger": expected_trigger(label),
+        "expected_pattern_ids": list(raw.get("expected_pattern_ids") or []),
+        "task_type": label,
+    }
+
+
+def _read_items_array(payload) -> list[dict]:
+    """Accept either ``{"items": [...]}`` (gold_set.json) or a bare ``[...]``."""
+    if isinstance(payload, dict):
+        items = payload.get("items")
+    else:
+        items = payload
+    if not isinstance(items, list):
+        raise ValueError("expected an items[] array (or {'items': [...]})")
+    return [_normalize_item(row) for row in items]
+
+
+class ARSRQFramingLoader(SplitDataLoader):
+    """Loader for the rq_framing_patterns gold set."""
+
+    def load_raw_items(self, data_path: str) -> list[dict]:
+        """Ratio mode: load every item from the single gold_set.json file."""
+        path = Path(data_path)
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+        return _read_items_array(payload)
+
+    def load_split_items(self, split_path: str) -> list[dict]:
+        """split_dir mode: load all items from one split directory's JSON file."""
+        path = Path(split_path)
+        json_files = sorted(path.glob("*.json"))
+        if not json_files:
+            raise FileNotFoundError(f"no .json file found in {split_path}")
+        with json_files[0].open(encoding="utf-8") as f:
+            payload = json.load(f)
+        return _read_items_array(payload)

--- a/tools/skillopt/ars_scoring.py
+++ b/tools/skillopt/ars_scoring.py
@@ -1,0 +1,174 @@
+"""Pure scoring helpers for the ARS x SkillOpt rq_framing_patterns harness.
+
+This module has **no SkillOpt dependency and makes no model calls**. It holds the
+two things the harness must get right regardless of which optimizer runs on top:
+
+  1. turning a target model's free-text answer into a ``trigger_advisory`` boolean
+     (:func:`parse_trigger`), and
+  2. scoring + aggregating those predictions against the gold labels with the
+     *same* metric definition ARS's own checker uses
+     (:func:`score_prediction`, :func:`compute_metrics`).
+
+Keeping this layer pure means it is unit-testable offline (see
+``tests/test_ars_scoring_offline.py``) — no ``ANTHROPIC_API_KEY``, no network, no
+SkillOpt install. The SkillOpt-facing glue (``ars_adapter.py`` / ``ars_gold_loader.py``)
+imports these functions; it never re-implements them.
+
+The metric mirrors ``scripts/check_rq_framing_patterns.py`` exactly: a
+``wording_cliche`` item is a positive (the advisory *should* fire), a
+``domain_native`` item is a negative (it should *not*), and the acceptance gate is
+FNR < 0.30, FPR < 0.20, balanced accuracy >= 0.75.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterable
+
+# Label vocabulary — must match evals/gold/rq_framing_patterns/gold_set.json.
+POSITIVE_LABEL = "wording_cliche"
+NEGATIVE_LABEL = "domain_native"
+
+# Acceptance thresholds — must match scripts/check_rq_framing_patterns.py and the
+# task manifest (evals/gold/rq_framing_patterns/manifest.yaml).
+FNR_CEILING = 0.30
+FPR_CEILING = 0.20
+BALANCED_ACCURACY_FLOOR = 0.75
+
+# Final-line marker the seed skill instructs the model to emit, e.g. "ADVISORY: YES".
+_MARKER_RE = re.compile(r"ADVISORY\s*[:=]\s*(YES|NO|TRUE|FALSE|TRIGGER|PASS)\b", re.IGNORECASE)
+_TRUEY = {"yes", "true", "trigger"}
+_FALSEY = {"no", "false", "pass"}
+
+
+def expected_trigger(label: str) -> bool:
+    """Ground-truth ``trigger_advisory`` for a gold label.
+
+    ``wording_cliche`` -> the advisory should fire (positive);
+    ``domain_native`` -> it should not (negative).
+    """
+    if label == POSITIVE_LABEL:
+        return True
+    if label == NEGATIVE_LABEL:
+        return False
+    raise ValueError(f"unknown label {label!r}; expected one of "
+                     f"{POSITIVE_LABEL!r} / {NEGATIVE_LABEL!r}")
+
+
+def parse_trigger(model_output: str) -> bool | None:
+    """Extract ``trigger_advisory`` from a target model's free-text answer.
+
+    Two formats are accepted, tried in order:
+
+      1. A JSON object anywhere in the text carrying a ``trigger_advisory``
+         boolean (or "yes"/"no"/"true"/"false" string), e.g.
+         ``{"trigger_advisory": true, "pattern": "impact/effect frame"}``.
+      2. A final-line marker, e.g. ``ADVISORY: YES`` / ``ADVISORY: NO``.
+
+    Returns ``None`` when neither is present, so the caller can record an
+    unparseable rollout rather than silently scoring it as a negative.
+    """
+    if not model_output:
+        return None
+
+    # 1) JSON object with a trigger_advisory field (scan all {...} candidates).
+    for candidate in re.findall(r"\{[^{}]*\}", model_output, re.DOTALL):
+        try:
+            obj = json.loads(candidate)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and "trigger_advisory" in obj:
+            val = obj["trigger_advisory"]
+            if isinstance(val, bool):
+                return val
+            if isinstance(val, str):
+                low = val.strip().lower()
+                if low in _TRUEY:
+                    return True
+                if low in _FALSEY:
+                    return False
+
+    # 2) Final-line marker — last marker wins (the model's concluding verdict).
+    markers = _MARKER_RE.findall(model_output)
+    if markers:
+        return markers[-1].lower() in _TRUEY
+
+    return None
+
+
+def score_prediction(model_output: str, label: str) -> dict[str, Any]:
+    """Score one rollout output against its gold label.
+
+    Returns a dict shaped for SkillOpt's rollout contract: ``hard`` (0/1) and
+    ``soft`` (float in [0, 1]) plus diagnostic fields used by reflection and by
+    :func:`compute_metrics`. An unparseable answer counts as a wrong prediction
+    on the side opposite the truth, so the optimizer is pressured to fix format
+    drift too.
+    """
+    exp = expected_trigger(label)
+    parsed = parse_trigger(model_output)
+    if parsed is None:
+        predicted = not exp  # unparseable == wrong, whichever way truth points
+        parsed_ok = False
+        fail_reason = "unparseable: no trigger_advisory JSON field or ADVISORY marker"
+    else:
+        predicted = parsed
+        parsed_ok = True
+        fail_reason = "" if predicted == exp else (
+            "false_negative (missed wording cliche)" if exp else
+            "false_positive (over-warned on domain-native RQ)")
+
+    hard = 1.0 if predicted == exp else 0.0
+    return {
+        "hard": hard,
+        "soft": hard,  # binary task: soft == hard
+        "predicted_trigger": predicted,
+        "expected_trigger": exp,
+        "parsed_ok": parsed_ok,
+        "fail_reason": fail_reason,
+    }
+
+
+def compute_metrics(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate scored records into the ARS rq_framing_patterns metric block.
+
+    Each record must carry ``predicted_trigger`` (bool) and ``expected_trigger``
+    (bool) — exactly what :func:`score_prediction` returns. The output mirrors
+    ``scripts/check_rq_framing_patterns.py``: tp/tn/fp/fn counts, FNR, FPR,
+    balanced accuracy, and a ``passes_gate`` flag against the binding thresholds.
+    """
+    tp = tn = fp = fn = 0
+    for rec in records:
+        predicted = bool(rec["predicted_trigger"])
+        actual = bool(rec["expected_trigger"])
+        if predicted and actual:
+            tp += 1
+        elif predicted and not actual:
+            fp += 1
+        elif not predicted and actual:
+            fn += 1
+        else:
+            tn += 1
+
+    positives = tp + fn
+    negatives = tn + fp
+    fnr = fn / positives if positives else 0.0
+    fpr = fp / negatives if negatives else 0.0
+    tpr = tp / positives if positives else 0.0
+    tnr = tn / negatives if negatives else 0.0
+    balanced_accuracy = (tpr + tnr) / 2 if positives and negatives else 0.0
+
+    passes_gate = (
+        positives > 0
+        and negatives > 0
+        and fnr < FNR_CEILING
+        and fpr < FPR_CEILING
+        and balanced_accuracy >= BALANCED_ACCURACY_FLOOR
+    )
+
+    return {
+        "counts": {"tp": tp, "tn": tn, "fp": fp, "fn": fn,
+                   "positives": positives, "negatives": negatives},
+        "metrics": {"fnr": fnr, "fpr": fpr, "balanced_accuracy": balanced_accuracy},
+        "passes_gate": passes_gate,
+    }

--- a/tools/skillopt/configs/rq_framing_patterns.yaml
+++ b/tools/skillopt/configs/rq_framing_patterns.yaml
@@ -1,0 +1,80 @@
+# SkillOpt config — ARS rq_framing_patterns wording-advisory skill.
+#
+# Self-contained (no `_base_`): SkillOpt's configs/_base_/default.yaml is NOT
+# shipped in the pip wheel, so every key the loader needs is inlined here. Run with:
+#
+#   PYTHONPATH=. python tools/skillopt/run_ars_skillopt.py \
+#       --config tools/skillopt/configs/rq_framing_patterns.yaml
+#
+# Budget is deliberately small (2 epochs, 40-item gold set). Scale train.num_epochs /
+# train.batch_size / optimizer.learning_rate up for a fuller run. Every target/optimizer
+# call goes through the Claude CLI (claude_chat backend), so it draws on your
+# authenticated `claude` binary rather than a separate metered API key.
+
+model:
+  backend: claude_chat
+  optimizer: claude-opus-4-8       # proposes skill edits — ARS uses Opus for review/architecture
+  target: claude-sonnet-4-6        # executes the skill — ARS uses Sonnet for execution (never Haiku)
+  optimizer_backend: claude_chat
+  target_backend: claude_chat
+  reasoning_effort: medium
+  rewrite_reasoning_effort: ""
+  rewrite_max_completion_tokens: 64000
+  claude_code_exec_effort: medium
+  claude_code_exec_max_thinking_tokens: 16384
+  # Azure/OpenAI/MiniMax keys are unused under claude_chat but kept blank for loader safety.
+  azure_openai_endpoint: ""
+  azure_openai_api_version: "2024-12-01-preview"
+  azure_openai_api_key: ""
+  minimax_base_url: ""
+  minimax_api_key: ""
+
+train:
+  num_epochs: 2
+  train_size: 0          # 0 = derive from the dataset split
+  batch_size: 8
+  accumulation: 1
+  seed: 42
+
+gradient:
+  minibatch_size: 8
+  merge_batch_size: 8
+  analyst_workers: 8
+  max_analyst_rounds: 3
+  failure_only: false
+
+optimizer:
+  learning_rate: 3          # max edits per step
+  min_learning_rate: 2
+  lr_scheduler: cosine
+  lr_control_mode: fixed
+  skill_update_mode: patch
+  use_slow_update: true
+  slow_update_samples: 8
+  slow_update_gate_with_selection: false
+  longitudinal_pair_policy: mixed
+  use_meta_skill: true
+  use_skill_aware_reflection: false
+  skill_aware_appendix_source: both
+  skill_aware_consolidate_threshold: 0
+
+evaluation:
+  use_gate: true
+  sel_env_num: 0
+  test_env_num: 0
+  eval_test: true
+
+env:
+  name: ars_rq_framing_patterns
+  skill_init: tools/skillopt/skills/rq_framing_patterns/initial.md
+  split_mode: ratio                 # auto-split the single gold file into train/val/test
+  split_ratio: "5:2:3"              # 40 items -> ~20 train / ~8 val / ~12 test
+  split_seed: 42
+  split_dir: ""
+  data_path: evals/gold/rq_framing_patterns/gold_set.json
+  split_output_dir: ""
+  exec_timeout: 120
+  max_completion_tokens: 2048
+  workers: 8
+  limit: 0
+  out_root: ""

--- a/tools/skillopt/run_ars_skillopt.py
+++ b/tools/skillopt/run_ars_skillopt.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Launcher: run SkillOpt training/eval on an ARS gold set without forking SkillOpt.
+
+SkillOpt resolves its environment adapter from a module-global registry
+(``scripts.train._ENV_REGISTRY``) that ``_register_builtins()`` only ever *adds*
+to — so we can register the ARS adapter into it before handing control to
+SkillOpt's own ``main()``. No edit to the installed SkillOpt package is required.
+
+Usage (from the ARS repo root, with SkillOpt installed: ``pip install skillopt``):
+
+    PYTHONPATH=. python tools/skillopt/run_ars_skillopt.py \\
+        --config tools/skillopt/configs/rq_framing_patterns.yaml
+
+    # evaluate an already-optimized skill instead of training:
+    PYTHONPATH=. python tools/skillopt/run_ars_skillopt.py --eval \\
+        --config tools/skillopt/configs/rq_framing_patterns.yaml
+
+Any flags after ``--config`` are SkillOpt's own (see ``skillopt-train --help``).
+This launcher only injects the registry entry; it changes nothing else.
+"""
+from __future__ import annotations
+
+import sys
+
+ENV_KEY = "ars_rq_framing_patterns"
+
+
+def _register() -> None:
+    """Insert the ARS adapter into SkillOpt's env registry (idempotent)."""
+    try:
+        from scripts import train as skillopt_train
+    except ImportError as exc:  # pragma: no cover - depends on external install
+        raise SystemExit(
+            "SkillOpt is not importable. Install it first: `pip install skillopt` "
+            "(or clone microsoft/SkillOpt and `pip install -e .`). "
+            f"Underlying import error: {exc}"
+        )
+    from tools.skillopt.ars_adapter import ARSRQFramingAdapter
+
+    skillopt_train._ENV_REGISTRY[ENV_KEY] = ARSRQFramingAdapter
+
+
+def main() -> None:
+    eval_mode = "--eval" in sys.argv
+    if eval_mode:
+        sys.argv.remove("--eval")
+    _register()
+    if eval_mode:
+        from scripts import eval_only
+        eval_only.main()
+    else:
+        from scripts import train
+        train.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/skillopt/skills/rq_framing_patterns/initial.md
+++ b/tools/skillopt/skills/rq_framing_patterns/initial.md
@@ -1,0 +1,54 @@
+# Skill: Research-Question Wording-Pattern Advisory
+
+Decide whether a single proposed research question (RQ) uses an **AI-typical
+wording shell** that warrants a Socratic revision nudge. You judge **wording
+only** — surface phrasing — never the idea's quality, novelty, feasibility, or
+how broad the topic is. The advisory is a gentle prompt to re-phrase, so prefer a
+conservative trigger: fire on template-shaped wording, stay silent on specific,
+domain-native phrasing.
+
+## Fire the advisory (trigger = YES) when the RQ is a generic template shell
+
+These shells read as fill-in-the-blank scaffolds that could be dropped onto almost
+any topic. Common families:
+
+- "Exploring / investigating / examining the **impact / effect of** X **on** Y"
+- "The **relationship / association between** X **and** Y"
+- "Understanding the **role of** X **in** Y"
+- "How X **influences / affects** Y"
+- "**Factors influencing / affecting** Y"
+- "A **study of** X" / "A **comparative study of** X and Y"
+- "**Challenges and opportunities of** X" / "**Barriers and facilitators to** Y"
+- "**Perceptions / attitudes toward** X"
+- "The **effectiveness of** X **for / in** Y"
+- "The **mediating / moderating role of** X"
+- "**Toward a framework / model for** X"
+- "The **role of AI / technology** in **enhancing** Y"
+- "**Experiences of** group X **in** setting Y"
+
+Signal: opener verbs (explore/investigate/examine/analyze/understand) + an
+abstract noun template (impact/relationship/role/factors/effectiveness) + generic
+connectors (of … on/in/between). The wording would survive swapping the nouns for
+any other field's nouns.
+
+## Stay silent (trigger = NO) on domain-native wording
+
+Do **not** trigger just because the topic is broad. Stay silent when the wording
+carries specifics a template would not: named settings, actors, mechanisms,
+conditions, or concrete events. Markers of domain-native phrasing:
+
+- Names a place, population, institution, or system ("rural clinics in Tainan",
+  "first-generation graduate students", "municipal procurement rules").
+- Asks about a concrete mechanism or decision ("which cues do X use when
+  deciding…", "under what conditions does X resist Y", "what makes X usable for Y").
+- Encodes a situated event or tension ("when nurses override sepsis alerts…",
+  "after transit expansion", "mid-term when a new dashboard arrives").
+
+A specific RQ can still be about a broad theme (feedback, adoption, authorship) —
+specificity of *wording*, not narrowness of *topic*, is what keeps it silent.
+
+## Decision
+
+Weigh shell-ness against specificity. If the phrasing is a swappable template,
+fire. If concrete particulars anchor it to a real setting/mechanism, stay silent.
+When genuinely mixed, lean silent (false positives erode trust in the advisory).

--- a/tools/skillopt/tests/test_ars_scoring_offline.py
+++ b/tools/skillopt/tests/test_ars_scoring_offline.py
@@ -1,0 +1,113 @@
+"""Offline plumbing test for the ARS x SkillOpt harness — ZERO API calls.
+
+Validates the only logic the harness must get right independent of any optimizer:
+parsing a model answer into ``trigger_advisory`` and scoring/aggregating against
+the gold labels. Imports only ``tools.skillopt.ars_scoring`` (pure — no SkillOpt,
+no network, no ``ANTHROPIC_API_KEY``), and drives it over the real
+``evals/gold/rq_framing_patterns/gold_set.json`` with stubbed model outputs.
+
+Run from the repo root:
+
+    python -m pytest tools/skillopt/tests/test_ars_scoring_offline.py -q
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.skillopt.ars_scoring import (
+    BALANCED_ACCURACY_FLOOR,
+    NEGATIVE_LABEL,
+    POSITIVE_LABEL,
+    compute_metrics,
+    expected_trigger,
+    parse_trigger,
+    score_prediction,
+)
+
+GOLD_PATH = Path(__file__).resolve().parents[3] / "evals/gold/rq_framing_patterns/gold_set.json"
+
+
+# ── parse_trigger ──────────────────────────────────────────────────────────
+def test_parse_marker_yes_no():
+    assert parse_trigger("Reasoning...\nADVISORY: YES") is True
+    assert parse_trigger("Reasoning...\nADVISORY: NO") is False
+    assert parse_trigger("advisory : true") is True
+    assert parse_trigger("ADVISORY=false") is False
+
+
+def test_parse_json_field():
+    assert parse_trigger('{"trigger_advisory": true}') is True
+    assert parse_trigger('prose {"trigger_advisory": false} more') is False
+    assert parse_trigger('{"trigger_advisory": "yes"}') is True
+
+
+def test_parse_last_marker_wins():
+    # A model that reconsiders mid-answer: the concluding verdict is authoritative.
+    assert parse_trigger("ADVISORY: NO ... on reflection ADVISORY: YES") is True
+
+
+def test_parse_unparseable_returns_none():
+    assert parse_trigger("I think this is fine.") is None
+    assert parse_trigger("") is None
+
+
+# ── expected_trigger ───────────────────────────────────────────────────────
+def test_expected_trigger_mapping():
+    assert expected_trigger(POSITIVE_LABEL) is True
+    assert expected_trigger(NEGATIVE_LABEL) is False
+
+
+# ── score_prediction ───────────────────────────────────────────────────────
+def test_score_correct_and_wrong():
+    # Correct positive.
+    s = score_prediction("ADVISORY: YES", POSITIVE_LABEL)
+    assert s["hard"] == 1.0 and s["parsed_ok"] and s["fail_reason"] == ""
+    # False negative.
+    s = score_prediction("ADVISORY: NO", POSITIVE_LABEL)
+    assert s["hard"] == 0.0 and "false_negative" in s["fail_reason"]
+    # False positive.
+    s = score_prediction("ADVISORY: YES", NEGATIVE_LABEL)
+    assert s["hard"] == 0.0 and "false_positive" in s["fail_reason"]
+
+
+def test_unparseable_scores_as_miss():
+    # Unparseable on a positive -> counted as the wrong (negative) prediction.
+    s = score_prediction("no verdict here", POSITIVE_LABEL)
+    assert s["hard"] == 0.0 and s["parsed_ok"] is False
+    assert s["predicted_trigger"] is False
+
+
+# ── compute_metrics over the real gold set ─────────────────────────────────
+def _load_gold():
+    items = json.loads(GOLD_PATH.read_text(encoding="utf-8"))["items"]
+    assert len(items) == 40, "gold set should hold 40 items"
+    return items
+
+
+def test_perfect_oracle_passes_gate():
+    """An oracle that always emits the gold-correct verdict scores 1.0 / passes."""
+    records = []
+    for it in _load_gold():
+        correct = "ADVISORY: YES" if it["label"] == POSITIVE_LABEL else "ADVISORY: NO"
+        records.append(score_prediction(correct, it["label"]))
+    m = compute_metrics(records)
+    assert m["counts"] == {"tp": 20, "tn": 20, "fp": 0, "fn": 0,
+                           "positives": 20, "negatives": 20}
+    assert m["metrics"]["balanced_accuracy"] == 1.0
+    assert m["metrics"]["fnr"] == 0.0 and m["metrics"]["fpr"] == 0.0
+    assert m["passes_gate"] is True
+
+
+def test_borderline_model_fails_gate():
+    """A model that over-warns on every domain-native RQ blows the FPR ceiling."""
+    records = []
+    for it in _load_gold():
+        # Always says YES -> all positives caught (FNR 0) but every negative is a FP.
+        records.append(score_prediction("ADVISORY: YES", it["label"]))
+    m = compute_metrics(records)
+    assert m["counts"]["fp"] == 20 and m["counts"]["fn"] == 0
+    assert m["metrics"]["fpr"] == 1.0
+    assert m["metrics"]["balanced_accuracy"] == 0.5
+    assert m["metrics"]["balanced_accuracy"] < BALANCED_ACCURACY_FLOOR
+    assert m["passes_gate"] is False


### PR DESCRIPTION
## What

Adds `tools/skillopt/` — an integration harness that wires
[Microsoft **SkillOpt**](https://github.com/microsoft/SkillOpt) onto the existing
`evals/gold/rq_framing_patterns` gold set, so the Kong #257 Socratic
wording-pattern advisory can be **trained as a natural-language skill** and gated
on held-out validation (SkillOpt's rollout → reflect → bounded-edit → validation-gate loop).

**Additive tooling only — no `SKILL.md`, agent, mode, or schema is touched.** The
only change outside the new directory is two `.gitignore` lines for the harness's
regenerated runtime artifacts.

## Why

ARS detects AI-typical RQ wording today with a deterministic regex detector
(`scripts/check_rq_framing_patterns.py`, the twenty `WP01`–`WP20` shells). It scores
`balanced_accuracy = 1.000` on the gold set — but the gold set was *authored to match
those regexes*, so the score reflects construction, not generalization. Any **novel**
AI-typical phrasing outside the 20 shells slips through silently.

This harness offers the complementary capability: train a compact **LLM skill** that
makes the same advisory judgment, measured by the **same metric and acceptance gate**
(FNR < 0.30, FPR < 0.20, balanced accuracy ≥ 0.75). It gives ARS a disciplined,
reproducible way to evolve the advisory toward generalization instead of hand-editing
a prompt — built on the gold-set + threshold infrastructure that already exists.

## Layout

| File | Role |
|---|---|
| `ars_scoring.py` | **Pure** (no SkillOpt/network/key): parse `trigger_advisory`, score + aggregate vs gold; mirrors `check_rq_framing_patterns.py`'s metric. |
| `ars_gold_loader.py` | SkillOpt `SplitDataLoader` over `gold_set.json`. |
| `ars_adapter.py` | SkillOpt `EnvAdapter`: single-turn `claude_chat` rollout + scoring + reflect. |
| `run_ars_skillopt.py` | Launcher — registers the adapter into SkillOpt's env registry **without forking SkillOpt**. |
| `configs/rq_framing_patterns.yaml` | Self-contained config (Claude backend, deliberately small budget). |
| `skills/rq_framing_patterns/initial.md` | Seed skill — the trainable starting point. |
| `tests/test_ars_scoring_offline.py` | Zero-API plumbing test over the real gold set. |

## Testing

- **Offline scoring test passes (zero API):**
  `python -m pytest tools/skillopt/tests/test_ars_scoring_offline.py -q` → 9 passed.
- **End-to-end plumbing verified against SkillOpt `v0.1.0` with zero model calls:**
  register adapter → load gold → deterministic 20/8/12 ratio split → build batch →
  stubbed rollout → score/metrics, all green.
- Resolved the benign `scripts` package-name collision between ARS and SkillOpt
  (PEP 420: SkillOpt's regular package wins; verified with the ARS root first on
  `PYTHONPATH`). Implemented `EnvAdapter.reflect` explicitly because `v0.1.0` marks
  it abstract with no body.

## Scope / next steps

Per `CONTRIBUTING.md`, this is additive tooling (like the existing `evals/` harness),
not a `SKILL.md`/agent change — so no prior issue was required. Running an actual
optimization spends model budget and is left as an **opt-in, maintainer-gated
follow-up**: train, validate the lift with `scripts/run_evals.py --task
rq_framing_patterns`, and bring before/after evidence to an issue before proposing any
trained skill for the pipeline.

Happy to adjust the target task, seed skill, or config to match maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
