### PR TITLE
feat(lint): #491 defrift lock (canonical enforcement sentence) + SETUP parity + manifest gap

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -139,7 +139,8 @@ jobs:
 
       - name: Check SETUP cross-model example parity (#491)
         # The pytest companion `test_check_setup_cross_model_parity.py`
-        # runs via the unified manifest.
+        # runs via the unified manifest (and also under pytest.yml's
+        # scripts/ glob — that 2x overlap is the accepted manifest pattern).
         run: python3 scripts/check_setup_cross_model_parity.py
 
       - name: Run version consistency unit tests

--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -137,6 +137,11 @@ jobs:
           PYTHONPATH: scripts
         run: python3 scripts/check_version_consistency.py
 
+      - name: Check SETUP cross-model example parity (#491)
+        # The pytest companion `test_check_setup_cross_model_parity.py`
+        # runs via the unified manifest.
+        run: python3 scripts/check_setup_cross_model_parity.py
+
       - name: Run version consistency unit tests
         env:
           PYTHONPATH: .

--- a/scripts/_ci_pytest_manifest.toml
+++ b/scripts/_ci_pytest_manifest.toml
@@ -259,3 +259,11 @@ path = "scripts/test_check_390_revision_patch_discipline.py"
 [[pytest]]
 id = "release-gate-changelog-covers-merges"
 path = "scripts/test_check_changelog_covers_merges.py"
+
+[[pytest]]
+id = "v3.9.4-temporal-verification"
+path = "scripts/test_check_v3_9_4_temporal_verification.py"
+
+[[pytest]]
+id = "491-setup-cross-model-parity"
+path = "scripts/test_check_setup_cross_model_parity.py"

--- a/scripts/check_setup_cross_model_parity.py
+++ b/scripts/check_setup_cross_model_parity.py
@@ -62,7 +62,13 @@ def canonical_model_ids(canonical_text: str) -> set[str]:
                 api_id_col = next(i for i, c in enumerate(cells) if "API ID" in c)
             continue
         if len(cells) > api_id_col:
-            ids.update(re.findall(r"`([^`]+)`", cells[api_id_col]))
+            # Globs like `gpt-*` (from the compat table's "any non-`gpt-*`
+            # id" prose) are prefix patterns, not model ids — exclude them.
+            ids.update(
+                tok
+                for tok in re.findall(r"`([^`]+)`", cells[api_id_col])
+                if "*" not in tok
+            )
     return ids
 
 

--- a/scripts/check_setup_cross_model_parity.py
+++ b/scripts/check_setup_cross_model_parity.py
@@ -13,13 +13,17 @@ This lint pins the two invariants that broke:
 1. **en/zh-TW parity** — both SETUP files must carry the same set of
    `ARS_CROSS_MODEL` example values (the zh-TW file mirrors the bash block
    verbatim; a one-sided edit is drift).
-2. **canonical membership** — every example value must appear (backticked)
-   in shared/cross_model_verification.md, the single source of truth for the
-   supported lineup. A SETUP example naming a model the canonical doc no
-   longer lists is exactly the B4-F02 failure.
+2. **canonical membership** — every example value must appear in a model
+   TABLE of shared/cross_model_verification.md (the column whose header
+   contains "API ID": the first-party supported table + the compat-provider
+   table). Backticked ids elsewhere in the doc deliberately do NOT count —
+   the legacy-accepted note backticks `gpt-5.4`/`gpt-5.4-pro`, and "accepted
+   for existing setups" is not "recommended in SETUP examples" (false-pass
+   surface caught by codex review on PR #492).
 
-Fail-closed: finding zero ARS_CROSS_MODEL examples in a SETUP file is an
-error (the extraction regex went stale), never a silent pass.
+Fail-closed twice: zero ARS_CROSS_MODEL examples in a SETUP file, or zero
+ids extracted from the canonical tables, is an error (the extraction went
+stale), never a silent pass.
 
 Exit codes: 0 on pass, 1 on any failure.
 """
@@ -40,10 +44,26 @@ CANONICAL = REPO_ROOT / "shared/cross_model_verification.md"
 #   # or: export ARS_CROSS_MODEL="gemini-3.1-pro-preview"
 ASSIGNMENT_RE = re.compile(r'ARS_CROSS_MODEL="([^"]+)"')
 
-# Canonical membership = the ID appears backticked anywhere in the canonical
-# doc (supported-model table or compat-provider table).
-def _backticked(canonical_text: str) -> set[str]:
-    return set(re.findall(r"`([^`]+)`", canonical_text))
+def canonical_model_ids(canonical_text: str) -> set[str]:
+    """Backticked ids from the "API ID" column of the canonical doc's model
+    tables ONLY. A table starts at a header row containing "API ID" and ends
+    at the first non-table line; ids backticked in surrounding prose (e.g.
+    the legacy-accepted note) are deliberately excluded."""
+    ids: set[str] = set()
+    api_id_col: int | None = None
+    for line in canonical_text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            api_id_col = None
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if api_id_col is None:
+            if any("API ID" in c for c in cells):
+                api_id_col = next(i for i, c in enumerate(cells) if "API ID" in c)
+            continue
+        if len(cells) > api_id_col:
+            ids.update(re.findall(r"`([^`]+)`", cells[api_id_col]))
+    return ids
 
 
 def extract_ids(setup_text: str) -> list[str]:
@@ -71,16 +91,24 @@ def check(en_text: str, zh_text: str, canonical_text: str) -> list[str]:
             f"quick-setup bash blocks must carry the same example values."
         )
 
-    known = _backticked(canonical_text)
+    known = canonical_model_ids(canonical_text)
+    if not known:
+        errors.append(
+            "shared/cross_model_verification.md: no ids extracted from any "
+            "'API ID' table column — the table format changed and the parser "
+            "went stale. Fail-closed per lint contract."
+        )
+        return errors
     for label, ids in (("docs/SETUP.md", en_ids), ("docs/SETUP.zh-TW.md", zh_ids)):
         for model_id in ids:
             if model_id not in known:
                 errors.append(
-                    f"{label}: ARS_CROSS_MODEL example {model_id!r} does not "
-                    f"appear in shared/cross_model_verification.md — the SETUP "
-                    f"example names a model outside the canonical lineup "
-                    f"(B4-F02 drift class). Update the example or the canonical "
-                    f"doc, in the same PR."
+                    f"{label}: ARS_CROSS_MODEL example {model_id!r} is not in "
+                    f"the canonical model tables of "
+                    f"shared/cross_model_verification.md (B4-F02 drift class; "
+                    f"legacy ids in the accepted-note do not count as "
+                    f"recommended). Update the example or the canonical table, "
+                    f"in the same PR."
                 )
     return errors
 

--- a/scripts/check_setup_cross_model_parity.py
+++ b/scripts/check_setup_cross_model_parity.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""SETUP cross-model example parity lint (#491 fold-in).
+
+The quick-setup bash blocks in docs/SETUP.md + docs/SETUP.zh-TW.md hardcode
+verifier model IDs (`ARS_CROSS_MODEL="..."`) because they are literal export
+strings a user pastes — they cannot be made version-agnostic the way the
+canonical doc's primary row was. That makes them a drift surface: the
+gpt-5.4→gpt-5.5 lineup migration (2026-06-10, F-003) fixed the canonical doc
+but missed SETUP for three weeks (B4-F02, audits/harness-retirement-2026-07-04.md).
+
+This lint pins the two invariants that broke:
+
+1. **en/zh-TW parity** — both SETUP files must carry the same set of
+   `ARS_CROSS_MODEL` example values (the zh-TW file mirrors the bash block
+   verbatim; a one-sided edit is drift).
+2. **canonical membership** — every example value must appear (backticked)
+   in shared/cross_model_verification.md, the single source of truth for the
+   supported lineup. A SETUP example naming a model the canonical doc no
+   longer lists is exactly the B4-F02 failure.
+
+Fail-closed: finding zero ARS_CROSS_MODEL examples in a SETUP file is an
+error (the extraction regex went stale), never a silent pass.
+
+Exit codes: 0 on pass, 1 on any failure.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SETUP_EN = REPO_ROOT / "docs/SETUP.md"
+SETUP_ZH = REPO_ROOT / "docs/SETUP.zh-TW.md"
+CANONICAL = REPO_ROOT / "shared/cross_model_verification.md"
+
+# Matches active and commented example lines alike:
+#   export ARS_CROSS_MODEL="gpt-5.5"
+#   # or: export ARS_CROSS_MODEL="gemini-3.1-pro-preview"
+ASSIGNMENT_RE = re.compile(r'ARS_CROSS_MODEL="([^"]+)"')
+
+# Canonical membership = the ID appears backticked anywhere in the canonical
+# doc (supported-model table or compat-provider table).
+def _backticked(canonical_text: str) -> set[str]:
+    return set(re.findall(r"`([^`]+)`", canonical_text))
+
+
+def extract_ids(setup_text: str) -> list[str]:
+    """All ARS_CROSS_MODEL example values in a SETUP file, in order."""
+    return ASSIGNMENT_RE.findall(setup_text)
+
+
+def check(en_text: str, zh_text: str, canonical_text: str) -> list[str]:
+    errors: list[str] = []
+    en_ids = extract_ids(en_text)
+    zh_ids = extract_ids(zh_text)
+
+    for label, ids in (("docs/SETUP.md", en_ids), ("docs/SETUP.zh-TW.md", zh_ids)):
+        if not ids:
+            errors.append(
+                f"{label}: no ARS_CROSS_MODEL example values found — either the "
+                f"quick-setup block was removed or the extraction regex went "
+                f"stale. Fail-closed per lint contract."
+            )
+
+    if en_ids and zh_ids and set(en_ids) != set(zh_ids):
+        errors.append(
+            f"SETUP en/zh-TW ARS_CROSS_MODEL example drift: "
+            f"en={sorted(set(en_ids))} zh-TW={sorted(set(zh_ids))}. The two "
+            f"quick-setup bash blocks must carry the same example values."
+        )
+
+    known = _backticked(canonical_text)
+    for label, ids in (("docs/SETUP.md", en_ids), ("docs/SETUP.zh-TW.md", zh_ids)):
+        for model_id in ids:
+            if model_id not in known:
+                errors.append(
+                    f"{label}: ARS_CROSS_MODEL example {model_id!r} does not "
+                    f"appear in shared/cross_model_verification.md — the SETUP "
+                    f"example names a model outside the canonical lineup "
+                    f"(B4-F02 drift class). Update the example or the canonical "
+                    f"doc, in the same PR."
+                )
+    return errors
+
+
+def main() -> int:
+    errors = check(
+        SETUP_EN.read_text(encoding="utf-8"),
+        SETUP_ZH.read_text(encoding="utf-8"),
+        CANONICAL.read_text(encoding="utf-8"),
+    )
+    if errors:
+        print("SETUP cross-model parity lint FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("SETUP cross-model parity lint PASSED: en/zh-TW examples match and "
+          "all values are in the canonical lineup.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_v3_9_2_phase_boundary.py
+++ b/scripts/check_v3_9_2_phase_boundary.py
@@ -26,6 +26,18 @@ Enforces three invariants:
    boundary), so the same keyword appearing elsewhere in the agent file
    does not count toward passing.
 
+4. **Canonical enforcement sentence (#491 defrift lock)** — every Bucket A
+   block's enforcement paragraph must carry the canonical sentence verbatim
+   (version-matched to the block's v3.9.2/v3.9.4 marker). The sentence is
+   shared boilerplate across all 23 blocks; the previous copy ("hook deferred
+   to v3.10 #134") went factually stale repo-wide for a month with no lint
+   noticing (audits/harness-retirement-2026-07-04.md B4-F01). Per-file tails
+   AFTER the sentence stay free (formatter's v3.7.1 hard-gate note, the
+   reviewers' Sprint Contract notes are legitimately file-specific).
+   If a release legitimately changes the enforcement reality, update
+   CANONICAL_ENFORCEMENT below and sweep all 23 files (+2 `agents/` mirrors)
+   in the same PR.
+
 Falsifiability discipline (per feedback_lint_passes_but_prompt_silent.md):
 keywords are scoped to the v3.9.2 block; bare keyword presence anywhere
 in the agent file does NOT count. The block must include all four phrases
@@ -98,8 +110,27 @@ BUCKET_BCD_AGENTS = [
 
 # v3.9.4: widened to accept either v3.9.2 or v3.9.4 phase boundary markers.
 # timeline_extraction_agent.md (added in v3.9.4) uses v3.9.4 in both markers.
-PHASE_BOUNDARY_RE = re.compile(r"## Phase Boundary \(v3\.9\.(?:2|4)\)")
+PHASE_BOUNDARY_RE = re.compile(r"## Phase Boundary \(v3\.9\.(2|4)\)")
 ENFORCEMENT_RE = re.compile(r"Enforcement \(v3\.9\.(?:2|4)\)")
+
+# #491 defrift lock — the canonical enforcement sentence, keyed by the block's
+# version marker ("2" = v3.9.2, "4" = v3.9.4). Single source of truth: any
+# per-file copy that drifts from this constant fails the lint. Update here +
+# sweep all 23 files (+2 mirrors) together when the enforcement reality changes.
+CANONICAL_ENFORCEMENT = {
+    "2": (
+        "**Enforcement (v3.9.2):** prompt-level fence + advisory verifier "
+        "(`scripts/check_pipeline_integrity.py`). Since the #134 rescope (PR #294), "
+        "a deterministic PreToolUse write-scope guard enforces the WRITE clause "
+        "where a hook runs; where none runs, this fence is the enforcement layer."
+    ),
+    "4": (
+        "**Enforcement (v3.9.4):** prompt-level fence + advisory verifier "
+        "(`scripts/check_pipeline_integrity.py` v3.9.4 extension). Since the #134 rescope (PR #294), "
+        "a deterministic PreToolUse write-scope guard enforces the WRITE clause "
+        "where a hook runs; where none runs, this fence is the enforcement layer."
+    ),
+}
 
 # H2 marker that ends the Phase Boundary block scope.
 # Used to scope keyword checks: keywords appearing elsewhere in the file
@@ -158,6 +189,22 @@ def check_bucket_a(path: Path) -> list[str]:
             f"{path.relative_to(REPO_ROOT)}: Phase Boundary block missing "
             f"required phrase: 'Enforcement (v3.9.2|v3.9.4)' (falsifiability "
             f"discipline: phrase must appear inside the H2 block)"
+        )
+    # Canonical enforcement sentence check (#491 defrift lock).
+    # Version-matched to the block's own marker; per-file tail after the
+    # sentence is free, so containment of the full sentence is the assertion.
+    version = PHASE_BOUNDARY_RE.search(block).group(1)
+    canonical = CANONICAL_ENFORCEMENT[version]
+    if canonical not in block:
+        errors.append(
+            f"{path.relative_to(REPO_ROOT)}: enforcement paragraph has drifted "
+            f"from the canonical sentence (#491 defrift lock, v3.9.{version} "
+            f"variant). The enforcement-status claim is shared boilerplate "
+            f"across all Bucket A blocks and must match CANONICAL_ENFORCEMENT "
+            f"in {Path(__file__).name} verbatim (per-file tail after the "
+            f"sentence stays free). If the enforcement reality legitimately "
+            f"changed, update the constant and sweep all 23 files (+2 mirrors) "
+            f"in the same PR."
         )
     return errors
 

--- a/scripts/check_v3_9_2_phase_boundary.py
+++ b/scripts/check_v3_9_2_phase_boundary.py
@@ -28,15 +28,15 @@ Enforces three invariants:
 
 4. **Canonical enforcement sentence (#491 defrift lock)** — every Bucket A
    block's enforcement paragraph must carry the canonical sentence verbatim
-   (version-matched to the block's v3.9.2/v3.9.4 marker). The sentence is
-   shared boilerplate across all 23 blocks; the previous copy ("hook deferred
-   to v3.10 #134") went factually stale repo-wide for a month with no lint
-   noticing (audits/harness-retirement-2026-07-04.md B4-F01). Per-file tails
-   AFTER the sentence stay free (formatter's v3.7.1 hard-gate note, the
-   reviewers' Sprint Contract notes are legitimately file-specific).
-   If a release legitimately changes the enforcement reality, update
-   CANONICAL_ENFORCEMENT below and sweep all 23 files (+2 `agents/` mirrors)
-   in the same PR.
+   (version-matched to the block's v3.9.2/v3.9.4 marker; per-file tails
+   AFTER the sentence stay free — formatter's v3.7.1 hard-gate note, the
+   reviewers' Sprint Contract notes are legitimately file-specific). The
+   previous copy ("hook deferred to v3.10 #134") went factually stale
+   repo-wide with no lint noticing (audits/harness-retirement-2026-07-04.md
+   B4-F01). Scope: the constant governs the Bucket A blocks only — the
+   `agents/` mirrors follow mechanically via check_agents_mirror_sync.py,
+   and the SKILL.md copies carry a different, shorter wording (separate
+   surface). Update procedure: see the error message in check_bucket_a.
 
 Falsifiability discipline (per feedback_lint_passes_but_prompt_silent.md):
 keywords are scoped to the v3.9.2 block; bare keyword presence anywhere
@@ -114,9 +114,12 @@ PHASE_BOUNDARY_RE = re.compile(r"## Phase Boundary \(v3\.9\.(2|4)\)")
 ENFORCEMENT_RE = re.compile(r"Enforcement \(v3\.9\.(?:2|4)\)")
 
 # #491 defrift lock — the canonical enforcement sentence, keyed by the block's
-# version marker ("2" = v3.9.2, "4" = v3.9.4). Single source of truth: any
-# per-file copy that drifts from this constant fails the lint. Update here +
-# sweep all 23 files (+2 mirrors) together when the enforcement reality changes.
+# version marker ("2" = v3.9.2, "4" = v3.9.4). Any Bucket A copy that drifts
+# fails the lint; update procedure lives in check_bucket_a's error message.
+# Deliberately lint-local rather than a shared/references/firm_rules.md
+# canonical block: this is factual enforcement-STATUS prose, not a behavioral
+# firm rule, and co-locating it with its only consumer avoids cross-lint
+# coupling (cross-referenced in firm_rules.md "Related mechanisms").
 CANONICAL_ENFORCEMENT = {
     "2": (
         "**Enforcement (v3.9.2):** prompt-level fence + advisory verifier "
@@ -199,12 +202,12 @@ def check_bucket_a(path: Path) -> list[str]:
         errors.append(
             f"{path.relative_to(REPO_ROOT)}: enforcement paragraph has drifted "
             f"from the canonical sentence (#491 defrift lock, v3.9.{version} "
-            f"variant). The enforcement-status claim is shared boilerplate "
-            f"across all Bucket A blocks and must match CANONICAL_ENFORCEMENT "
-            f"in {Path(__file__).name} verbatim (per-file tail after the "
-            f"sentence stays free). If the enforcement reality legitimately "
-            f"changed, update the constant and sweep all 23 files (+2 mirrors) "
-            f"in the same PR."
+            f"variant). It must contain CANONICAL_ENFORCEMENT from "
+            f"{Path(__file__).name} verbatim (per-file tail after the sentence "
+            f"stays free). If the enforcement reality legitimately changed, "
+            f"update the constant and sweep all {len(BUCKET_A_AGENTS)} Bucket A "
+            f"files in the same PR; the `agents/` mirrors follow via "
+            f"check_agents_mirror_sync.py."
         )
     return errors
 

--- a/scripts/test_check_setup_cross_model_parity.py
+++ b/scripts/test_check_setup_cross_model_parity.py
@@ -1,0 +1,70 @@
+"""Unit tests for check_setup_cross_model_parity.py (#491 fold-in)."""
+import unittest
+from pathlib import Path
+
+from tests.test_helpers import run_script
+
+SCRIPT = Path(__file__).resolve().parent / "check_setup_cross_model_parity.py"
+
+EN_OK = 'export ARS_CROSS_MODEL="gpt-5.5"\n# or: export ARS_CROSS_MODEL="gemini-3.1-pro-preview"\n'
+ZH_OK = EN_OK
+CANONICAL_OK = "| GPT-5.5 | `gpt-5.5` | ... |\n| Gemini 3.1 Pro | `gemini-3.1-pro-preview` | ... |\n"
+
+
+def _load_module():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "check_setup_cross_model_parity", SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SetupCrossModelParityTests(unittest.TestCase):
+
+    def test_repo_baseline_passes(self) -> None:
+        """The committed SETUP + canonical doc state must pass."""
+        result = run_script(SCRIPT)
+        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}")
+        self.assertIn("PASSED", result.stdout)
+
+    def test_clean_fixture_passes(self) -> None:
+        module = _load_module()
+        self.assertEqual(module.check(EN_OK, ZH_OK, CANONICAL_OK), [])
+
+    def test_en_zh_drift_fails(self) -> None:
+        """One-sided edit (the B4-F02 shape: en updated, zh-TW forgotten)."""
+        module = _load_module()
+        zh_stale = 'export ARS_CROSS_MODEL="gpt-5.4-pro"\n'
+        canonical = CANONICAL_OK + "| legacy | `gpt-5.4-pro` | ... |\n"
+        errors = module.check(EN_OK, zh_stale, canonical)
+        self.assertTrue(any("drift" in e for e in errors), msg=f"errors: {errors}")
+
+    def test_unknown_model_fails(self) -> None:
+        """Example naming a model outside the canonical lineup."""
+        module = _load_module()
+        bad = 'export ARS_CROSS_MODEL="gpt-9.9-imaginary"\n'
+        errors = module.check(bad, bad, CANONICAL_OK)
+        self.assertTrue(
+            any("gpt-9.9-imaginary" in e and "canonical" in e for e in errors),
+            msg=f"errors: {errors}",
+        )
+
+    def test_zero_examples_fails_closed(self) -> None:
+        """Regex-went-stale / block-removed must be an error, not a pass."""
+        module = _load_module()
+        errors = module.check("no examples here", ZH_OK, CANONICAL_OK)
+        self.assertTrue(
+            any("Fail-closed" in e for e in errors), msg=f"errors: {errors}"
+        )
+
+    def test_commented_example_lines_are_extracted(self) -> None:
+        """`# or:` alternates count — they are user-pasteable examples too."""
+        module = _load_module()
+        ids = module.extract_ids(EN_OK)
+        self.assertEqual(ids, ["gpt-5.5", "gemini-3.1-pro-preview"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_setup_cross_model_parity.py
+++ b/scripts/test_check_setup_cross_model_parity.py
@@ -8,7 +8,14 @@ SCRIPT = Path(__file__).resolve().parent / "check_setup_cross_model_parity.py"
 
 EN_OK = 'export ARS_CROSS_MODEL="gpt-5.5"\n# or: export ARS_CROSS_MODEL="gemini-3.1-pro-preview"\n'
 ZH_OK = EN_OK
-CANONICAL_OK = "| GPT-5.5 | `gpt-5.5` | ... |\n| Gemini 3.1 Pro | `gemini-3.1-pro-preview` | ... |\n"
+CANONICAL_OK = (
+    "| Model | API ID | Provider |\n"
+    "|-------|--------|----------|\n"
+    "| GPT-5.5 | `gpt-5.5` | OpenAI |\n"
+    "| Gemini 3.1 Pro | `gemini-3.1-pro-preview` | Google |\n"
+    "\n"
+    "(`gpt-5.4` / `gpt-5.4-pro` remain accepted for existing setups.)\n"
+)
 
 
 def _load_module():
@@ -37,9 +44,40 @@ class SetupCrossModelParityTests(unittest.TestCase):
         """One-sided edit (the B4-F02 shape: en updated, zh-TW forgotten)."""
         module = _load_module()
         zh_stale = 'export ARS_CROSS_MODEL="gpt-5.4-pro"\n'
-        canonical = CANONICAL_OK + "| legacy | `gpt-5.4-pro` | ... |\n"
-        errors = module.check(EN_OK, zh_stale, canonical)
+        errors = module.check(EN_OK, zh_stale, CANONICAL_OK)
         self.assertTrue(any("drift" in e for e in errors), msg=f"errors: {errors}")
+
+    def test_legacy_id_in_prose_note_does_not_count(self) -> None:
+        """codex P1 regression (PR #492): `gpt-5.4-pro` is backticked in the
+        canonical doc's legacy-accepted NOTE but absent from the model tables —
+        a SETUP example reverting to it must FAIL, not pass on the note."""
+        module = _load_module()
+        stale = 'export ARS_CROSS_MODEL="gpt-5.4-pro"\n'
+        errors = module.check(stale, stale, CANONICAL_OK)
+        self.assertTrue(
+            any("gpt-5.4-pro" in e and "not in" in e for e in errors),
+            msg=f"errors: {errors}",
+        )
+
+    def test_canonical_table_parse_fails_closed(self) -> None:
+        """No 'API ID' table in the canonical doc = parser stale = error."""
+        module = _load_module()
+        errors = module.check(EN_OK, ZH_OK, "prose only, `gpt-5.5` backticked")
+        self.assertTrue(
+            any("parser went stale" in e for e in errors), msg=f"errors: {errors}"
+        )
+
+    def test_compat_table_column_counts(self) -> None:
+        """Ids in the compat table's 'Example API ID(s)' column are members."""
+        module = _load_module()
+        canonical = CANONICAL_OK + (
+            "\n| Provider | Example API ID(s) | Endpoint |\n"
+            "|----------|-------------------|----------|\n"
+            "| DeepSeek | `deepseek-v4-pro` | https://api.deepseek.com/v1 |\n"
+        )
+        ids = module.canonical_model_ids(canonical)
+        self.assertIn("deepseek-v4-pro", ids)
+        self.assertNotIn("gpt-5.4-pro", ids)
 
     def test_unknown_model_fails(self) -> None:
         """Example naming a model outside the canonical lineup."""

--- a/scripts/test_check_setup_cross_model_parity.py
+++ b/scripts/test_check_setup_cross_model_parity.py
@@ -79,6 +79,25 @@ class SetupCrossModelParityTests(unittest.TestCase):
         self.assertIn("deepseek-v4-pro", ids)
         self.assertNotIn("gpt-5.4-pro", ids)
 
+    def test_wildcard_prefix_tokens_are_not_ids(self) -> None:
+        """codex P2 regression (PR #492): the compat table's "any
+        non-`gpt-*`/`gemini-*` id" prose sits in an API ID column — globs are
+        prefix patterns, not model ids, and a SETUP example of `gpt-*` must
+        fail, not pass on the leaked token."""
+        module = _load_module()
+        canonical = CANONICAL_OK + (
+            "\n| Provider | Example API ID(s) | Endpoint |\n"
+            "|----------|-------------------|----------|\n"
+            "| Any OpenAI-compatible | any non-`gpt-*`/`gemini-*` id | any |\n"
+        )
+        self.assertNotIn("gpt-*", module.canonical_model_ids(canonical))
+        glob_setup = 'export ARS_CROSS_MODEL="gpt-*"\n'
+        errors = module.check(glob_setup, glob_setup, canonical)
+        self.assertTrue(
+            any("gpt-*" in e and "not in" in e for e in errors),
+            msg=f"errors: {errors}",
+        )
+
     def test_unknown_model_fails(self) -> None:
         """Example naming a model outside the canonical lineup."""
         module = _load_module()

--- a/scripts/test_check_setup_cross_model_parity.py
+++ b/scripts/test_check_setup_cross_model_parity.py
@@ -2,7 +2,7 @@
 import unittest
 from pathlib import Path
 
-from tests.test_helpers import run_script
+from tests.test_helpers import load_module_from_path, run_script
 
 SCRIPT = Path(__file__).resolve().parent / "check_setup_cross_model_parity.py"
 
@@ -19,13 +19,7 @@ CANONICAL_OK = (
 
 
 def _load_module():
-    import importlib.util
-    spec = importlib.util.spec_from_file_location(
-        "check_setup_cross_model_parity", SCRIPT
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_module_from_path("check_setup_cross_model_parity", SCRIPT)
 
 
 class SetupCrossModelParityTests(unittest.TestCase):

--- a/scripts/test_check_v3_9_2_phase_boundary.py
+++ b/scripts/test_check_v3_9_2_phase_boundary.py
@@ -103,13 +103,8 @@ class CanonicalEnforcementDefriftTests(unittest.TestCase):
     )
 
     def _load_module(self):
-        import importlib.util
-        spec = importlib.util.spec_from_file_location(
-            "check_v3_9_2_phase_boundary", SCRIPT
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
+        from tests.test_helpers import load_module_from_path
+        return load_module_from_path("check_v3_9_2_phase_boundary", SCRIPT)
 
     def _block(self, enforcement_line: str, version: str = "2") -> str:
         return (

--- a/scripts/test_check_v3_9_2_phase_boundary.py
+++ b/scripts/test_check_v3_9_2_phase_boundary.py
@@ -88,5 +88,108 @@ class CheckV392PhaseBoundaryTests(unittest.TestCase):
         )
 
 
+class CanonicalEnforcementDefriftTests(unittest.TestCase):
+    """#491 defrift lock — the canonical enforcement sentence guard.
+
+    Mutation discipline: every negative case drives the REAL check_bucket_a
+    logic against a fixture file (module REPO_ROOT redirected to a tempdir),
+    so a guard that silently stops matching cannot stay green.
+    """
+
+    STALE_SENTENCE = (
+        "**Enforcement (v3.9.2):** prompt-level only. Advisory verifier "
+        "(`scripts/check_pipeline_integrity.py`) can detect violations post-hoc. "
+        "Deterministic PreToolUse hook deferred to v3.10 active conductor (#134)."
+    )
+
+    def _load_module(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "check_v3_9_2_phase_boundary", SCRIPT
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _block(self, enforcement_line: str, version: str = "2") -> str:
+        return (
+            f"## Phase Boundary (v3.9.{version})\n\n"
+            "You MUST NOT write files in other phases.\n"
+            "You MAY READ files in `phase1_*/`.\n\n"
+            f"{enforcement_line}\n\n"
+            "## Next Section\n"
+        )
+
+    def _check(self, module, content: str) -> list[str]:
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = root / "fixture_agent.md"
+            fixture.write_text(content, encoding="utf-8")
+            module.REPO_ROOT = root
+            return module.check_bucket_a(fixture)
+
+    def test_canonical_constants_shape(self) -> None:
+        """Both version variants exist and carry their own version marker."""
+        module = self._load_module()
+        self.assertEqual(set(module.CANONICAL_ENFORCEMENT), {"2", "4"})
+        self.assertIn("Enforcement (v3.9.2)", module.CANONICAL_ENFORCEMENT["2"])
+        self.assertIn("Enforcement (v3.9.4)", module.CANONICAL_ENFORCEMENT["4"])
+        self.assertIn("PR #294", module.CANONICAL_ENFORCEMENT["2"])
+
+    def test_canonical_sentence_passes(self) -> None:
+        module = self._load_module()
+        errors = self._check(module, self._block(module.CANONICAL_ENFORCEMENT["2"]))
+        self.assertEqual(errors, [])
+
+    def test_canonical_with_file_specific_tail_passes(self) -> None:
+        """Per-file tails after the canonical sentence stay free."""
+        module = self._load_module()
+        line = (module.CANONICAL_ENFORCEMENT["2"]
+                + " The v3.6.2 Sprint Contract Protocol below ALSO applies.")
+        errors = self._check(module, self._block(line))
+        self.assertEqual(errors, [])
+
+    def test_stale_pre_294_sentence_fails(self) -> None:
+        """THE regression case: the pre-PR-#294 sentence that drifted repo-wide
+        (audits/harness-retirement-2026-07-04.md B4-F01) must now fail."""
+        module = self._load_module()
+        errors = self._check(module, self._block(self.STALE_SENTENCE))
+        self.assertEqual(len(errors), 1, msg=f"errors: {errors}")
+        self.assertIn("drifted", errors[0])
+        self.assertIn("#491", errors[0])
+
+    def test_single_word_mutation_fails(self) -> None:
+        module = self._load_module()
+        mutated = module.CANONICAL_ENFORCEMENT["2"].replace(
+            "write-scope guard", "write scope guard"
+        )
+        self.assertNotEqual(mutated, module.CANONICAL_ENFORCEMENT["2"])
+        errors = self._check(module, self._block(mutated))
+        self.assertEqual(len(errors), 1, msg=f"errors: {errors}")
+        self.assertIn("drifted", errors[0])
+
+    def test_version_mismatched_sentence_fails(self) -> None:
+        """A v3.9.4 block carrying the v3.9.2 sentence is drift, not a pass."""
+        module = self._load_module()
+        errors = self._check(
+            module,
+            self._block(module.CANONICAL_ENFORCEMENT["2"], version="4"),
+        )
+        self.assertEqual(len(errors), 1, msg=f"errors: {errors}")
+        self.assertIn("v3.9.4 variant", errors[0])
+
+    def test_canonical_matches_repo_files(self) -> None:
+        """The constants must match what actually ships in the agent files —
+        a constant that drifts from disk would make the baseline test fail,
+        but assert it directly for a precise failure message."""
+        module = self._load_module()
+        repo_root = Path(__file__).resolve().parent.parent
+        v392_sample = (repo_root / "deep-research/agents/synthesis_agent.md").read_text(encoding="utf-8")
+        v394_sample = (repo_root / "deep-research/agents/timeline_extraction_agent.md").read_text(encoding="utf-8")
+        self.assertIn(module.CANONICAL_ENFORCEMENT["2"], v392_sample)
+        self.assertIn(module.CANONICAL_ENFORCEMENT["4"], v394_sample)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/shared/references/firm_rules.md
+++ b/shared/references/firm_rules.md
@@ -4,6 +4,8 @@ This file is the **single source of truth** for firm-rule wording that is otherw
 
 **Why this file exists:** the contamination `R-L3-2-*` wording provably drifted between v3.9.0 (contamination-only) and v3.9.4 (contamination-AND-temporal) drafts before being single-sourced here. Manual 5×-duplication is not enough; the sync lint pins it.
 
+**Related mechanisms:** the Phase Boundary enforcement-status sentence (factual status prose, not a behavioral firm rule) is single-sourced as `CANONICAL_ENFORCEMENT` inside `scripts/check_v3_9_2_phase_boundary.py` (#491) rather than here — same defrift goal, separate mechanism co-located with its only consumer.
+
 **ID namespaces (do NOT confuse — they were overloaded until v3.10 PR-A):**
 
 - `R-L3-2-*` = **contamination advisory** rules (origin: v3.7.3 spec §3.2 L3-2; extended v3.9.0 §3.3). Original holder of the `R-L3-2` ID.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -36,6 +36,22 @@ def run_script(
     )
 
 
+def load_module_from_path(name: str, path: Path):
+    """Import a script file as a module (for unit-testing its functions).
+
+    Centralises the spec_from_file_location -> module_from_spec ->
+    exec_module boilerplate. Six pre-existing test files carry local copies
+    under various names (_load, _load_lint, _load_module) — they can migrate
+    at next edit; new test files should call this.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def run_skill_linter(script_path: Path, root: Path) -> subprocess.CompletedProcess[str]:
     """Invoke a SKILL.md linter (--path arg + PYTHONPATH=scripts/)."""
     return run_script(


### PR DESCRIPTION
Closes #491

## What

Follow-ups from the 2026-07-04 harness-retirement pass — the "one lock instead of 25 bandaids" work:

1. **Canonical enforcement sentence guard** (`check_v3_9_2_phase_boundary.py` invariant 4): the enforcement-status sentence shared by all 23 Bucket A Phase Boundary blocks is now pinned to a single `CANONICAL_ENFORCEMENT` constant (version-matched v3.9.2/v3.9.4; per-file tails stay free). The pre-#294 copy sat factually wrong across 29 surfaces for a month with the lint iterating those exact blocks and pinning only the marker — that class of drift now fails CI. 7 new mutation tests, including the literal stale sentence as the regression case.
2. **SETUP cross-model example parity** (new `check_setup_cross_model_parity.py` + 6 tests, wired into spec-consistency.yml): en/zh-TW `ARS_CROSS_MODEL` examples must match each other and be members of the canonical lineup doc — the B4-F02 gpt-5.4 drift class. Fail-closed if extraction finds zero examples.
3. **Manifest gap** (`_ci_pytest_manifest.toml` 58→60): adds `test_check_v3_9_4_temporal_verification.py`, whose CI-only coverage made PR #490 local-green/CI-red on the bibliography_agent sha256 pin. Also adds the new parity test. Note: the manifest header's known "unlisted files" policy question (#156 follow-up) is untouched — this adds only the entry that demonstrably bit, plus the new test.

## Verification

- Manifest drift guard: 60 entries OK; full local manifest run 60/60 green
- `test_check_v3_9_2_phase_boundary.py` 11/11 (4 existing + 7 new mutation tests driving the real `check_bucket_a` against fixtures)
- `test_check_setup_cross_model_parity.py` 6/6; both new lints green on repo baseline
- personal-boundary scan 993 files / 0 violations; diff sensitive-term grep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBdGUAb184hmuiRiWAm4A9