### PR TITLE
ci(eval-harness): render PR comment as verdict + table, fold raw JSON

### DIFF
--- a/.github/workflows/eval-harness.yml
+++ b/.github/workflows/eval-harness.yml
@@ -105,13 +105,11 @@ jobs:
           if [ -n "$failed" ]; then
             echo "::notice title=Eval below threshold::${failed}"
           fi
-          {
-            echo "## Eval harness results"
-            echo ""
-            echo '```json'
-            cat "$report"
-            echo '```'
-          } > eval_comment.md
+          # Comment body: one-line verdict + per-task table + raw JSON folded
+          # into <details>. Display layer only — rendered by a unit-tested
+          # module (scripts/render_eval_comment.py), not inline shell; the
+          # threshold verdict above is untouched.
+          python -m scripts.render_eval_comment "$report" > eval_comment.md
 
       - name: Post PR comment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/scripts/_ci_pytest_manifest.toml
+++ b/scripts/_ci_pytest_manifest.toml
@@ -147,6 +147,10 @@ id = "v3.10-184-eval-harness-workflow"
 path = "scripts/test_eval_harness_workflow.py"
 
 [[pytest]]
+id = "184-render-eval-comment"
+path = "scripts/test_render_eval_comment.py"
+
+[[pytest]]
 id = "v3.10-134-write-scope-guard"
 path = "scripts/test_ars_write_scope_guard.py"
 

--- a/scripts/render_eval_comment.py
+++ b/scripts/render_eval_comment.py
@@ -35,9 +35,9 @@ def _fmt_value(value: Any) -> str:
 
 def _cell(text: Any) -> str:
     """Markdown-table-safe cell: report strings (task_name, metric, comparison)
-    come from eval manifests, so a `|` or newline would break the table or spoof
-    extra rows/results."""
-    return str(text).replace("\n", " ").replace("|", "\\|")
+    come from eval manifests, so a `|` or any line boundary (\\n, \\r, U+2028…)
+    would break the table or spoof extra rows/results."""
+    return " ".join(str(text).splitlines()).replace("|", "\\|")
 
 
 def _task_failures(task: dict[str, Any]) -> tuple[bool, bool]:
@@ -119,7 +119,8 @@ def main(argv: list[str] | None = None) -> int:
         print("usage: python -m scripts.render_eval_comment <report.json>",
               file=sys.stderr)
         return 2
-    raw_json = open(args[0], encoding="utf-8").read()
+    with open(args[0], encoding="utf-8") as fh:
+        raw_json = fh.read()
     report = json.loads(raw_json)
     print(render_comment(report, raw_json))
     return 0

--- a/scripts/render_eval_comment.py
+++ b/scripts/render_eval_comment.py
@@ -33,6 +33,13 @@ def _fmt_value(value: Any) -> str:
     return str(value)
 
 
+def _cell(text: Any) -> str:
+    """Markdown-table-safe cell: report strings (task_name, metric, comparison)
+    come from eval manifests, so a `|` or newline would break the table or spoof
+    extra rows/results."""
+    return str(text).replace("\n", " ").replace("|", "\\|")
+
+
 def _task_failures(task: dict[str, Any]) -> tuple[bool, bool]:
     """(aggregate_failed, per_class_failed) — mirrors the gate's failure signal."""
     agg = task.get("aggregate_metric") or {}
@@ -42,16 +49,16 @@ def _task_failures(task: dict[str, Any]) -> tuple[bool, bool]:
 
 
 def _table_row(task: dict[str, Any]) -> str:
-    name = task.get("task_name", "?")
+    name = _cell(task.get("task_name", "?"))
     if task.get("status", "measured") != "measured":
         return f"| {name} | — | — | — | {_PENDING_RESULT} |"
     agg = task.get("aggregate_metric") or {}
-    metric = agg.get("metric", "—")
-    value = _fmt_value(agg["value"]) if "value" in agg else "—"
+    metric = _cell(agg.get("metric", "—"))
+    value = _cell(_fmt_value(agg["value"])) if "value" in agg else "—"
     if "threshold_value" in agg:
         comparison = agg.get("comparison", ">=")
         symbol = _COMPARISON_SYMBOLS.get(comparison, comparison)
-        threshold = f"{symbol} {_fmt_value(agg['threshold_value'])}"
+        threshold = _cell(f"{symbol} {_fmt_value(agg['threshold_value'])}")
     else:
         threshold = "—"
     agg_failed, pc_failed = _task_failures(task)

