### PR TITLE
docs: Capitalize 'Quick Install' header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ v3.3 was inspired by [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Son
 
 The architecture doc supersedes the sprawling pipeline description that used to live here. Everything about *what runs in which stage* now lives in one place.
 
-## Quick install
+## Quick Install
 
 **Prerequisites**
 


### PR DESCRIPTION
<!-- Thanks for contributing to academic-research-skills. -->

## Summary

<!-- What does this PR change and why? -->
Capitalize the "Quick Install" header for consistency and readability.
Files changed

[README.md](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html): fixed header from "## Quick install" → "## Quick Install" (single-line docs change).
Why

Minor documentation consistency fix with no functional impact.
Eval impact

## Eval impact

No eval impact.
Testing

Docs-only change; no tests required.

If this PR adds a new `<platform>/` directory, read the
[Platform ports policy](https://github.com/Imbad0202/academic-research-skills/blob/main/CONTRIBUTING.md#platform-ports-community-maintained-only)
and **open a design issue first**. Otherwise, leave this section as "Not a platform port."

> Not a platform port.

Fixes #629 
## Checklist

- [x] Tests added / updated and passing locally
- [x] Eval impact section above is accurate
