### PR TITLE
docs(pi): update post-merge install guidance

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -63,6 +63,8 @@ v3.3 は [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（Song, Song, Pf
 
 **Claude Science をお使いですか？** 4 つのスキルは直接インポートできます: **Skills → Import from GitHub** で `https://github.com/Imbad0202/academic-research-skills` を貼り付け、**Preview** → **Import 4 skills**（本リポジトリ v3.14.0+ が必要 — インポーターは marketplace manifest に明示されたスキルパスを読み取ります）。インポートはその時点のスナップショットです: ARS の更新後は再インポートしてください。インポートされたスキルは ARS の方法論（研究・執筆・査読プロトコル）を伝えます。Claude Code 固有の仕組み — slash commands、hooks、サブエージェントオーケストレーション — は移行されません。詳細は [docs/SETUP.md](docs/SETUP.md) の Method 5 を参照。
 
+**Pi を使用していますか？** `pi install git:github.com/Imbad0202/academic-research-skills` で、リポジトリ内のコミュニティ管理 wrapper をインストールできます。元の ARS コンテンツを正本として維持し、Pi 固有のオーケストレーションと hook の制限を明記しています。詳細は [`pi/README.md`](pi/README.md) を参照してください。
+
 **Codex CLI を使用していますか?** 代わりに姉妹ディストリビューションをインストールしてください: [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) — 同じワークフローコンテンツ、`ars-*` エイリアスを持つ単一の `$academic-research-suite` スキルとしての Codex ネイティブパッケージング。
 
 ## パフォーマンス＆コスト

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -64,6 +64,8 @@ v3.3은 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018) (Song, Song, Pfis
 
 **Claude Science를 사용하시나요?** 네 개의 스킬을 바로 가져올 수 있습니다: **Skills → Import from GitHub**에서 `https://github.com/Imbad0202/academic-research-skills`를 붙여넣고 **Preview** → **Import 4 skills**(이 저장소 v3.14.0+ 필요 — 가져오기 도구는 marketplace manifest에 명시된 스킬 경로를 읽습니다). 가져오기는 특정 시점의 스냅샷입니다: ARS 업데이트 후에는 다시 가져오세요. 가져온 스킬은 ARS 방법론(연구/작성/리뷰 프로토콜)을 담습니다. Claude Code 전용 메커니즘 — slash commands, hooks, 서브에이전트 오케스트레이션 — 은 이전되지 않습니다. 자세한 내용은 [docs/SETUP.md](docs/SETUP.md) Method 5를 참조하세요.
 
+**Pi를 사용하시나요?** `pi install git:github.com/Imbad0202/academic-research-skills`로 저장소 내 커뮤니티 유지보수 wrapper를 설치할 수 있습니다. 원본 ARS 콘텐츠를 기준으로 유지하며 Pi 전용 오케스트레이션 및 hook 제한을 문서화합니다. 자세한 내용은 [`pi/README.md`](pi/README.md)를 참조하세요.
+
 **Codex CLI를 사용하시나요?** 대신 자매 배포판을 설치하세요: [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) — 동일한 워크플로 콘텐츠를, `ars-*` 별칭을 갖는 단일 `$academic-research-suite` 스킬로 Codex 네이티브 패키징한 것입니다.
 
 ## 성능 & 비용

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The architecture doc supersedes the sprawling pipeline description that used to 
 
 **Using Claude Science?** The four skills import directly: **Skills → Import from GitHub**, paste `https://github.com/Imbad0202/academic-research-skills`, **Preview**, then **Import 4 skills** (requires v3.14.0+ of this repo — the importer reads the explicit skill paths in the marketplace manifest). Imports are point-in-time snapshots: re-import after ARS updates. Imported skills carry the ARS methodology (research / writing / review protocols); Claude Code-specific machinery — slash commands, hooks, subagent orchestration — does not transfer. See [docs/SETUP.md](docs/SETUP.md) Method 5 for details.
 
+**Using Pi?** Install the in-tree, community-maintained wrapper with `pi install git:github.com/Imbad0202/academic-research-skills`. It keeps the original ARS content authoritative and documents Pi-specific orchestration and hook limitations. See [`pi/README.md`](pi/README.md).
+
 **Using Codex CLI?** Install the sibling distribution instead: [`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex) — same workflow content, Codex-native packaging as a single `$academic-research-suite` skill with `ars-*` aliases.
 
 **Third-party platforms and integrations** that wrap or host ARS are listed in [THIRD_PARTY.md](THIRD_PARTY.md) — community-submitted and not reviewed or endorsed by the maintainer.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,6 +63,8 @@ v3.3 的灵感来自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 
 **使用 Claude Science？** 四个 skill 可直接导入：**Skills → Import from GitHub**，粘贴 `https://github.com/Imbad0202/academic-research-skills`，点 **Preview**，再点 **Import 4 skills**（需本 repo v3.14.0+——导入器读取 marketplace manifest 中显式声明的 skill 路径）。导入是一次性快照：ARS 更新后需重新导入。导入的 skill 承载 ARS 方法论（研究／写作／评审协议）；Claude Code 专属机制——slash commands、hooks、subagent 编排——不会转移。详见 [docs/SETUP.md](docs/SETUP.md) Method 5。
 
+**使用 Pi？** 运行 `pi install git:github.com/Imbad0202/academic-research-skills` 安装仓库内的社区维护 wrapper。它继续以原始 ARS 内容为准，并记录 Pi 在编排和 hooks 方面的限制。详见 [`pi/README.md`](pi/README.md)。
+
 **用 Codex CLI？** 请安装姐妹版：[`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex)。同一套 workflow 内容，Codex 原生打包为单一 `$academic-research-suite` skill，提供 `ars-*` 别名。
 
 ## 性能与费用

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -65,6 +65,8 @@ v3.3 的靈感來自 [**PaperOrchestra**](https://arxiv.org/abs/2604.05018)（So
 
 **使用 Claude Science？** 四個 skill 可直接匯入：**Skills → Import from GitHub**，貼上 `https://github.com/Imbad0202/academic-research-skills`，按 **Preview**，再按 **Import 4 skills**（需本 repo v3.14.0+——匯入器讀取 marketplace manifest 中明列的 skill 路徑）。匯入是單次快照：ARS 更新後需重新匯入。匯入的 skill 承載 ARS 方法論（研究／寫作／審查協定）；Claude Code 專屬機制——slash commands、hooks、subagent 編排——不會轉移。細節見 [docs/SETUP.zh-TW.md](docs/SETUP.zh-TW.md) 方法五。
 
+**使用 Pi？** 執行 `pi install git:github.com/Imbad0202/academic-research-skills` 安裝 repo 內的社群維護 wrapper。它持續以原始 ARS 內容為準，並記錄 Pi 在編排與 hooks 方面的限制。詳見 [`pi/README.md`](pi/README.md)。
+
 **用 Codex CLI？** 請改裝姊妹版：[`Imbad0202/academic-research-skills-codex`](https://github.com/Imbad0202/academic-research-skills-codex)。同一套 workflow 內容，Codex 原生包裝為單一 `$academic-research-suite` skill，提供 `ars-*` 別名。
 
 ## 效能與費用

--- a/pi/README.md
+++ b/pi/README.md
@@ -16,7 +16,7 @@ Run `/ars-pi-doctor` to inspect the current environment. The curated [degraded-m
 ## Requirements
 
 - Pi with package support (`pi install` / `pi -e`)
-- This complete repository checkout; `pi/` is only a wrapper around its parent files
+- The complete repository package, loaded from GitHub or from a local checkout; `pi/` is only a wrapper around its parent files and cannot be copied by itself
 - Optional capabilities depend on the user's Pi setup:
   - a subagent, workflow, or parallel-agent skill/tool for true multi-agent execution
   - a web-search or page-retrieval skill/tool for literature search and verification
@@ -26,9 +26,17 @@ There are no required Pi orchestration or web-search dependencies. When a capabi
 
 ## Try without installing
 
-From the repository root:
+Load the package temporarily from GitHub for the current Pi run:
 
 ```bash
+pi -e git:github.com/Imbad0202/academic-research-skills
+```
+
+To try a local checkout instead, clone the repository first:
+
+```bash
+git clone https://github.com/Imbad0202/academic-research-skills.git
+cd academic-research-skills
 pi -e ./pi
 ```
 
@@ -59,16 +67,22 @@ For automatic ARS skill selection from subsequent natural-language prompts, expl
 
 ## Install from GitHub
 
-When this branch exists on GitHub, Pi can install the repository directly because the root `package.json` points to this wrapper and the original ARS resources:
+Pi can install the canonical repository directly because the root `package.json` points to this wrapper and the original ARS resources:
 
 ```bash
-pi install git:github.com/OWNER/academic-research-skills
+pi install git:github.com/Imbad0202/academic-research-skills
 ```
 
-Pin a branch, tag, or commit when needed:
+Pin a branch, tag, or commit that contains the Pi wrapper when needed:
 
 ```bash
-pi install git:github.com/OWNER/academic-research-skills@REF
+pi install git:github.com/Imbad0202/academic-research-skills@REF
+```
+
+Update installed Git packages with `pi update --extensions`. Remove this package with:
+
+```bash
+pi remove git:github.com/Imbad0202/academic-research-skills
 ```
 
 ## Install from this checkout
@@ -79,7 +93,7 @@ Keep the checkout at a stable path, then run from the repository root:
 pi install .
 ```
 
-The nested manifest remains usable for wrapper-only local installation:
+The nested manifest also supports local installation from the wrapper directory:
 
 ```bash
 pi install ./pi


### PR DESCRIPTION
<!-- Thanks for contributing to academic-research-skills. -->

## Summary

[skip-closes-check]

Justification: Documentation-only follow-up to merged PR #636; no open issue is being resolved.

Updates Pi documentation after the wrapper merged:

- replaces placeholder and pre-merge installation wording with the canonical repository URL;
- adds direct temporary loading and explicit clone-and-run instructions;
- documents Git package install, update, and removal commands;
- adds a concise Pi installation link to the translated root READMEs.

## Eval impact

No eval impact.

## Platform port?

Not a platform port. This only updates documentation for the existing Pi port.

## Checklist

- [x] Applicable tests passing locally (documentation-only; no test changes needed)
- [x] Eval impact section above is accurate

Validation:

- Pi wrapper tests: 9/9 passed
- Evidence checksums: 23/23 passed
- Version and specification consistency checks passed
- `git diff --check` passed