### PR TITLE
docs: add THIRD_PARTY.md directory + README pointer (#497)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The architecture doc supersedes the sprawling pipeline description that used to 
 
 **Using Codex CLI?** Install the sibling distribution instead: [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) — same workflow content, Codex-native packaging as a single `$academic-research-suite` skill with `ars-*` aliases.
 
+**Third-party platforms and integrations** that wrap or host ARS are listed in [THIRD_PARTY.md](THIRD_PARTY.md) — community-submitted and not reviewed or endorsed by the maintainer.
+
 ## Performance & cost
 
 **👉 [docs/PERFORMANCE.md](docs/PERFORMANCE.md)** — per-mode token budgets, full-pipeline estimate (~$4–6 for a 15k-word paper), and recommended Claude Code settings (Auto mode; Agent Team optional).

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,53 @@
+# Third-party projects
+
+This page lists third-party projects, platforms, and services that build on, wrap,
+or integrate Academic Research Skills (ARS).
+
+## Disclaimer
+
+**Listing here is not an endorsement.** The entries below are community-submitted
+and have **not been reviewed, tested, or verified** by the ARS maintainer. They are
+operated by independent third parties, not affiliated with this project.
+
+- Being listed here does not mean the maintainer vouches for the project's quality,
+  security, privacy practices, or continued availability.
+- Links may point to external platforms with their own terms, pricing, tracking, and
+  data-handling policies. Read them before you sign up or upload anything.
+- **Use at your own risk.** Do not paste unpublished research, personal data, or any
+  confidential material into a third-party service without checking its policies first.
+
+If you want a project *reviewed and officially recognized* by ARS (rather than merely
+listed), that is a separate track — see **Getting officially recognized** below.
+
+## How to get listed
+
+The bar to be listed here is intentionally low, and separate from endorsement. Open an
+issue or a pull request adding a row to the table. To be eligible, your project must:
+
+1. **Credit ARS** — visibly attribute Academic Research Skills and link back to this
+   repository.
+2. **Describe it faithfully** — do not misrepresent what ARS is or what your project
+   does with it.
+
+That is all that is required for a listing. The maintainer may decline or remove an
+entry that violates these two conditions, or that turns out to be spam, malware, or
+otherwise harmful.
+
+## Getting officially recognized
+
+Listing on this page is *not* the same as ARS officially supporting or bundling your
+integration. If you are building a platform port or a first-class integration and want
+it recognized in the main README or shipped with the suite, that goes through the
+**platform-ports policy** (community-maintained ports), which sets a higher bar than a
+directory listing. See the Platform Port Reminder policy and open an issue to discuss.
+
+## Listed projects
+
+| Project | Maintainer | What it does | Link |
+|---------|-----------|--------------|------|
+| ClawMama | kinhunt (third party) | Hosted OpenClaw/Hermes-style agent offering a first-run trial of the Academic Research Pipeline via Telegram or WhatsApp | [Try in Telegram or WhatsApp](https://app.clawmama.run/skills/639wu5/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_academic_research_skills) |
+
+*Columns:* **Project** name as the third party calls it · **Maintainer** the account
+that submitted / operates it · **What it does** a one-line neutral description ·
+**Link** where it lives. Descriptions are the submitters' own claims, restated
+neutrally; the maintainer has not verified them.


### PR DESCRIPTION
## What

Adds a `THIRD_PARTY.md` directory for community-submitted projects that wrap or host ARS, and a neutral pointer to it from the README install section. Closes #497.

## Why

Issue #497 asked to add a third-party hosted trial link (ClawMama) to the README install flow. The main install section links only to maintainer-verified paths, so a third-party hosted link doesn't belong there. Instead:

- **New `THIRD_PARTY.md`** — a low-bar community directory that is explicitly *separate from endorsement*. Listing requires only (1) visible attribution + backlink and (2) a faithful description. A prominent disclaimer states entries are unreviewed, third-party-operated, use-at-your-own-risk, and that official recognition is a separate (higher-bar) track.
- **ClawMama listed as the first entry** with the submitter's Telegram/WhatsApp trial link (as provided in #497).
- **README install section** gains one neutral, non-recommending line pointing to the page, alongside the existing SETUP / Claude Science / Codex pointers.

## Scope / safety

- Two changes only: one new top-level doc + one README line (see diff).
- No version bump, no CHANGELOG/SETUP/command-inventory changes — release-discipline invariants untouched.
- No PII or restricted strings introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LULee15MynDuu18MDVyNBb