### PR TITLE
docs(pipeline): #528 fix two real inconsistencies (methodology handoff + 3' Minor coaching) [skip-closes-check]

### DIFF
--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -277,7 +277,7 @@ After user confirmation:
 
 1. Pass the previous stage's deliverables as input to the next stage
 2. Trigger handoff protocol (defined in each skill's SKILL.md):
-   - Stage 1  --> 2: deep-research handoff (RQ Brief + Bibliography + Synthesis)
+   - Stage 1  --> 2: deep-research handoff (RQ Brief + Methodology Blueprint + Bibliography + Synthesis)
    - Stage 2  --> 2.5: Pass complete paper to integrity_verification_agent
    - Stage 2.5 --> 3: Pass verified paper to reviewer
    - Stage 3  --> 4: Pass Revision Roadmap to academic-paper revision mode

--- a/academic-pipeline/agents/pipeline_orchestrator_agent.md
+++ b/academic-pipeline/agents/pipeline_orchestrator_agent.md
@@ -500,7 +500,7 @@ Reference helper: `scripts/slr_lineage.py` `emit(stages, incoming_slr_lineage)`.
 
 | Transition | Transferred Materials | Schema Reference | Transfer Method |
 |-----------|----------------------|-----------------|----------------|
-| Stage 1 -> 2 | RQ Brief, Annotated Bibliography, Synthesis Report | Schema 1 (RQ Brief), Schema 2 (Bibliography), Schema 3 (Synthesis) | deep-research handoff protocol |
+| Stage 1 -> 2 | RQ Brief, Methodology Blueprint, Annotated Bibliography, Synthesis Report | Schema 1 (RQ Brief), Schema 2 (Bibliography), Schema 3 (Synthesis) | deep-research handoff protocol |
 | Stage 2 -> 2.5 | Complete Paper Draft | Schema 4 (Paper Draft) | Pass to integrity_verification_agent |
 | Stage 2.5 -> 3 | Verified Paper Draft + Integrity Report | Schema 4 + Schema 5 (Integrity Report) | Pass to reviewer (with verification report attached). Carry forward `experiment_provenance[]` + `experiment_alignment_results[]` + `experiment_intake_declaration` (#260) |
 | Stage 3 -> **coaching** -> 4 | Editorial Decision, Revision Roadmap, 5 Review Reports | Schema 6 (Review Report), Schema 7 (Revision Roadmap) | **First Socratic dialogue** -> academic-paper revision mode input |
@@ -575,7 +575,7 @@ Request state_tracker_agent to produce the Progress Dashboard when needed.
 
 ## Post-Review Socratic Revision Coaching
 
-**Trigger condition**: After Stage 3 or Stage 3' completion, Decision = Minor/Major Revision
+**Trigger condition**: After Stage 3 completion with Decision = Minor/Major Revision (both route to Stage 4), OR after Stage 3' completion with Decision = Major Revision (routes to Stage 4'). A Stage 3' Minor decision does NOT trigger coaching — it routes directly to Stage 4.5 per the state machine (`Accept|Minor -> 4.5`), so there is no coaching step on that path.
 **Executor**: academic-paper-reviewer's eic_agent (Phase 2.5)
 **Purpose**: Help users understand review comments and plan revision strategy, rather than passively receiving a change list
 
@@ -612,7 +612,7 @@ Request state_tracker_agent to produce the Progress Dashboard when needed.
 - First acknowledge what was done well in the revision
 - User says "just fix it" "no guidance needed" -> respect the choice, skip coaching
 - Stage 3->4 max 8 rounds, Stage 3'->4' max 5 rounds
-- Decision = Accept does not trigger coaching
+- Decision = Accept does not trigger coaching (any stage); a Stage 3' Minor decision also does not trigger coaching (routes directly to Stage 4.5)
 
 ---
 

--- a/academic-pipeline/references/pipeline_state_machine.md
+++ b/academic-pipeline/references/pipeline_state_machine.md
@@ -145,7 +145,7 @@ This document defines all legal states, transition conditions, transition action
 | INIT | Stage 4 | User has review comments | Confirm paper + review comments, launch revision |
 | INIT | Stage 5 | User has final draft for format conversion | Confirm format requirements, launch format-convert |
 | Stage 1 | **checkpoint** | Stage 1 completed | Wait for user confirmation |
-| checkpoint | Stage 2 | User confirms | handoff RQ Brief + Bibliography + Synthesis |
+| checkpoint | Stage 2 | User confirms | handoff RQ Brief + Methodology Blueprint + Bibliography + Synthesis |
 | Stage 2 | **checkpoint** | Stage 2 completed, Paper Draft produced | Wait for user confirmation |
 | checkpoint | Stage 2.5 | User confirms | Pass Paper Draft to integrity agent |
 | Stage 2.5 | **checkpoint** | PASS | Wait for user confirmation |


### PR DESCRIPTION
## Scope

**Partial** resolution of #528. The Mode-A structural replay surfaced four items; this PR fixes only the **two that are genuine contradictions**, and deliberately leaves the two under-specified boundaries and #527 for later (issue stays open).

Text-only, no schema change, no version bump.

## What changed

### 1. Methodology Blueprint missing from Stage 1→2 handoff (3 surfaces)
It was listed in Stage 1 deliverables (`SKILL.md:105`) and the Material Dependency Matrix (`pipeline_state_machine.md:198`) but omitted from all three handoff descriptions. Now aligned:
- `academic-pipeline/SKILL.md:280`
- `academic-pipeline/references/pipeline_state_machine.md:148`
- `academic-pipeline/agents/pipeline_orchestrator_agent.md:503` (Schema column unchanged — text only)

### 2. Stage 3′ Minor coaching-trigger contradiction
The trigger read `After Stage 3 or Stage 3' completion, Decision = Minor/Major`, but routing sends a Stage 3′ Minor **directly to Stage 4.5**, while the only defined Stage 3′ coaching flow leads to Stage 4′. Split the trigger by stage:
- Stage 3 → Minor/Major both trigger coaching (route to Stage 4)
- Stage 3′ → **Major only** (routes to Stage 4′); **Minor does NOT trigger coaching**, goes straight to Stage 4.5

Extended the Coaching Rules exclusion list (`:615`) to state the Stage 3′ Minor carve-out so the section is internally self-consistent.

## Deferred (issue #528 stays OPEN)
- **Stage 5** entry-gate vs completion-gate ambiguity — under-specified, not contradictory
- **Stage 6** terminal-action vocabulary + final state transition — absent from the state machine, but no current failure
- **#527** cross-model handoff contract — separate issue, deferred

These are slow-maintenance debt with no current failure; per maintainer decision they wait until those files are next touched.

## Verification
- Full pytest: **3076 passed, 3 skipped, 1 xfailed, 127 subtests**
- `check_spec_consistency.py`: 28 passed (no existing assertion broken)
- Every changed line reviewed by diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCrwLqm9EaDXvTgrYxhjZx

---

[skip-closes-check] Partial fix — #528 stays open by design: only the two genuine contradictions (methodology handoff + Stage 3' Minor coaching trigger) are resolved here; the Stage 5 gate-position and Stage 6 terminal-semantics items are under-specified (not contradictory, no current failure) and are deferred per maintainer decision.
