### PR TITLE
fix(plugin): declare explicit skill paths in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,13 @@
       "source": "./",
       "description": "4 skills + 27 modes + Material Passport pipeline. Includes v3.6.7 cross-model audit gate and v3.6.8 generator-evaluator contract.",
       "version": "3.13.0",
-      "license": "CC-BY-NC-4.0"
+      "license": "CC-BY-NC-4.0",
+      "skills": [
+        "./academic-paper",
+        "./academic-paper-reviewer",
+        "./academic-pipeline",
+        "./deep-research"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds an explicit `"skills"` array (the four real top-level skill directories) to the marketplace plugin entry.

## Why

The entry relied on the default `skills/` directory scan, but `skills/` holds **symlinks** to the top-level skill dirs. Symlink-blind consumers — GitHub-API importers (e.g. Claude Science's "Import from GitHub" reports *"Not importable: no skills/ dirs with SKILL.md"*) and Windows checkouts without symlink support — see zero skills. Same failure class as #413 (agents/ symlinks).

## Claude Code behavior is unchanged

Per the plugins reference (docs dated 2026-06-30), for a marketplace entry whose `source` resolves to the marketplace root (ours is `"./"`), paths listed in `skills` **replace** the default `skills/` scan and become the complete set. Claude Code installs therefore load the same four skills as before, from their real paths instead of via symlinks — no content change, no double-loading.

## Verification

- JSON parses; `scripts/check_version_consistency.py` passes.
- Each listed path contains `SKILL.md`.
- Post-merge: re-run Claude Science "Import from GitHub" against the repo to confirm the importer now finds the 4 skills (this is the consumer that motivated the fix and cannot be exercised in CI).

[skip-closes-check] Metadata-only portability fix agreed directly with the maintainer; no tracking issue exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jcH7gEkVTQ1baMbVedSZp