--- a/scripts/render_eval_comment.py
+++ b/scripts/render_eval_comment.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Render a ``run_evals`` report as the eval-harness PR comment markdown.
+
+Display layer ONLY (#184 follow-up): the workflow used to paste the whole
+``eval_report.json`` into the PR comment as one raw fenced block. This module
+renders the same report as a one-line verdict + a per-task table, with the
+full JSON folded into a ``<details>`` block. The threshold verdict itself is
+computed by ``scripts._eval_threshold_gate`` — this renderer never gates.
+
+Kept out of the workflow YAML (no inline heredoc) per the same house rule as
+the gate module; see scripts/test_eval_harness_workflow.py.
+
+CLI::
+
+    python -m scripts.render_eval_comment <report.json>
+
+prints the comment markdown to stdout.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+_COMPARISON_SYMBOLS = {">=": "≥", "<=": "≤", "==": "="}
+
+_PENDING_RESULT = "⏸️ pending"
+
+
+def _fmt_value(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _task_failures(task: dict[str, Any]) -> tuple[bool, bool]:
+    """(aggregate_failed, per_class_failed) — mirrors the gate's failure signal."""
+    agg = task.get("aggregate_metric") or {}
+    agg_failed = agg.get("passed") is False
+    pc_failed = any(pc.get("passed") is False for pc in task.get("per_class", []))
+    return agg_failed, pc_failed
+
+
+def _table_row(task: dict[str, Any]) -> str:
+    name = task.get("task_name", "?")
+    if task.get("status", "measured") != "measured":
+        return f"| {name} | — | — | — | {_PENDING_RESULT} |"
+    agg = task.get("aggregate_metric") or {}
+    metric = agg.get("metric", "—")
+    value = _fmt_value(agg["value"]) if "value" in agg else "—"
+    if "threshold_value" in agg:
+        comparison = agg.get("comparison", ">=")
+        symbol = _COMPARISON_SYMBOLS.get(comparison, comparison)
+        threshold = f"{symbol} {_fmt_value(agg['threshold_value'])}"
+    else:
+        threshold = "—"
+    agg_failed, pc_failed = _task_failures(task)
+    if agg_failed:
+        result = "❌"
+    elif pc_failed:
+        # Aggregate met its threshold but a per-class metric did not — the gate
+        # still blocks (#328), so the row must not show a clean pass.
+        result = "❌ (per-class)"
+    else:
+        result = "✅"
+    return f"| {name} | {metric} | {value} | {threshold} | {result} |"
+
+
+def render_comment(report: dict[str, Any], raw_json: str) -> str:
+    tasks = report.get("per_task", [])
+    measured = [t for t in tasks if t.get("status", "measured") == "measured"]
+    pending = [t for t in tasks if t.get("status", "measured") != "measured"]
+    passed = [t for t in measured if not any(_task_failures(t))]
+
+    if not measured:
+        verdict = "⏸️ no measured tasks"
+    else:
+        emoji = "✅" if len(passed) == len(measured) else "❌"
+        verdict = f"{emoji} {len(passed)}/{len(measured)} measured tasks passed"
+    if pending:
+        verdict += f" · {len(pending)} pending (not wired)"
+
+    lines = [
+        "## Eval harness results",
+        "",
+        verdict,
+        "",
+        "| Task | Metric | Value | Threshold | Result |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    lines.extend(_table_row(t) for t in measured + pending)
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Raw JSON</summary>",
+            "",
+            "```json",
+            raw_json.rstrip("\n"),
+            "```",
+            "",
+            "</details>",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print("usage: python -m scripts.render_eval_comment <report.json>",
+              file=sys.stderr)
+        return 2
+    raw_json = open(args[0], encoding="utf-8").read()
+    report = json.loads(raw_json)
+    print(render_comment(report, raw_json))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_eval_harness_workflow.py
+++ b/scripts/test_eval_harness_workflow.py
@@ -124,6 +124,16 @@ def test_harness_step_computes_failed_tasks(workflow):
     assert "GITHUB_OUTPUT" in body
 
 
+def test_comment_built_by_renderer_module(workflow):
+    steps = _steps(workflow)
+    run_step = next(s for s in steps if s.get("id") == "run")
+    body = run_step["run"]
+    # The PR comment body is rendered by the unit-tested display module (not a
+    # raw `cat` of the report into a fenced block).
+    assert "scripts.render_eval_comment" in body
+    assert "eval_comment.md" in body
+
+
 def test_workflow_has_no_inline_python_heredoc(raw):
     # Fix 1 moved the gate logic into a module; no fragile inline python heredoc
     # should remain in the workflow.

--- a/scripts/test_render_eval_comment.py
+++ b/scripts/test_render_eval_comment.py
@@ -127,3 +127,11 @@ def test_cli_main_writes_markdown(tmp_path, capsys):
 
 def test_cli_main_usage_error():
     assert main([]) == 2
+
+
+def test_table_cells_escape_pipes_and_newlines():
+    # task_name / metric come from eval manifests; a `|` or newline must not
+    # break the table or spoof extra columns (codex review P2).
+    task = _measured("evil|name\nrow", metric="acc|uracy")
+    out = _render([task])
+    assert "| evil\\|name row | acc\\|uracy |" in out

--- a/scripts/test_render_eval_comment.py
+++ b/scripts/test_render_eval_comment.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import json
 
-from scripts.render_eval_comment import main, render_comment
+from scripts._eval_threshold_gate import failed_tasks
+from scripts.render_eval_comment import _task_failures, main, render_comment
 
 
 def _measured(name, metric="accuracy", value=1.0, threshold=0.9,
@@ -129,9 +130,33 @@ def test_cli_main_usage_error():
     assert main([]) == 2
 
 
-def test_table_cells_escape_pipes_and_newlines():
-    # task_name / metric come from eval manifests; a `|` or newline must not
-    # break the table or spoof extra columns (codex review P2).
-    task = _measured("evil|name\nrow", metric="acc|uracy")
+def test_failure_signal_agrees_with_threshold_gate():
+    # _task_failures deliberately MIRRORS (does not import) the gate's failure
+    # rule — importing would couple display to the gate's flat key format.
+    # This pin makes the mirror loud instead of silent: if a future gated axis
+    # lands in _eval_threshold_gate but not here, this fails in CI rather than
+    # the comment rendering green on a run the gate blocks.
+    report = {"per_task": [
+        _measured("agg_fail", value=0.5, passed=False),
+        _measured("pc_fail", per_class=[{"class_name": "high",
+                                         "metric": "accuracy",
+                                         "passed": False}]),
+        _measured("both_fail", value=0.5, passed=False,
+                  per_class=[{"class_name": "low", "metric": "accuracy",
+                              "passed": False}]),
+        _measured("clean"),
+        _pending("pending_task"),
+    ]}
+    renderer_failed = {t["task_name"] for t in report["per_task"]
+                       if any(_task_failures(t))}
+    gate_failed = {key.split(".")[0] for key in failed_tasks(report)}
+    assert renderer_failed == gate_failed == {"agg_fail", "pc_fail", "both_fail"}
+
+
+def test_table_cells_escape_pipes_and_line_boundaries():
+    # task_name / metric come from eval manifests; a `|` or any line boundary
+    # (\n, \r, \r\n) must not break the table or spoof extra columns/rows
+    # (codex review P2 + re-review \r gap).
+    task = _measured("evil|name\nrow\rmore\r\nend", metric="acc|uracy")
     out = _render([task])
-    assert "| evil\\|name row | acc\\|uracy |" in out
+    assert "| evil\\|name row more end | acc\\|uracy |" in out

--- a/scripts/test_render_eval_comment.py
+++ b/scripts/test_render_eval_comment.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/render_eval_comment.py (eval-harness PR comment renderer).
+
+Display layer only: these tests pin the comment SHAPE (verdict line, table
+rows, folded raw JSON). The gate semantics stay pinned by
+scripts/test__eval_threshold_gate.py; the renderer must agree with the gate's
+failure signal (aggregate AND per-class) so the table never shows a clean pass
+on a run the gate blocks.
+"""
+from __future__ import annotations
+
+import json
+
+from scripts.render_eval_comment import main, render_comment
+
+
+def _measured(name, metric="accuracy", value=1.0, threshold=0.9,
+              comparison=">=", passed=True, per_class=None):
+    task = {
+        "task_name": name,
+        "status": "measured",
+        "aggregate_metric": {
+            "metric": metric,
+            "value": value,
+            "threshold_value": threshold,
+            "comparison": comparison,
+            "passed": passed,
+        },
+    }
+    if per_class is not None:
+        task["per_class"] = per_class
+    return task
+
+
+def _pending(name):
+    # Shape mirrors run_evals._pending_result: a placeholder aggregate_metric
+    # with no threshold — the renderer must key off status, not metric absence.
+    return {
+        "task_name": name,
+        "status": "pending",
+        "notice": "entrypoint unavailable",
+        "aggregate_metric": {
+            "metric": "accuracy",
+            "value": 0.0,
+            "direction": "higher_is_better",
+        },
+    }
+
+
+def _render(tasks):
+    report = {"per_task": tasks}
+    return render_comment(report, json.dumps(report, indent=2))
+
+
+def test_all_passed_verdict_line():
+    out = _render([_measured("citation_extraction"),
+                   _measured("rq_framing_patterns", metric="balanced_accuracy",
+                             threshold=0.75),
+                   _pending("field_norm_severity"),
+                   _pending("surface_form_parity")])
+    assert "✅ 2/2 measured tasks passed · 2 pending (not wired)" in out
+
+
+def test_measured_row_renders_metric_value_threshold():
+    out = _render([_measured("citation_extraction")])
+    assert "| citation_extraction | accuracy | 1.00 | ≥ 0.90 | ✅ |" in out
+
+
+def test_pending_row_uses_placeholder_columns():
+    out = _render([_measured("citation_extraction"),
+                   _pending("field_norm_severity")])
+    assert "| field_norm_severity | — | — | — | ⏸️ pending |" in out
+
+
+def test_aggregate_failure_marks_row_and_verdict():
+    out = _render([_measured("citation_extraction", value=0.80, passed=False)])
+    assert "| citation_extraction | accuracy | 0.80 | ≥ 0.90 | ❌ |" in out
+    assert "❌ 0/1 measured tasks passed" in out
+
+
+def test_per_class_only_failure_still_fails_row():
+    # Aggregate passes but a per-class metric fails: the gate blocks (#328),
+    # so the row and the verdict must not read as a clean pass.
+    per_class = [{"class_name": "high", "metric": "accuracy",
+                  "value": 0.70, "threshold_value": 0.85,
+                  "comparison": ">=", "passed": False}]
+    out = _render([_measured("citation_extraction", per_class=per_class)])
+    assert "❌ (per-class)" in out
+    assert "❌ 0/1 measured tasks passed" in out
+
+
+def test_lower_is_better_comparison_passes_through():
+    out = _render([_measured("field_norm_severity", metric="fnr", value=0.10,
+                             threshold=0.30, comparison="<=")])
+    assert "| field_norm_severity | fnr | 0.10 | ≤ 0.30 | ✅ |" in out
+
+
+def test_measured_rows_sort_before_pending():
+    out = _render([_pending("surface_form_parity"),
+                   _measured("citation_extraction")])
+    assert out.index("| citation_extraction |") < out.index(
+        "| surface_form_parity |")
+
+
+def test_no_pending_omits_pending_suffix():
+    out = _render([_measured("citation_extraction")])
+    assert "pending" not in out.splitlines()[2]
+
+
+def test_raw_json_folded_in_details():
+    report = {"per_task": [_measured("citation_extraction")]}
+    raw = json.dumps(report, indent=2)
+    out = render_comment(report, raw)
+    assert out.index("<details>") < out.index("```json") < out.index(raw)
+    assert out.index(raw) < out.index("</details>")
+
+
+def test_cli_main_writes_markdown(tmp_path, capsys):
+    report = {"per_task": [_measured("citation_extraction"),
+                           _pending("surface_form_parity")]}
+    path = tmp_path / "eval_report.json"
+    path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    assert main([str(path)]) == 0
+    stdout = capsys.readouterr().out
+    assert stdout.startswith("## Eval harness results")
+    assert "✅ 1/1 measured tasks passed · 1 pending (not wired)" in stdout
+
+
+def test_cli_main_usage_error():
+    assert main([]) == 2


### PR DESCRIPTION
## What

The eval-harness workflow pasted the entire `eval_report.json` into every PR comment as one raw fenced block. This PR replaces that with a readable comment:

- one-line verdict: `✅ N/M measured tasks passed · K pending (not wired)`
- a per-task table (Task / Metric / Value / Threshold / Result), measured rows first, pending rows with `—` placeholders
- the full raw JSON folded into `<details>`

## How

- New `scripts/render_eval_comment.py` — display module, no gate logic. Follows the house rule already stated in the workflow ("logic lives in a unit-tested module, not an inline heredoc"), and `test_workflow_has_no_inline_python_heredoc` forbids the heredoc route anyway.
- The row verdict mirrors the gate's failure signal (aggregate AND per-class, #328): a task whose aggregate passes but a per-class metric fails renders `❌ (per-class)`, so the table never shows a clean pass on a run the gate blocks.
- 11 unit tests in `scripts/test_render_eval_comment.py`, registered in `scripts/_ci_pytest_manifest.toml`; `test_eval_harness_workflow.py` gains a pin so the comment can't silently regress to a raw dump.

## Not touched

`run_evals`, `scripts._eval_threshold_gate`, the threshold gate step, and the `[eval-regression-acknowledged]` ack contract — display layer only.

## Verification

- 31 tests pass locally (renderer + workflow + gate).
- Rendered against a real local `run_evals` report — output matches the approved shape.
- This workflow file change triggers the eval-harness run on this very PR, so the new comment format is visible below.

[skip-closes-check] Display-layer CI polish agreed directly with the maintainer; no tracking issue exists for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jcH7gEkVTQ1baMbVedSZp