### PR TITLE
docs: credit devCharlotte for Korean README translation

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -328,6 +328,8 @@ https://github.com/Imbad0202/academic-research-skills
 
 **[xpfo-go](https://github.com/xpfo-go)** (xpfo) — 기여자. 간체중국어 README([`README.zh-CN.md`](README.zh-CN.md))를 번역했습니다([PR #181](https://github.com/Imbad0202/academic-research-skills/pull/181)).
 
+**[devCharlotte](https://github.com/devCharlotte)** — 기여자. 한국어 README([`README.ko-KR.md`](README.ko-KR.md))를 번역했습니다([PR #469](https://github.com/Imbad0202/academic-research-skills/pull/469)).
+
 **[Yaobin29](https://github.com/Yaobin29)** — 기여자. [PR #433](https://github.com/Imbad0202/academic-research-skills/pull/433)에서 리뷰어 응답 도구를 제안했습니다. `deep-research three-way-scan` 모드와 `academic-paper rebuttal-audit` 모드(해당 PR의 `audit` 개념을 발전시킨 기능)가 v3.12.1에서 정식으로 통합되었습니다.
 
 ---
@@ -413,7 +415,7 @@ https://github.com/Imbad0202/academic-research-skills
 
 ### v3.7.0 (2026-05-05) — Claude Code Plugin Packaging
 
-> 플러그인 패키징 업그레이드: ARS가 이제 `/plugin marketplace add Imbad0202/academic-research-skills` + `/plugin install academic-research-skills`로 Claude Code CLI / VS Code / JetBrains에 한 줄로 설치됩니다. 전통적인 `git clone` + `~/.claude/skills/` 경로로 연결하는  방식도 계속 동작합니다 — 두 트랙 모두 일급입니다.
+> 플러그인 패키징 업그레이드: ARS가 이제 `/plugin marketplace add Imbad0202/academic-research-skills` + `/plugin install academic-research-skills`로 Claude Code CLI / VS Code / JetBrains에 한 줄로 설치됩니다. 전통적인 `git clone` + `~/.claude/skills/` 경로로 연결하는 방식도 계속 동작합니다 — 두 트랙 모두 일급입니다.
 
 - **플러그인 manifest + marketplace 메타데이터**(Phase 1, PR #68). `.claude-plugin/plugin.json`이 스위트를 선언(`skills/` 디렉터리에서 상대 symlink로 자동 발견되는 4개 스킬). `.claude-plugin/marketplace.json`이 플러그인을 등록해 단일 GitHub 호스팅 엔드포인트가 marketplace 목록과 플러그인 소스를 모두 제공. README + `README.zh-TW.md` + `docs/SETUP.md`가 dual-track 설치 지침을 담음.
 - **10개 슬래시 명령**(`commands/ars-*.md`, Phase 2.1, PR #69)이 `MODE_REGISTRY.md` 항목을 `/ars-<mode>` 트리거에 매핑. 모델 라우팅은 각 명령의 frontmatter에 고정 — `full`과 `revision-coach`에는 `opus`(아키텍처 / 검토 해석 깊이), 나머지 8개에는 `sonnet`. 프로젝트 정책에 따라 Haiku 없음.

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ https://github.com/Imbad0202/academic-research-skills
 
 **[xpfo-go](https://github.com/xpfo-go)** (xpfo) — Contributor. Translated the Simplified Chinese README ([`README.zh-CN.md`](README.zh-CN.md)) ([PR #181](https://github.com/Imbad0202/academic-research-skills/pull/181)).
 
+**[devCharlotte](https://github.com/devCharlotte)** — Contributor. Translated the Korean README ([`README.ko-KR.md`](README.ko-KR.md)) ([PR #469](https://github.com/Imbad0202/academic-research-skills/pull/469)).
+
 **[Yaobin29](https://github.com/Yaobin29)** — Contributor. Proposed reviewer-response tooling in [PR #433](https://github.com/Imbad0202/academic-research-skills/pull/433); the `deep-research three-way-scan` mode and the `academic-paper rebuttal-audit` mode (rescued from the PR's `audit` concept) were integrated from that contribution in v3.12.1.
 
 ---


### PR DESCRIPTION
Maintainer cleanup following #469 (Korean README).

## Changes
- Add **devCharlotte** to the Contributors section in `README.md` and `README.ko-KR.md`, crediting the Korean README translation (#469). This matches the existing translator credits for [eltociear](https://github.com/eltociear) (Japanese) and [xpfo-go](https://github.com/xpfo-go) (Simplified Chinese), per `CONTRIBUTING.md`'s Credit policy.
- Fix a double-space typo in `README.ko-KR.md` (`연결하는  방식` → `연결하는 방식`) introduced during the #469 review follow-up.

Docs-only. `check_spec_consistency.py`, `check_version_consistency.py`, and the Korean README regression suite (28 tests) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)