### PR TITLE
docs(third-party): acknowledge Yila-AI/sci-ssci-skills as upstream project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **THIRD_PARTY.md "Upstream & related projects" section (#573).** Acknowledges [Yila-AI/sci-ssci-skills](https://github.com/Yila-AI/sci-ssci-skills) by [@MissOrangePeel](https://github.com/MissOrangePeel) as the origin of the mechanism shape adapted in the #569/#570 revision-round claim-drift guards (PR #571), reciprocating their README listing of ARS under "Projects using or adapting this work".
+
 ## [3.19.0] - 2026-07-22 — Revision-round claim-drift guards, PDF read-integrity preflight, read-scope attestation
 
 ### Added

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,7 +1,8 @@
 # Third-party projects
 
 This page lists third-party projects, platforms, and services that build on, wrap,
-or integrate Academic Research Skills (ARS).
+or integrate Academic Research Skills (ARS). It also acknowledges upstream projects
+whose mechanisms ARS has adapted (see **Upstream & related projects** below).
 
 ## Disclaimer
 
@@ -51,3 +52,13 @@ directory listing. See the Platform Port Reminder policy and open an issue to di
 that submitted / operates it · **What it does** a one-line neutral description ·
 **Link** where it lives. Descriptions are the submitters' own claims, restated
 neutrally; the maintainer has not verified them.
+
+## Upstream & related projects
+
+The reverse direction: independent projects whose mechanisms ARS has adapted, with
+credit recorded in the corresponding issues and pull requests. Listing here is
+acknowledgement, not endorsement, and implies no affiliation.
+
+| Project | Maintainer | Relationship | Link |
+|---------|-----------|--------------|------|
+| sci-ssci-skills | [@MissOrangePeel](https://github.com/MissOrangePeel) (Yila-AI) | Origin of the claim-strength ladder + deterministic invariant-checking mechanism shape adapted into the v3.19.0 revision-round claim-drift guards (#569 / #570, PR [#571](https://github.com/Imbad0202/academic-research-skills/pull/571)) | [Yila-AI/sci-ssci-skills](https://github.com/Yila-AI/sci-ssci-skills) |


### PR DESCRIPTION
Adds an **Upstream & related projects** section to `THIRD_PARTY.md`, acknowledging [Yila-AI/sci-ssci-skills](https://github.com/Yila-AI/sci-ssci-skills) by @MissOrangePeel as the origin of the mechanism shape adapted in the #569/#570 revision-round claim-drift guards (PR #571). Reciprocates the upstream author's offer (PR #571 comment) to list ARS in their README under "Projects using or adapting this work".

The existing **Listed projects** table's semantics (projects that build on ARS, credit-ARS eligibility bar) are untouched; the new section covers the reverse direction explicitly.

Also adds the corresponding `[Unreleased]` CHANGELOG entry.

[skip-closes-check] Justification: reciprocal documentation courtesy arising from a PR comment exchange, no tracking issue exists; docs-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JExsFR2zMv9XNpeDCNwim8
