### PR TITLE
Add advisory cross-run adjudication activity

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -434,6 +434,15 @@ jobs:
           PYTHONPATH: .
         run: python3 scripts/check_cross_document_consistency_advisory_integration.py
 
+      - name: Check adjudication-activity advisory integration (#673)
+        # Static, hermetic guard for the closed schemas and CLI, exact renderer
+        # language, terminal-first/post-terminal best-effort wiring, sealed
+        # terminal authority, and the non-consumer boundary. Mutation tests run
+        # through the unified pytest manifest above.
+        env:
+          PYTHONPATH: .
+        run: python3 scripts/check_673_adjudication_activity.py
+
       - name: Run v3.9.2 Phase Boundary coverage lint (#133)
         # Enforces 22 Bucket A agents have ## Phase Boundary (v3.9.2)
         # block, 16 Bucket B/C/D agents DON'T, and each Bucket A block

--- a/academic-pipeline/SKILL.md
+++ b/academic-pipeline/SKILL.md
@@ -287,7 +287,7 @@ After user confirmation:
    - Stage 3' --> 4.5 (Accept/Minor direct path): Pass verified revised draft + the traceability sidecar's frozen records to integrity_verification_agent as gate input
    - Stage 4/4' --> 4.5: Pass revision-completed paper to integrity_verification_agent (final verification); on the Major-via-4' path the Stage 3' traceability sidecar travels along as gate input
    - Stage 4.5 --> 5: Pass verified final draft to the one mandatory Stage-5 entry checkpoint; run #660 then #672 against that same accepted artifact ID/SHA-256 before format-convert dispatch
-   - Stage 5  --> 6: Pass final deliverables list + pipeline state history to Process Summary (user may decline Stage 6 at the Stage 5 completion checkpoint)
+   - Stage 5  --> 6: Pass final deliverables list + the Process-Summary projection of pipeline state history, omitting the #673 activity projection of terminal root `run_id`, pending/sealed activity fields, selected-store data, renderer output, and diagnostics (user may decline Stage 6 at the Stage 5 completion checkpoint)
 3. Begin next stage
 ```
 
@@ -439,6 +439,40 @@ At the end of each revision round, if **delta < 3 points** on the 0-100 rubric A
 At pipeline start, estimate token cost based on paper length, mode, and cross-model toggle. Present estimate and ask for user confirmation before Stage 1 begins.
 
 Alongside the token estimate, present the **interaction-count budget**: long-horizon document corruption compounds with the number of document round-trips, not with token volume (DELEGATE-52, arXiv:2604.15597). Enumerate the round-trip caps the pipeline already enforces — 2 full revision loops (Early-Stopping above), 8 + 5 Socratic coaching rounds (Stage 3→4 / 3'→4'), and the integrity-gate fix→re-verify loop at Stages 2.5/4.5 — and state the worst-case round-trip total those caps imply for the chosen mode. At each stage checkpoint, report the accumulated round-trip count next to the stage status. **Advisory only**: the count never blocks; the per-loop caps remain the enforcement layer. A run that exceeds its stated worst case signals a loop the caps do not cover — surface that explicitly rather than silently continuing.
+
+---
+
+## Cross-run Adjudication Activity (#673; opt-in advisory side channel)
+
+The state tracker section "Adjudication-activity metadata" is the single
+producer/state authority. Each run receives one stable explicit `run_id`.
+Structured handlers first durably apply their existing author-choice,
+compliance-override, explicit-request, or MANDATORY-checkpoint routing/state
+effect and only then best-effort append a data-minimized binding to the
+five-row `pending_adjudication_activity_bindings[]` inventory. A refused
+MANDATORY skip leaves state unchanged before the optional receipt stores
+`skip_refused`. Author groups use `artifact_group_stage` and may preserve both
+Stage 3 and Stage 3-prime; receipt stages use the complete Stage 1-through-6
+closed enum, with no Stage 0. Compliance permits a plain report-only
+captured-zero group and requires the paired action receipt only for a fully
+qualifying override.
+
+Terminal behavior is unchanged and runs first. After the completed/aborted
+state is durable, and only for a user-selected local store, the orchestrator
+passes explicit state/artifact-root paths and the explicit pending five rows to
+`seal_terminal_inventory(state_path, artifact_root, pending_bindings)`, then
+best-effort runs sealed-inventory `build-input`, idempotent `append-run`, and
+optional `render`. The helper computes hashes; it does not read pending state,
+accept caller hashes, infer sources, or scan. Root `run_id` plus sealed root
+`adjudication_activity_sources` are exact authority. Any activity failure is an
+advisory diagnostic and cannot affect the already-durable terminal outcome.
+
+Activity data never enters a Material Passport, handoff, Process Record,
+reviewer/model/observer/compliance input, gate, verdict, checkpoint input, or
+stage transition. No live model, judge, eval, network/API, ambient clock,
+directory scan, or glob participates. Full details and frozen receipt schemas
+remain in `docs/design/2026-08-10-673-cross-run-adjudication-activity-spec.md`
+and `shared/contracts/activity/`.
 
 ---
 

--- a/academic-pipeline/agents/pipeline_orchestrator_agent.md
+++ b/academic-pipeline/agents/pipeline_orchestrator_agent.md
@@ -35,6 +35,10 @@ Determine the entry point from the user's first message. Use the following keywo
 - User attaches a file --> determine type (paper draft, review report, research notes)
 - User mentions no materials --> assume starting from scratch
 
+**Run identity (#673):** initialize the state tracker once with an explicit,
+stable `run_id`. Reuse that value for every action-time activity receipt; never
+derive or refresh it from a clock, path, artifact contents, or transcript.
+
 **Important: mid-entry routing rules**
 - User brings a paper and requests "review" -> go to Stage 2.5 (INTEGRITY) first, then Stage 3 (REVIEW) after passing
 - Cannot jump directly to Stage 3 (unless user can provide a previous integrity verification report)
@@ -381,6 +385,31 @@ Users respond to checkpoint prompts with one of these commands. The orchestrator
 - Skippable: Stage 1 (deep-research, if user provides own bibliography), Stage 3' (re-review, if only minor revisions), Stage 4' (re-revise, if accepted), Stage 6 (process summary — declined at the Stage 5 completion checkpoint; marked `skipped`, pipeline still terminates `completed`)
 - Non-Skippable: Stage 2 (writing), Stage 2.5 (pre-review integrity), Stage 3 (initial review), Stage 4.5 (final integrity), Stage 5 (finalize)
 
+#### Adjudication-activity action-time hook (#673)
+
+The state tracker section "Adjudication-activity metadata" is the single
+producer/state authority. Every author choice, qualifying compliance override,
+structured explicit justify/redo request, and MANDATORY-checkpoint response
+first completes and durably applies its existing routing/state behavior. Only
+then may its structured handler best-effort request the closed receipt binding;
+it must never parse conversation history to backfill one. Receipt failure is an
+advisory diagnostic and cannot change routing, state, the compliance outcome,
+or any checkpoint result.
+
+For an attempted `skip` at a MANDATORY checkpoint, refuse the skip and leave
+pipeline state unchanged first. Only afterward may the handler record the
+source `skip` as stored disposition `skip_refused`. MANDATORY receipt stages use
+the complete closed Stage 1-through-6 enum listed by the state tracker (including
+half/prime stages); there is no Stage 0. Author groups use
+`artifact_group_stage` and preserve both Stage 3 and Stage 3-prime groups when
+both occurred. Interaction identity is a run-scoped occurrence id, never a
+content hash.
+
+Activity metadata is always advisory-only. It is not a gate, verdict,
+checkpoint input, dispatch input, model/judge/eval request, passport/handoff
+field, or Process Record source, and its production performs no network/API,
+clock, or ambient filesystem scan.
+
 ### Mode Switching Rules
 
 Users may request changing a sub-skill's mode at a checkpoint. Not all switches are safe.
@@ -571,7 +600,7 @@ Reference helper: `scripts/slr_lineage.py` `emit(stages, incoming_slr_lineage)`.
 | Stage 3' -> 4.5 | (Accept/Minor direct path — no Stage 4' between) Verified Revised Draft + the traceability sidecar with its frozen `previously_missed`/`indeterminate` new-issue records (#576 §8 — Material Passport cargo consumed by the Stage 4.5 gate) | Schema 4 (revised) + traceability sidecar | Pass to integrity_verification_agent (final verification); the frozen records are gate INPUT, not just cargo |
 | Stage 4/4' -> 4.5 | Revised/Re-Revised Draft + #547/#548 context + complete validated `revision-evidence-bundle/1.0` from exact integrity PASS through every review write/no-op/integrity round + (Major-via-4' path) the Stage 3' traceability sidecar with its frozen `previously_missed`/`indeterminate` new-issue records | Schema 4 + #670 bundle + traceability sidecar | Pass to integrity_verification_agent; registered surfaces are replayed, while the explicit unregistered-claim boundary remains mandatory E6 review input |
 | Stage 4.5 -> 5 | Final Verified Draft + Final Integrity Report + exact preregistration sidecar/companion + independent #660/#672 results | Schema 4 + Schema 5 + `preregistration-artifact/1.0`; independent advisory schemas | At the one mandatory entry checkpoint run #660 then #672 on identical accepted-draft ID/SHA and surface both without changing routing. On confirmation: Produce MD -> DOCX via Pandoc when available (otherwise instructions) -> ask about LaTeX -> confirm -> PDF. Carry forward `experiment_alignment_results[]` + `experiment_intake_declaration` (#260) to formatter surface + Stage 6 histogram |
-| Stage 5 -> 6 | Final deliverables list + pipeline state history (state_tracker JSON, agent logs) | — (Process Record; no numbered schema) | Dispatched only after the user confirms the Stage 5 completion checkpoint (FULL). User may decline Stage 6 there: mark it `skipped`, set pipeline state `completed`. Protocol: `../references/process_summary_protocol.md`; terminal semantics: `../references/pipeline_state_machine.md` § Stage 6 terminal semantics |
+| Stage 5 -> 6 | Final deliverables list + Process-Summary projection of pipeline state history and agent logs, explicitly omitting the #673 activity projection of terminal root `run_id`, pending/sealed activity fields, selected-store data, renderer output, and diagnostics | — (Process Record; no numbered schema) | Dispatched only after the user confirms the Stage 5 completion checkpoint (FULL). User may decline Stage 6 there: mark it `skipped`, set pipeline state `completed`. Protocol: `../references/process_summary_protocol.md`; terminal semantics: `../references/pipeline_state_machine.md` § Stage 6 terminal semantics |
 
 **#672 sidecar continuity:** At Stage 1, this shell-capable orchestrator alone
 invokes `scripts/build_cross_document_consistency_advisory.py
@@ -642,9 +671,30 @@ Notify state_tracker_agent to update state whenever a stage begins or completes:
 - Checkpoint passed: `update_pipeline_state("running")`
 - Material produced: `update_material(material_name, true)`
 - Integrity check result: `update_integrity(stage_id, verdict, details)`
-- Pipeline terminal transition: on the Stage 6 terminal acknowledgement (`finish` / `end` / `done` / `confirm`, or an unambiguous natural-language equivalent) — `update_stage("6", "completed", outputs)` + `update_pipeline_state("completed")`; if the user declined Stage 6 at the Stage 5 completion checkpoint — `update_stage("6", "skipped", {reason: "user declined Stage 6"})` + `update_pipeline_state("completed")`
+- Pipeline terminal transition: on the Stage 6 terminal acknowledgement (`finish` / `end` / `done` / `confirm`, or an unambiguous natural-language equivalent) — `update_stage("6", "completed", outputs)` + `update_pipeline_state("completed")`; if the user declined Stage 6 at the Stage 5 completion checkpoint — `update_stage("6", "skipped", {reason: "user declined Stage 6"})` + `update_pipeline_state("completed")`. Persist this transition first, without consulting activity metadata.
 
 Request state_tracker_agent to produce the Progress Dashboard when needed.
+
+### Post-terminal adjudication-activity sequence (#673)
+
+After the existing terminal transition above is durable, and only when the user
+selected an explicit local activity store, perform this best-effort sequence:
+
+1. pass the explicit state path, artifact-root path, and the state tracker's
+   explicit five-row `pending_adjudication_activity_bindings[]` value to
+   `seal_terminal_inventory(state_path, artifact_root, pending_bindings)`;
+2. let that deterministic helper calculate raw artifact hashes and atomically
+   seal the root `adjudication_activity_sources` inventory without changing the
+   already-terminal state/stage/status;
+3. run `build-input` using only that sealed inventory, then idempotent
+   `append-run`, and optionally `render`.
+
+The helper may not discover the pending field itself, accept caller-reported
+hashes, infer paths, scan/glob a directory, or use a clock/network/model. Any
+seal/build/append/render failure is surfaced only as an advisory diagnostic and
+does not roll back, delay, or rewrite the terminal outcome. The terminal state
+file's root `run_id` plus sealed root `adjudication_activity_sources` are exact
+source/run authority; the pending rows are not.
 
 ---
 

--- a/academic-pipeline/agents/state_tracker_agent.md
+++ b/academic-pipeline/agents/state_tracker_agent.md
@@ -31,6 +31,85 @@ For every stage transition, the tracker records a `dialogue_log_ref` containing 
 
 Append-only list. Each entry is an observer report produced at a FULL/SLIM checkpoint or during Stage 6 record compilation (the whole-pipeline pass). Entries never gate state transitions — they are stored for the final Process Record's "Collaboration Depth Trajectory" chapter only. The tracker must reject any write request that attempts to turn observer output into a blocking condition.
 
+### Adjudication-activity metadata (#673; authoritative producer/state contract)
+
+Adjudication activity is an opt-in, local, deterministic, **advisory-only**
+side channel. At run initialization the tracker receives one explicit `run_id`
+matching `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`; it stores that value at the
+state root and never regenerates, changes, or infers it from a clock, path,
+conversation, artifact content, or filesystem metadata.
+
+The tracker is sole writer for two internal root fields:
+
+- `pending_adjudication_activity_bindings[]` is a non-authoritative staging
+  inventory with exactly the five canonical source-family rows. Through the
+  sole-writer API, a producer may best-effort append a captured artifact binding
+  to its row only **after** it has durably applied the user's ordinary
+  routing/state effect. Captured pending bindings carry only artifact id, role,
+  group id, `artifact_group_stage`, and relative path—never a caller-computed
+  hash. A not-applicable or unavailable row has empty artifacts plus its closed
+  reason. A failed append emits an advisory diagnostic and cannot refuse, roll
+  back, or alter the ordinary effect.
+- `adjudication_activity_sources` is absent until post-terminal sealing. Once
+  sealed, it is the exact five-row inventory, in frozen-spec order, and is never
+  inferred or rebuilt. The terminal state file's root `run_id` plus this sealed
+  root inventory are the exact source/run authority. Pending bindings are not
+  authority.
+
+Action-time producers use only closed receipts from the #673 spec:
+
+1. Author adjudication captures one or two complete two-artifact groups
+   (`author_adjudication_input`, then `author_adjudication`). Each group uses
+   `artifact_group_stage`, with Stage 3 before Stage 3-prime when both exist.
+   The author occurrence identity is the run-scoped `author_event_id`; its
+   interaction digest is derived from `run_id` plus that occurrence id, never
+   from content.
+2. Compliance captures each report group. A plain PASS/WARN report without
+   `user_override` is a valid report-only captured-zero group. Only a qualifying
+   blocking compliance override receives the paired
+   `compliance_override_action_receipt`; a non-qualifying report must not receive
+   one.
+3. Re-review capture binds the exact manifest/precommitment/verdict/traceability
+   quartet after that existing producer has completed.
+4. Explicit-request and MANDATORY-checkpoint logs are written only by the
+   structured action handler at occurrence time, never reconstructed from
+   transcript prose. The complete receipt-stage enum is
+   `pipeline_stage_1 | pipeline_stage_2 | pipeline_stage_2_5 |
+   pipeline_stage_3 | pipeline_stage_3_prime | pipeline_stage_4 |
+   pipeline_stage_4_prime | pipeline_stage_4_5 | pipeline_stage_5 |
+   pipeline_stage_6`. There is no Stage 0. An attempted MANDATORY `skip` first
+   follows the existing refusal path and leaves pipeline state unchanged; only
+   afterward may the best-effort receipt store `skip_refused`.
+
+Terminal writes are strictly ordered. The tracker first durably performs the
+existing terminal transition without reading or depending on any activity
+metadata. Only if the user selected a store may the orchestrator then call the
+deterministic post-terminal helper
+`seal_terminal_inventory(state_path, artifact_root, pending_bindings)` with the
+explicit state path, artifact-root path, and explicitly passed five-row
+`pending_adjudication_activity_bindings[]`. The helper does not read that field
+from state, infer roles, paths, groups, stages, or reasons, or scan for artifacts.
+It may append/seal `adjudication_activity_sources` in the already-terminal state
+file, but must leave terminal `pipeline_state`, current stage, and stage status
+byte-semantically unchanged. Seal/build/append/render failure is advisory,
+creates no substitute store record, and never changes the durable terminal
+outcome. `build-input` projects only the sealed inventory; it accepts no
+caller-reported paths or hashes and performs no ambient scan. `append-run` treats
+an identical `run_id` plus input-receipt digest as idempotent success with no
+write, revision/sequence allocation, or metadata change; a different digest is
+a conflict. Artifact hashes are byte bindings, not identities, and may legally
+repeat within or across retained runs. Optional renderer output is a standalone
+user-facing advisory: its exact limitation and coverage strings are surfaced
+verbatim and never rewritten by the orchestrator.
+
+Neither pending bindings, sealed inventory, selected-store information, store
+contents, renderer output, nor diagnostics may enter a Material Passport,
+stage handoff, Process Record, reviewer/model/observer input, compliance
+decision, gate, verdict, or checkpoint input. Producers and terminal helpers use
+no live model, judge, eval, network/API, ambient clock, directory scan, or glob.
+The frozen design spec and activity schemas remain authoritative for receipt
+shapes, capture-state reasons, group/role ordering, hashing, and replay.
+
 ### State Update Protocol
 
 1. Requesting agent calls `request_update(field, new_value, reason)`
@@ -68,6 +147,7 @@ Every material artifact produced by the pipeline carries a version label. These 
 
 ```json
 {
+  "run_id": "run-42",
   "topic": "Paper topic (determined by Stage 1 or user input)",
   "language": "en",
   "pipeline_version": "2.6",
@@ -310,7 +390,7 @@ Update the specified stage's status.
 - Status can only advance (pending -> in_progress -> completed), cannot regress
 - Exception: Stage 2.5 and 4.5 FAIL retries are legal (status remains in_progress)
 - Skipped status means the user skipped this stage (Stage 2.5 and 4.5 cannot be skipped)
-- Stage 6 terminal semantics (#528): on the terminal acknowledgement, `update_stage("6", "completed", outputs)` then `update_pipeline_state("completed")`; if the user declines Stage 6 at the Stage 5 completion checkpoint, `update_stage("6", "skipped", {reason: "user declined Stage 6"})` then `update_pipeline_state("completed")`. See `../references/pipeline_state_machine.md` § Stage 6 terminal semantics
+- Stage 6 terminal semantics (#528): on the terminal acknowledgement, `update_stage("6", "completed", outputs)` then `update_pipeline_state("completed")`; if the user declines Stage 6 at the Stage 5 completion checkpoint, `update_stage("6", "skipped", {reason: "user declined Stage 6"})` then `update_pipeline_state("completed")`. This terminal transition is persisted before, and never depends on, #673 post-terminal activity work. See `../references/pipeline_state_machine.md` § Stage 6 terminal semantics
 
 ### 2. update_pipeline_state(state)
 

--- a/academic-pipeline/references/pipeline_state_machine.md
+++ b/academic-pipeline/references/pipeline_state_machine.md
@@ -247,6 +247,39 @@ When Stage 6 runs, its completion is the pipeline's **terminal checkpoint**:
 3. On acknowledgement: state_tracker marks Stage 6 `completed` and sets the pipeline global state to `completed`. This is the terminal transition — there is no next stage.
 4. After `completed`, no stage transition is legal (see Prohibited Transitions). New requests start a new pipeline run or a targeted single-skill invocation (mid-entry).
 
+### Post-terminal adjudication-activity side channel (#673)
+
+The ordinary state machine is authoritative and always terminates first. A
+`completed` run durably records Stage 6 with status `completed` or `skipped` as
+defined above. An `aborted` run durably records its first replayable terminal
+stage. The closed replayable activity vocabulary is Stage 1, 2, 2.5, 3,
+3-prime, 4, 4-prime, 4.5, 5, and 6; there is no Stage 0.
+
+Only after that terminal write succeeds, and only for an explicitly selected
+local store, may the orchestrator invoke the state tracker's #673
+post-terminal sequence. It passes explicit state/artifact-root paths plus the
+explicit five-row `pending_adjudication_activity_bindings[]` value to
+`seal_terminal_inventory(state_path, artifact_root, pending_bindings)`. Pending
+captured artifact bindings carry id, role, group id,
+`artifact_group_stage`, and relative path but no hash; the helper computes raw
+hashes. Non-applicable/unavailable rows carry empty artifacts and a closed
+reason. The helper neither reads the pending field itself nor infers or scans
+for sources.
+
+The helper seals the exact root `adjudication_activity_sources` inventory while
+leaving terminal state, stage, and status byte-semantically unchanged. The
+terminal file's root `run_id` plus that sealed root inventory are exact
+source/run authority; pending rows are not. `build-input` can project only the
+sealed inventory and cannot accept caller-reported hashes. Idempotent append
+and optional render follow. Any post-terminal failure is advisory, creates no
+substitute record, and cannot change the already-durable terminal state.
+
+This side channel is never a legal transition, precondition, gate, verdict,
+checkpoint input, passport/handoff/Process Record field, or model/observer/
+compliance input. It uses no live model, judge, eval, network/API, ambient
+clock, directory scan, or glob. Producer details are single-homed in
+`../agents/state_tracker_agent.md` § "Adjudication-activity metadata".
+
 ---
 
 ## Material Dependency Matrix

--- a/academic-pipeline/references/process_summary_protocol.md
+++ b/academic-pipeline/references/process_summary_protocol.md
@@ -42,7 +42,25 @@
      Stage 6 in_progress — they are not acknowledgements.
    - On acknowledgement: state_tracker marks Stage 6 completed and sets the pipeline global state to completed. There is no next stage.
      (See pipeline_state_machine.md § Stage 6 terminal semantics.)
+   - Persist that terminal transition first and without consulting #673
+     adjudication-activity metadata. If the user selected a local activity
+     store, seal/build/append/render runs only afterward as best-effort
+     post-terminal work; its failure cannot change completion.
 ```
+
+## Adjudication-activity exclusion (#673)
+
+The Process Record may describe the user-visible decisions already present in
+the ordinary dialogue and state history. It MUST NOT read, copy, summarize,
+score, or mention activity metadata. It MUST NOT include
+`pending_adjudication_activity_bindings[]`, the sealed
+`adjudication_activity_sources` inventory, the selected store/path, stored
+records, renderer output, or diagnostics. Those artifacts are a
+separate local advisory side channel, not Process Record evidence. They also
+must not be passed to `collaboration_depth_agent` or any model/judge/eval call.
+The Stage 6 compilation rules do not perform an ambient filesystem scan for
+them. See `../agents/state_tracker_agent.md` § "Adjudication-activity metadata"
+for the single producer/state authority.
 
 ## Required Content in Process Record
 

--- a/docs/design/2026-08-10-673-cross-run-adjudication-activity-spec.md
+++ b/docs/design/2026-08-10-673-cross-run-adjudication-activity-spec.md
@@ -1,0 +1,1068 @@
+# #673 Cross-run Adjudication Activity — Frozen Contract
+
+**Status:** frozen design; implementation must conform byte-for-byte where this
+specification says "exact"
+**Issue:** #673
+**Date:** 2026-08-10
+**Scope:** a user-selected local activity store, deterministic extraction from
+explicit canonical artifacts, advisory rendering, deletion, and hermetic tests
+
+## 1. Purpose and authority boundary
+
+This feature records a narrow fact: which explicit adjudication actions were
+captured across eligible terminal pipeline runs. It does not infer whether a
+user read carefully, was attentive, remained engaged, agreed sincerely, or
+retained meaningful ownership. It does not judge whether an action or result
+was correct.
+
+The store is an optional, user-owned local artifact. A caller selects it by an
+explicit `--store` path on every operation. There is no default path,
+environment-variable fallback, home-directory convention, recursive discovery,
+passport lookup, or search for nearby stores. Nothing is transmitted or
+aggregated across users.
+
+The feature is observability only:
+
+- it is never read by a gate, checkpoint-type selector, editorial decision,
+  verdict, score, ranking, model prompt, agent dispatch, or terminal-state
+  transition;
+- it has no target, threshold, benchmark, rate, health class, pass state,
+  traffic-light rendering, or comparison with another user;
+- store failure cannot block, delay, undo, or change a pipeline transition; and
+- a terminal state is persisted first. Activity capture and rendering run only
+  afterwards as a best-effort advisory side effect.
+
+The exact limitation sentence rendered in every output is:
+
+> This records explicit adjudication activity only. It cannot determine correctness, attentiveness, engagement, or whether human ownership is real; genuine agreement and non-review can produce the same history.
+
+The exact following sentence is also mandatory:
+
+> This series is advisory only; it never gates, blocks, scores, or changes any verdict.
+
+Separately and normatively, neither runtime nor renderer may define a target or
+threshold or change any checkpoint or decision.
+
+## 2. Frozen implementation surface
+
+The complete production surface is closed to:
+
+- `shared/contracts/activity/adjudication_activity_input.schema.json`, schema
+  version `adjudication-activity-input/1.0`;
+- `shared/contracts/activity/adjudication_activity_store.schema.json`, schema
+  version `adjudication-activity-store/1.0`;
+- `scripts/adjudication_activity.py`;
+- `academic-pipeline/agents/state_tracker_agent.md`, which owns the closed
+  action-time receipt writes and terminal-state receipt projection;
+- `academic-pipeline/agents/pipeline_orchestrator_agent.md`,
+  `academic-pipeline/SKILL.md`,
+  `academic-pipeline/references/pipeline_state_machine.md`, and
+  `academic-pipeline/references/process_summary_protocol.md`, which own the
+  opt-in post-terminal append/render hook and refused-MANDATORY-skip behavior;
+- `shared/compliance_checkpoint_protocol.md`, which owns the paired explicit
+  compliance-override receipt;
+- `shared/handoff_schemas.md`, which documents that these are local run
+  receipts and that neither activity store nor aggregate enters a handoff or
+  Material Passport;
+- `scripts/check_673_adjudication_activity.py` and focused runtime/integration
+  tests, including a static non-consumer check; and
+- `scripts/_ci_pytest_manifest.toml` plus the existing spec-consistency
+  workflow registration.
+
+The receipt writers create data-minimized local run artifacts only. This file
+map does not authorize adding the store, counts, or renderer output to a
+passport, handoff, Process Record, agent prompt, or model payload. An
+implementation that ships schemas and a CLI without these producer and
+terminal-hook paths is incomplete and cannot claim end-to-end acceptance.
+
+There is no legacy loader, migration command, compatibility branch, or
+retroactive backfill. Any other schema version fails closed. A historical run
+that did not produce a v1 source manifest is not scanned or reconstructed.
+
+## 3. Eligible runs and observation window
+
+One store record represents one eligible terminal run. The only eligible
+terminal states are `completed` and `aborted`.
+
+Terminal eligibility is proved by a closed inline `terminal_receipt` in the
+input manifest. It copies a minimal projection and binds the exact existing
+state-tracker JSON; there is no new terminal-receipt file or schema. The runtime
+opens the bound state file beneath the explicit `--artifact-root`, rejects
+duplicate keys and non-finite numbers, verifies its raw-byte SHA-256, and
+strictly replays these state-tracker fields:
+
+- receipt and input-root `run_id` are equal and both equal the state file's
+  `run_id`;
+- receipt `pipeline_state`, state-file `pipeline_state`, and input
+  `terminal_state` must be equal;
+- the state-file `current_stage` must map exactly to receipt `current_stage`
+  and input `terminal_stage`;
+- receipt `current_stage_status` must equal the status at the state file's raw
+  `stages[current_stage]` key;
+- a completed run must have `pipeline_state == "completed"`,
+  `current_stage == "6"`, and Stage 6 status `completed` or `skipped`; and
+- an aborted run must have `pipeline_state == "aborted"`; its exact
+  `current_stage` maps to the recorded terminal stage and its copied status is
+  exactly one of the state tracker's closed
+  `pending | in_progress | completed | skipped | blocked` values.
+
+The closed stage mapping is:
+
+| State-tracker value | Activity value |
+|---|---|
+| `1` | `pipeline_stage_1` |
+| `2` | `pipeline_stage_2` |
+| `2.5` | `pipeline_stage_2_5` |
+| `3` | `pipeline_stage_3` |
+| `3p` | `pipeline_stage_3_prime` |
+| `4` | `pipeline_stage_4` |
+| `4p` | `pipeline_stage_4_prime` |
+| `4.5` | `pipeline_stage_4_5` |
+| `5` | `pipeline_stage_5` |
+| `6` | `pipeline_stage_6` |
+
+The first replayable aborted stage is Stage 1. Stage 0 is not in this closed
+vocabulary because the state tracker has no Stage 0 status record to prove.
+
+This includes both completed paths already defined by the pipeline: Stage 6
+completed after terminal acknowledgement, or Stage 6 explicitly declined and
+marked `skipped` before the global state becomes `completed`. Merely reaching a
+stage, emitting a final draft, or receiving a review decision is not terminal.
+
+### 3.1 Terminal source inventory is run authority
+
+The state-tracker contract gains a stable `run_id` and a closed
+`adjudication_activity_sources` inventory. The inventory has exactly the five
+source-family rows in §4 order and, for every captured group, every closed
+group/stage/role/id/relative-path/raw-SHA binding in canonical order. It also
+records each row's capture state and reason. It contains no events, counts, or
+prose.
+
+Action-time producers best-effort append their closed receipt/artifact bindings
+to pending state-tracker metadata through its sole-writer path. Receipt failure
+never changes the action's already-derived routing or state effect.
+
+Terminal integration is strictly two-step. First, the existing terminal
+transition is made durable without reading, hashing, validating, or depending
+on any activity metadata. Second, and only when the user selected a store, a
+post-terminal metadata helper reopens that terminal state, resolves every
+family to `captured`, `not_applicable`, or `unavailable`, computes current raw
+hashes, validates exact groups, and atomically appends/seals the five-row
+inventory in the same state JSON while leaving the terminal
+state/stage/status byte-semantically unchanged. Failure of this second write
+emits a diagnostic, creates no store row, and cannot roll back or alter the
+terminal outcome.
+
+The helper is a deterministic library entry point in
+`scripts/adjudication_activity.py` named `seal_terminal_inventory(...)`; the
+orchestrator passes explicit state and artifact-root paths and closed pending
+receipt bindings. It performs no model reasoning, hash transcription, scan, or
+path discovery.
+
+`build-input` may only copy this exact inventory projection. `append-run`
+reopens the raw-hash-bound state file, compares every input source field and
+artifact binding to the sealed inventory, then reopens each referenced artifact
+and verifies its bytes. Consequently a caller cannot splice a valid #670
+sidecar or re-review quartet from another run merely by naming its path and
+hash.
+
+A state tracker without both stable `run_id` and the post-terminal sealed five-
+row inventory is legacy and ineligible for reconstruction. No directory scan
+or inferred backfill is allowed. New successfully sealed v1 runs always carry
+all five rows, including explicit unavailable rows when action-time capture
+failed.
+
+The renderer selects the last `N` retained eligible run records by
+`append_sequence`, never by a timestamp, filename, run id, filesystem order, or
+event count. `N` defaults to `10`; the closed accepted range is `2..50`. If the
+store retains fewer than `N`, all retained records are selected. A captured
+zero-event run and a run with one or more unavailable source families both stay
+in the selected-run denominator. Deleted sequence gaps stay gaps.
+
+This denominator is deliberately store-relative. A terminal run for which the
+user did not select this store, or whose best-effort append failed, has no
+fabricated placeholder in the store and is not counted. The renderer never
+calls the store the user's complete pipeline history or the last `N` actual
+runs; it reports only successfully retained eligible run records in the
+explicitly selected store.
+
+Zero or one retained eligible run renders `INSUFFICIENT_HISTORY`, never pass,
+healthy, zero-risk, or an inferred absence of adjudication.
+
+## 4. Source-manifest input, not caller-supplied events
+
+The input is a closed source manifest. Its root is:
+
+```json
+{
+  "schema_version": "adjudication-activity-input/1.0",
+  "store_id": "ADJ-ACTIVITY-STORE-example",
+  "run_id": "run-42",
+  "terminal_state": "completed",
+  "terminal_stage": "pipeline_stage_6",
+  "terminal_receipt": {
+    "artifact_id": "pipeline-state-terminal-receipt",
+    "relative_path": "state/run-42.json",
+    "sha256": "<64 lowercase hex>",
+    "run_id": "run-42",
+    "pipeline_state": "completed",
+    "current_stage": "pipeline_stage_6",
+    "current_stage_status": "completed"
+  },
+  "sources": ["<the five receipts below, in exact order>"],
+  "data_minimization": {
+    "raw_prose_embedded": false,
+    "user_identity_embedded": false,
+    "absolute_paths_embedded": false
+  }
+}
+```
+
+The input contains no events, counts, rates, score, overturn field, free prose,
+user identity, absolute path, or timestamp. The runtime alone derives events
+after replaying canonical artifacts.
+
+`sources` contains exactly five receipts in this order:
+
+1. `revision_author_adjudication`;
+2. `compliance_report`;
+3. `re_review_traceability`;
+4. `explicit_user_request`; and
+5. `mandatory_checkpoint_response`.
+
+Every receipt has one of three states:
+
+- `captured`: at least one relative artifact binding is present and every bound
+  artifact is opened, hash-verified, schema-checked, and replayed. A captured
+  family may validly derive zero events.
+- `not_applicable`: `reason_code` is exactly `not_applicable_for_run`, and the
+  artifact list is empty. Normal absence because that workflow path was not
+  exercised uses this state, not `unavailable`.
+- `unavailable`: the artifact list is empty and `reason_code` is exactly one of
+  `source_not_provided | source_unreadable | source_invalid |
+  capture_not_supported`. This is an observed capture limitation, not zero
+  activity. The run remains in the denominator and the limitation is rendered.
+
+Stage exists only on each source artifact binding as
+`artifact_group_stage`. It is non-null only for
+`revision_author_adjudication`, with the closed values
+`pipeline_stage_3 | pipeline_stage_3_prime`; every artifact in one group has
+the same stage. It is null for all other roles and families. The input builder
+must replay the terminal state-tracker receipt and require each named author
+stage's status to be `completed`; `append-run` repeats that replay. Thus the
+stage is explicit and hash-bound without being inferred from a sidecar or
+trusted as a free receipt label.
+
+Artifact paths use canonical POSIX relative syntax, have at most 512
+characters, and are resolved only under the explicit artifact root. Absolute
+paths, drive paths, backslashes, control characters, empty components, `.` or
+`..` components, a trailing separator, path escape after resolution, symlinks,
+and non-regular files are rejected. Hashes cover exact raw bytes, including a
+trailing newline when present.
+
+Every source artifact binding also carries closed `artifact_group_id`,
+`artifact_group_stage`, and `artifact_role` fields. `artifact_group_id` is a
+bounded ASCII identifier used only to join an exact source set.
+`artifact_role` comes from the per-family closed vocabulary below; a free
+`artifact_id`, filename, extension, array position alone, or inspected content
+may not decide a role. Within one family, group ids are unique and artifacts
+are in contract group/stage then role order. A missing, duplicate, extra,
+swapped, cross-stage, or cross-group role makes the captured source invalid.
+
+## 5. Canonical sources and extraction
+
+Extraction is a closed projection over the artifacts below. Unknown records,
+free-form conversation, prose similarity, sentiment, keywords, and model
+classification never create an event.
+
+### 5.1 `revision_author_adjudication`
+
+This family has one or two groups. Each group contains exactly:
+
+1. role `author_adjudication_input`, validated as
+   `author-adjudication-input/1.0`; and
+2. role `author_adjudication`, validated as `author-adjudication/1.0`.
+
+Both share one group id and one `artifact_group_stage`; no third role is
+allowed. Group stages are unique and canonical: Stage 3 first, then Stage
+3-prime when both exist. This represents a run that performed initial author
+adjudication and later re-review adjudication without dropping either source.
+
+The runtime requires the input/output projections of `author_events`,
+`author_adjudications`, `display_order`, and `collateral_authorizations` to be
+identical and every adjudication's `author_event_id` to resolve to an explicit
+session-user event. It reads the raw #670 author-owned sidecar, never a Schema
+11 traceability copy or rendered decision letter.
+
+It emits one event per sidecar adjudication with:
+
+| `author_triage` | `event_type` | `disposition` | Overturn? |
+|---|---|---|---|
+| `wont_address` | `author_triage_wont_address` | `wont_address` | no |
+| `not_on_point` | `author_triage_not_on_point` | `not_on_point` | yes |
+
+`will_address` emits no event. A reason, target count, claim authorization, or
+scope entry never becomes a separate event. Stage is exactly the producing
+group's `artifact_group_stage`, `pipeline_stage_3` or
+`pipeline_stage_3_prime`, after the state-tracker completion replay above; no
+other stage is accepted. The resolved unique `author_event_id` is the
+occurrence `interaction_id`; runtime derives the event's non-null
+`interaction_sha256` by §5.6. The author event's `input_sha256` remains in the
+source-event projection but is never used as a causal deduplication key.
+
+### 5.2 `compliance_report`
+
+This family has `1..16` groups in the action-time producer's append order.
+Every group contains exactly one `compliance_report` role and zero or one
+`compliance_override_action_receipt` role:
+
+1. `compliance_report`, a Schema 12 object validated against
+   `shared/compliance_report.schema.json`; and
+2. `compliance_override_action_receipt`, required only for a qualifying
+   override and forbidden for a plain no-override report.
+
+The action receipt has this exact logical shape and contains no rationale:
+
+```json
+{
+  "schema_version": "adjudication-compliance-override-action/1.0",
+  "receipt_id": "COMPLIANCE-OVERRIDE-1",
+  "run_id": "run-42",
+  "actor_role": "user",
+  "source": "explicit_session_user_action",
+  "action": "acknowledge_compliance_limitation",
+  "stage": "pipeline_stage_2_5",
+  "scope": ["M4"],
+  "report_sha256": "<paired report raw-byte SHA-256>",
+  "override_ordinal": 1,
+  "interaction_id": "USER-ACTION-17",
+  "interaction_sha256": "<64 lowercase hex>"
+}
+```
+
+One `compliance_block_override` event with disposition `block_overridden` is
+emitted for one valid group—not for every `scope[]` element—only when all of
+these are true:
+
+- `overall_decision == "block"` and `user_action_required == true`;
+- `mode == "systematic_review"`, and the report's compliance contribution
+  itself is blocking: a non-empty PRISMA
+  `by_tier.mandatory.fail` with PRISMA `block_decision == "block"`, a RAISE
+  principle status `fail` with RAISE `block_decision == "block"`, or both; a
+  legacy-only orchestrator block is not enough;
+- `user_override.decision == true`;
+- the actual blocking-contributor set is recomputed as the union of systematic-
+  review Mandatory PRISMA item ids in the report's fail set and RAISE principle
+  ids whose status is `fail`;
+- the report `user_override.scope`, action-receipt `scope`, and recomputed
+  blocking-contributor set are equal as duplicate-free sets;
+- report stage and receipt stage agree; receipt `report_sha256` equals the
+  raw-byte hash in the paired manifest binding; and the receipt has a unique
+  `receipt_id` plus the exact matching run id, actor, source, action, and
+  non-null interaction digest; and
+- within each stage, `override_ordinal` starts at 1 and is contiguous without
+  gaps or duplicates. Ordinal 2 requires a non-empty rationale and ordinal 3
+  and later require at least 100 Unicode scalar values, exactly replaying the
+  shipped friction ladder.
+
+Stage `2.5` maps to `pipeline_stage_2_5`; stage `4.5` maps to
+`pipeline_stage_4_5`. Non-systematic-review RAISE failures remain warn-capped
+and never enter the blocking-contributor set. A PASS or WARN report,
+legacy-only block, `user_action_required=false`, an
+empty or mismatched scope, a scope that covers a non-blocking contributor but
+misses a blocker, an unpaired or report-hash-swapped receipt, or a broken
+pair makes the group invalid and emits no event. Schema 12's structural acceptance of a
+PASS-plus-`user_override` object is therefore never sufficient evidence. The
+event retains the paired receipt's exact `interaction_sha256`. The contiguous
+per-stage ordinal makes omitted/reordered predecessors observable; the action-
+time writer and extractor both enforce it.
+
+A plain PASS or WARN report with no `user_override` and no action receipt is a
+valid report-only group and emits zero events. This is how a run that executed
+compliance without an override remains honestly `captured`, not
+`not_applicable` or `unavailable`. Conversely, any report containing a
+`user_override` claim that fails the full predicate, or any action receipt
+paired to a non-qualifying report, fails the captured source rather than being
+silently converted to zero.
+
+### 5.3 `re_review_traceability`
+
+The captured set has one group with exactly four roles in this order:
+
+1. current role `input_manifest` (`re-review-input-manifest/1.1`);
+2. current role `precommitment`;
+3. current role `verdict_record`; and
+4. final cumulative role `traceability`.
+
+All four closed schemas validate; `round_id` agrees; and the existing exact
+chain is replayed:
+
+```text
+restricted-canonical(input_manifest) -> precommitment.input_manifest_hash
+restricted-canonical(precommitment)   -> verdict_record.precommitment_hash
+restricted-canonical(verdict_record)  -> traceability.verdict_record_hash
+```
+
+One `re_review_verdict_changed` event with disposition `verdict_changed` and
+stage `pipeline_stage_3_prime` is emitted only for this complete user-owned
+chain:
+
+1. a final cumulative `dissent_adjudications[]` record has
+   `adjudicator == "user"` and `outcome == "original_upheld"`;
+2. the current, non-superseded `reapplications[]` record for the same item has
+   `answer_refs` containing `adjudication:<that dissent_id>`;
+3. an `adjustments[]` record for the same item has
+   `basis == "cross_model_adjudication"`,
+   `source_ref == "reapplication:<that reapplication_id>"`, and unequal
+   `from_verdict` and `to_verdict`;
+4. the adjustment is in the exact non-forking adjustment chain whose tail is
+   named by the final row; and
+5. the row's final verdict equals the chain tail's `to_verdict`.
+
+Every link must be unique. A superseded reapplication, system answer, user
+`replacement_approved` outcome, `user_accepted_fail_closed`, other adjustment
+basis, equal from/to verdict, orphan ref, fork, stale traceability emission, or
+plain difference between Phase 2A and the final row emits nothing. This avoids
+attributing a system Phase 2B adjustment to the user. The current source lacks
+a stable shared action receipt, so `interaction_sha256` is `null`.
+
+The exact public meaning of this event is: **“user adjudication was followed by
+a verified verdict change.”** It must never be described as the user hand-
+setting a verdict. The `g2d_acceptances[].accepted_by == "user"` /
+`user_accepted_fail_closed` path is intentionally excluded: it acknowledges a
+fail-closed `CANNOT_VERIFY` reapplication, and the re-review contract explicitly
+says the user does not hand-set a verdict there. Golden fixtures pin one
+positive `original_upheld -> current reapplication ->
+cross_model_adjudication from != to` chain and one negative
+`g2d_acceptance -> user_accepted_fail_closed` chain.
+
+### 5.4 `explicit_user_request`
+
+The family has one group containing exactly one role,
+`explicit_user_request_log`. It is a closed JSON receipt log with this exact
+logical shape:
+
+```json
+{
+  "schema_version": "adjudication-explicit-user-request-log/1.0",
+  "run_id": "run-42",
+  "records": [
+    {
+      "request_id": "REQUEST-1",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "action": "justify_finding",
+      "stage": "pipeline_stage_3",
+      "finding_id": "REV-001",
+      "interaction_id": "USER-ACTION-17",
+      "interaction_sha256": "<64 lowercase hex>"
+    }
+  ]
+}
+```
+
+The log is an upstream action-time receipt, not a transcript. `run_id` must
+match; record ids are unique; `actor_role` and `source` are constants; the
+closed actions are `justify_finding | redo_finding`; stages use the full closed
+stage enum; ids are bounded to 128 ASCII identifier characters; and the log
+contains at most 4,096 records and no prose.
+
+`justify_finding` maps to `finding_justification_requested` /
+`justification_requested`; `redo_finding` maps to
+`finding_redo_requested` / `redo_requested`. Neither is an overturn merely
+because a user requested explanation or another pass. The exact
+`interaction_sha256` is retained for cross-family causal deduplication.
+
+### 5.5 `mandatory_checkpoint_response`
+
+The family has one group containing exactly one role,
+`mandatory_checkpoint_response_log`. It is a closed JSON receipt log with this
+exact logical shape:
+
+```json
+{
+  "schema_version": "adjudication-mandatory-checkpoint-log/1.0",
+  "run_id": "run-42",
+  "records": [
+    {
+      "response_id": "RESPONSE-1",
+      "checkpoint_id": "stage-4.5-integrity",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_4_5",
+      "disposition": "adjust",
+      "interaction_id": "USER-ACTION-17",
+      "interaction_sha256": "<64 lowercase hex>"
+    }
+  ]
+}
+```
+
+The same closed-log constraints apply. Allowed source dispositions are
+`proceed | skip | pause | adjust | view_progress | redo | abort`. `proceed`
+proves an explicit action but emits no event. `skip` is a refused attempt at a
+MANDATORY checkpoint: it must leave pipeline state unchanged and emits
+`mandatory_checkpoint_non_proceed` with stored disposition `skip_refused`.
+Each of the other five non-proceed choices emits the same event type with its
+source disposition unchanged. Allowed stages are the complete replayable
+pipeline-stage vocabulary, Stage 1 through Stage 6 including half/prime stages.
+This deliberately covers core integrity/review/finalization checkpoints plus
+audit-MINOR, score-regression, and structural-revision MANDATORY handlers at
+Stage 4/4-prime. Non-MANDATORY checkpoint records are invalid, not silently
+counted.
+
+Normalization is owned by the explicit checkpoint handler, never a prose
+parser. Handler branches map as follows: `continue`, `ship_with_known_residue`,
+and `acknowledge_structural_shape` -> `proceed`; `iterate`, `retry`, and
+`another_round` -> `redo`; `narrow`, `expand_exact_scope`, and explicit setting
+changes -> `adjust`; progress/status inspection -> `view_progress`; pause/stop-
+here -> `pause`; abort/terminate/abort-stage -> `abort`; and an attempted skip
+-> `skip`, which is then stored as `skip_refused`. A new handler branch must be
+added to this closed normalization table before it can produce activity.
+
+The orchestrator may create these two receipt-log families only from a
+structured command, UI action, or an explicit event-writing API at the time of
+the user's action. It may not convert unstructured natural-language history
+into a receipt after the fact.
+
+### 5.6 Cross-family causal deduplication
+
+Content hashes are not deduplication keys: two distinct actions may have
+identical text. Deduplication uses only an equal, non-null
+`interaction_sha256` emitted by the action-time source.
+
+Every non-null interaction digest is recomputed, never trusted:
+
+```text
+interaction_sha256 = SHA256(
+  b"ars.adjudication-activity.interaction/1.0\0" +
+  canonical({"run_id": <run_id>, "interaction_id": <interaction_id>})
+)
+```
+
+`interaction_id` is a unique run-scoped occurrence id, not message content.
+For #670 it is the resolved unique `author_event_id`. Compliance, explicit-
+request, and mandatory-checkpoint receipts carry it explicitly; when one user
+action creates more than one receipt, their action-time producer copies the
+same id and derived digest. Re-review stays null when its current chain has no
+provable action-time occurrence id. The store retains only the digest.
+
+The source order in §4 is also precedence order. After all candidate events
+are derived, for each non-null interaction digest the runtime retains every
+per-item event from the earliest family containing that digest and suppresses
+events with that digest from later families. Thus a typed author, compliance,
+re-review, or explicit-request event wins over a generic mandatory-checkpoint
+receipt, while a single interaction that adjudicates several items still keeps
+all of those item events inside the winning family. `null` interaction values
+never deduplicate.
+
+### 5.7 Exact source-event projections and order
+
+The `source_record` input to `source_event_sha256` is closed per family:
+
+- author: `item_id`, `author_event_id`, `author_triage`, the resolved
+  `input_sha256`, and derived `interaction_sha256`;
+- compliance: `artifact_group_id`, mapped stage, sorted blocking-contributor
+  ids, report raw-byte SHA-256, action-receipt raw-byte SHA-256, and
+  `interaction_id` plus `interaction_sha256`;
+- re-review: `round_id`, `dissent_id`, `item_id`, `reapplication_id`,
+  `adjustment_id`, `from_verdict`, `to_verdict`, and traceability raw-byte
+  SHA-256;
+- explicit request: exactly `request_id`, `actor_role`, `source`, `action`,
+  `stage`, `finding_id`, `interaction_id`, and `interaction_sha256`; and
+- mandatory response: exactly `response_id`, `checkpoint_id`,
+  `checkpoint_type`, `actor_role`, `source`, `stage`, the source disposition,
+  `interaction_id`, and `interaction_sha256`.
+
+No rationale or finding text enters a projection. For `skip`, the source
+projection retains source disposition `skip`, while the derived event stores
+the mechanically mapped `skip_refused`.
+
+Candidates are generated in family order, then author-sidecar array order,
+compliance group order, numeric re-review adjustment-id order, explicit-log
+record order, and mandatory-log record order. Causal deduplication preserves
+the relative order of surviving candidates. Append-time extraction computes
+and freezes this order before the sealed run-record digest is written. Offline
+store validation verifies the retained array and its record/event digest
+commitments, but does not claim to reconstruct omitted source records from the
+data-minimized store. A user who deliberately rewrites a local store and
+recomputes every public digest has authored a new self-consistent store; this
+feature provides deterministic consistency, not keyed authenticity. The CLI
+offers no event-reordering or sealed-run update operation, and event order does
+not affect run-window selection or either count.
+
+## 6. Closed event and count semantics
+
+The store's seven event types and exact dispositions are:
+
+| Event type | Exact disposition(s) | Counts as adjudication | Counts as overturn |
+|---|---|---:|---:|
+| `author_triage_wont_address` | `wont_address` | yes | no |
+| `author_triage_not_on_point` | `not_on_point` | yes | yes |
+| `compliance_block_override` | `block_overridden` | yes | yes |
+| `re_review_verdict_changed` | `verdict_changed` | yes | yes |
+| `finding_justification_requested` | `justification_requested` | yes | no |
+| `finding_redo_requested` | `redo_requested` | yes | no |
+| `mandatory_checkpoint_non_proceed` | `skip_refused | pause | adjust | view_progress | redo | abort` | yes | no |
+
+`adjudication_count` is the number of retained derived events in the selected
+runs. `overturn_count` is recomputed as the number whose `event_type` is in the
+exact set:
+
+```text
+author_triage_not_on_point
+compliance_block_override
+re_review_verdict_changed
+```
+
+Neither count is stored. No caller supplies an overturn boolean. A declined
+action, request for justification, redo request, or decision not to proceed is
+observable adjudication, but it does not assert that an underlying finding or
+verdict was overturned.
+
+An unavailable source contributes no fabricated event and does not mean zero.
+For that reason all displayed event totals are labelled as recorded activity,
+and `unavailable_run_count` is also shown.
+
+## 7. Store, identity, canonical bytes, and caps
+
+The closed store root is:
+
+```json
+{
+  "schema_version": "adjudication-activity-store/1.0",
+  "store_id": "ADJ-ACTIVITY-STORE-example",
+  "revision": 1,
+  "next_sequence": 2,
+  "runs": ["<sealed run records>"],
+  "data_minimization": {
+    "raw_prose_embedded": false,
+    "user_identity_embedded": false,
+    "absolute_paths_embedded": false
+  }
+}
+```
+
+An initialized empty store is `revision=0`, `next_sequence=1`, `runs=[]`.
+Every successful append or explicit delete rewrite increments `revision` by
+exactly one. Append assigns the current `next_sequence`, then increments it.
+Deletion never decrements it. Surviving sequences are strictly increasing,
+unique, never renumbered, and never reused. Deleting every run may therefore
+leave an empty store with a positive revision and `next_sequence > 1`.
+Because each allocated sequence came from one earlier append and deletions add
+revisions without allocating sequences, every valid store also satisfies
+`revision >= next_sequence - 1`.
+
+Each run is sealed and contains only:
+
+- `append_sequence`, `run_id`, `terminal_state`, and `terminal_stage`;
+- exact terminal- and input-receipt hashes;
+- `sealed: true` and a run-record hash; and
+- the five source rows, which retain capture state, reason, canonical artifact
+  hashes, and minimal derived events. Artifact ids and paths are not retained.
+
+Each minimal event contains exactly `event_id`, `event_type`, `stage`,
+`disposition`, nullable `interaction_sha256`, and `source_event_sha256`. It
+contains no finding text, rationale, response text, user identity, agent name,
+model id, timestamp, path, score, or aggregate.
+
+### 7.1 Restricted canonical JSON
+
+Contract digests use the following restricted JCS-compatible encoding; no
+broader canonicalization behavior is implied:
+
+- permitted scalar types are string, integer, boolean, and null; floats and
+  non-finite values are forbidden;
+- duplicate object keys are rejected during parsing;
+- contract keys are ASCII and sort by ascending code point;
+- arrays preserve contract-defined order;
+- encoding uses compact separators, `ensure_ascii=false`, UTF-8, and no BOM;
+  and
+- canonical digest bytes have no trailing newline. Persisted store bytes are
+  those canonical bytes followed by exactly one LF; the LF is excluded from
+  contract digests but included in raw-file confirmation hashes.
+
+The exact domain separators and preimages are:
+
+```text
+input_receipt_sha256 = SHA256(
+  b"ars.adjudication-activity.input/1.0\0" + canonical(input_manifest)
+)
+
+source_event_sha256 = SHA256(
+  b"ars.adjudication-activity.source-event/1.0\0" +
+  canonical({"source_family": <family>, "source_record": <exact projection>})
+)
+
+event_digest = SHA256(
+  b"ars.adjudication-activity.event-id/1.0\0" +
+  canonical({
+    "run_id": <run_id>,
+    "source_family": <family>,
+    "event_type": <type>,
+    "stage": <stage>,
+    "disposition": <disposition>,
+    "interaction_sha256": <sha-or-null>,
+    "source_event_sha256": <sha>
+  })
+)
+event_id = "ACTIVITY-EVENT-" + lowercase_hex(event_digest)
+
+record_sha256 = SHA256(
+  b"ars.adjudication-activity.run/1.0\0" +
+  canonical(<complete run record with only record_sha256 omitted>)
+)
+```
+
+The family-specific `source_record` is exactly the closed record that caused
+the event plus its stable parent identifiers needed to disambiguate it; it
+excludes prose not needed by the predicate. The extraction implementation must
+freeze those projections as named pure functions and mutation-test every
+included field. Raw artifact bindings use ordinary SHA-256 over exact file
+bytes, not this canonical form.
+
+### 7.2 Identity and duplicate policy
+
+Within retained records, `run_id`, `append_sequence`, `input_receipt_sha256`,
+`record_sha256`, and `event_id` are each unique where applicable. Re-appending
+the same `run_id` with the same `input_receipt_sha256` is an idempotent success:
+while holding the exclusive lock, runtime validates the retained sealed record,
+emits the exact `already_appended` line in §8, and performs no write, revision
+increment, sequence allocation, or metadata-time change. The same `run_id` with
+a different input receipt, or the same input receipt under a different run id,
+fails with `CONFLICT`; append never updates or merges an existing run. A
+successful explicit deletion removes the selected record completely and
+deliberately removes its deduplication memory. A later new append may reuse that
+run id only because the user explicitly deleted the prior record; it receives a
+fresh, higher append sequence.
+
+### 7.3 Hard caps
+
+The runtime fails closed before mutation at all of these limits:
+
+- input manifest: 1 MiB raw bytes;
+- one referenced artifact: 8 MiB raw bytes;
+- all referenced artifacts for one run: 64 MiB raw bytes;
+- artifacts per source family: 64;
+- source-log records and derived events: at most 4,096 per run;
+- derived events: at most 100,000 per store;
+- retained runs: at most 10,000; and
+- persisted store: at most 16 MiB, including its final LF.
+
+Reaching a cap never evicts, truncates, summarizes, or rewrites an older run.
+The append fails without changing the store; the user may explicitly select a
+new store or delete records.
+
+## 8. CLI and exact success output
+
+The only commands are:
+
+```text
+python scripts/adjudication_activity.py init-store \
+  --store <file> --store-id <id>
+
+python scripts/adjudication_activity.py build-input \
+  --state <pipeline-state.json> --artifact-root <dir> \
+  --store-id <id> --output <manifest.json>
+
+python scripts/adjudication_activity.py append-run \
+  --store <file> --artifact-root <dir> --input <manifest.json>
+
+python scripts/adjudication_activity.py render \
+  --store <file> [--window <2..50>]
+
+python scripts/adjudication_activity.py validate --store <file>
+
+python scripts/adjudication_activity.py delete-runs \
+  --store <file> --store-id <id> --expect-store-sha256 <raw-byte-sha> \
+  (--run-id <id> [--run-id <id> ...] | --sequence-range <first>:<last>)
+
+python scripts/adjudication_activity.py delete-store \
+  --store <file> --store-id <id> --expect-store-sha256 <raw-byte-sha> \
+  --confirm DELETE-ADJUDICATION-ACTIVITY-STORE
+```
+
+Every path-bearing operation requires its path explicitly. `init-store` creates
+only a missing path as the canonical empty store; an existing path is a
+`CONFLICT`, even when its bytes are identical. `build-input` accepts no source
+rows, paths, hashes, events, or counts from the caller. It strictly replays the
+explicit state path, requires stable `run_id` plus a sealed five-row
+`adjudication_activity_sources` inventory, copies only that exact projection,
+binds the raw state bytes as `terminal_receipt`, validates every projected
+artifact beneath the explicit artifact root, and atomically creates only the
+explicit output path. An existing output path is a `CONFLICT` and no ambient
+scan or reconstruction is permitted. `append-run` creates a missing store using
+the input `store_id`; it never creates a store after a validation or extraction
+failure. An existing store id must equal the input id. `validate` verifies
+schema, canonical bytes, caps, run digests, ordering, uniqueness, terminal
+invariants, source/event family constraints, cross-family causal uniqueness,
+`revision`, and `next_sequence`.
+
+`delete-runs` accepts exactly one selection mode. The id set is non-empty and
+duplicate-free. A sequence range is inclusive with `first <= last`. Every
+selected id must exist; a range must select at least one retained record. The
+command requires both the exact store id and SHA-256 of the current raw store
+file, then deletes whole records, increments revision once, preserves
+`next_sequence`, writes no tombstone or aggregate, and reports:
+
+```text
+[ARS-ADJUDICATION-ACTIVITY] deleted_runs=<k>; revision=<r>; next_sequence=<s>
+```
+
+`delete-store` takes the same raw-byte hash plus the exact confirmation token.
+For a valid store it also verifies `store_id`. If parsing or validation fails,
+whole-store deletion remains the sole recovery path: exact path, exact current
+raw-byte hash, and exact token are sufficient; no field is trusted from corrupt
+JSON. It unlinks only that regular store file and emits:
+
+```text
+[ARS-ADJUDICATION-ACTIVITY] deleted_store=true
+```
+
+Successful initialization, input construction, append, idempotent append, and
+validation emit exactly:
+
+```text
+[ARS-ADJUDICATION-ACTIVITY] initialized store_id=<json-string>; revision=0; next_sequence=1
+[ARS-ADJUDICATION-ACTIVITY] built_input run_id=<json-string>; source_count=5
+[ARS-ADJUDICATION-ACTIVITY] appended run_id=<json-string>; append_sequence=<n>; revision=<r>
+[ARS-ADJUDICATION-ACTIVITY] already_appended run_id=<json-string>; append_sequence=<n>; revision=<r>
+[ARS-ADJUDICATION-ACTIVITY] valid store_id=<json-string>; retained_runs=<n>; revision=<r>; next_sequence=<s>
+```
+
+JSON string quoting is used for ids so control characters can never forge a
+line. Success exits `0`. Errors emit one stderr line and no stdout:
+
+```text
+[ARS-ADJUDICATION-ACTIVITY ERROR:<CODE>] <bounded detail>
+```
+
+The closed exit mapping is:
+
+| Exit | Codes | Meaning |
+|---:|---|---|
+| 2 | `USAGE` | argument grammar, command, or window error |
+| 3 | `PATH`, `INPUT`, `SOURCE` | unsafe path or invalid input/source artifact |
+| 4 | `STORE` | missing, non-canonical, schema-invalid, digest-invalid, or corrupt store |
+| 5 | `CONFLICT`, `CAP` | conflicting identity/path or hard-cap refusal |
+| 6 | `DELETE_CONFIRMATION` | store id, raw hash, target set, range, or confirmation mismatch |
+| 7 | `LOCK`, `WRITE` | lock contention/unsupported locking or atomic I/O failure |
+
+Details are capped at 500 Unicode scalar values and never include artifact
+content, user prose, or an absolute path.
+
+## 9. Exact renderer
+
+For zero or one selected run, the first line is exactly:
+
+```text
+[ARS-ADJUDICATION-ACTIVITY INSUFFICIENT_HISTORY] selected_retained_eligible_run_count=<n>; minimum_required=2; requested_window=<N>.
+```
+
+For two or more, the first line is exactly:
+
+```text
+[ARS-ADJUDICATION-ACTIVITY] selected_retained_eligible_run_count=<n>; requested_window=<N>; adjudication_count=<k> (denominator: <n> retained eligible terminal run records); overturn_count=<j> (denominator: <k> recorded adjudications); unavailable_run_count=<u> (denominator: <n> retained eligible terminal run records).
+```
+
+The insufficient-history form follows its first line with the same three count
+clauses, beginning `[ARS-ADJUDICATION-ACTIVITY COUNTS]`. This makes zero/one-run
+output honest without turning insufficient data into a pass.
+
+Next, one line per selected run appears in ascending append-sequence order:
+
+```text
+sequence=<s>; run_id=<json-string>; terminal_state=<state>; adjudication_count=<k> (denominator: 1 retained eligible terminal run record); overturn_count=<j> (denominator: <k> recorded adjudications); unavailable_source_count=<u> (denominator: 5 source families).
+```
+
+Next this exact coverage line appears:
+
+```text
+Coverage: only successfully retained records in this explicitly selected store are shown; runs without this store selection or whose append failed are not represented.
+```
+
+Finally the exact two sentences in §1 appear, each on its own line. There is no
+percentage. When `<k>` is zero, `overturn_count=0 (denominator: 0 recorded
+adjudications)` remains literal rather than fabricating a rate. A run is in
+`unavailable_run_count` iff at least one of its five source rows is
+`unavailable`; `not_applicable` and captured-zero are distinct and visible in
+the per-run unavailable-source denominator.
+
+## 10. Locking, atomicity, and corruption
+
+All operations first reject a store path that is a directory, symlink, FIFO,
+device, socket, or multiply-linked regular file. A zero-byte adjacent
+`<store>.lock` is coordination metadata only: it contains no id, count, digest,
+or activity and is not a derived aggregate. Reads take a shared advisory lock;
+append and deletion take an exclusive lock. Lock acquisition is one
+non-blocking attempt, so the runtime uses no timeout clock. Unsupported locking
+or contention fails without reading a mutable snapshot.
+
+A writer performs, while holding the lock:
+
+1. open and validate the current store from one file descriptor;
+2. derive the complete candidate in memory and validate it again;
+3. enforce every cap before writing;
+4. create a mode-`0600` temporary regular file in the same directory;
+5. write canonical bytes plus one LF, flush, and `fsync` it;
+6. atomically `replace` the selected store path; and
+7. `fsync` the parent directory before reporting success.
+
+Any failure before step 6 leaves the old bytes untouched. A fault at or after
+replace is reported as `WRITE`; tests reopen the path and accept only the full
+old or full new canonical store, never a partial hybrid. No backup, journal,
+cache, summary, tombstone, or alternate store is left behind.
+
+Parsing rejects invalid UTF-8, BOM, duplicate keys, floats/non-finite values,
+trailing data, schema drift, non-canonical persisted bytes, digest mismatch,
+wrong source order, wrong event family/stage/disposition, duplicate identity,
+bad revision/sequence relationships, and cap overflow. `append-run`, `render`,
+`validate`, and `delete-runs` all fail closed on corruption. Only the raw-byte,
+confirmation-bound `delete-store` recovery in §8 may operate on a corrupt
+store.
+
+## 11. Integration and data minimization
+
+For every author choice, compliance override, explicit request, and checkpoint
+response, the existing handler first derives and durably applies its ordinary
+routing/state effect. Only then does it best-effort write the closed activity
+receipt and pending inventory binding. Receipt failure cannot refuse, roll
+back, or change proceed, pause, adjust, view-progress, redo, abort, or a valid
+compliance override. For `skip`, the existing MANDATORY refusal and unchanged
+pipeline state are derived first; `skip_refused` is only an after-the-fact
+receipt of that result.
+
+The terminal integration order is fixed:
+
+1. make and durably persist the existing terminal state transition, without
+   consulting activity state;
+2. if and only if a store was selected, best-effort seal the exact five-source
+   inventory in post-terminal metadata;
+3. deterministically `build-input` from that sealed state, without scanning;
+4. invoke idempotent `append-run`;
+5. optionally invoke `render`; and
+6. surface any step-2-through-5 failure as an advisory diagnostic while
+   preserving the already-durable terminal outcome.
+
+The store path, store contents, renderer output, and failure state are never
+copied into the Material Passport, handoff schemas, Process Record, reviewer
+input, collaboration-depth observer, compliance decision, or model request.
+No network, model, judge, external API, ambient clock, directory scan, glob, or
+filesystem metadata time participates in extraction, ordering, counting, or
+tests.
+
+Source prose is used only transiently when a current canonical validator must
+verify its artifact. Only the minimal event projection and digests enter the
+store. The runtime must not log raw rationale, finding text, checkpoint answer,
+artifact content, user identity, or an absolute path on success or failure.
+
+## 12. Required P1 kill mutations
+
+The focused suite must prove each mutation below fails or, for renderer/control
+plane cases, cannot affect the forbidden consumer:
+
+1. add caller-supplied `events`, counts, rates, score, threshold, or overturn
+   boolean to the input;
+2. accept a running/paused state, a mismatched terminal receipt, completed
+   before Stage 6, or an aborted run whose stage does not replay;
+3. omit, duplicate, or reorder a source family; turn unavailable into zero;
+   exclude captured-zero or unavailable runs from the window denominator;
+4. accept an absolute/traversing/symlink/non-regular artifact or a wrong raw
+   hash; accept a missing, duplicate, extra, swapped, free-named, or
+   cross-group artifact role;
+5. extract #670 activity from a Schema 11 copy, count `will_address`, count each
+   target/reason, classify `wont_address` as an overturn, or accept an author
+   stage outside Stage 3/3-prime; spoof `artifact_group_stage`, fail to bind it
+   into the input digest, or omit the matching completed stage in the terminal
+   receipt;
+6. count one compliance scope element as one event; count a PASS/WARN report,
+   `user_action_required=false`, an unpaired/fake action receipt, a scope that
+   is not exactly the recomputed blocking-contributor set, or accept a broken
+   per-stage friction ladder;
+7. count a Phase 2B/system adjustment, `user_accepted_fail_closed`,
+   `replacement_approved`, stale/superseded reapplication, equal from/to
+   verdict, forked adjustment chain, or orphan re-review ref;
+8. infer justify/redo/non-proceed from conversation, accept a non-user receipt,
+   count `proceed`, accept a non-MANDATORY checkpoint, silently allow a
+   MANDATORY `skip`, store it as anything but `skip_refused`, or let the refused
+   skip change pipeline state;
+9. deduplicate by content, let a later generic family beat an earlier typed
+   family, discard sibling per-item events in the winning family, or deduplicate
+   null interaction digests; trust a supplied interaction hash, or use
+   `input_sha256` instead of the run/id occurrence digest;
+10. store or accept any event type/disposition/stage outside the closed matrix,
+    or derive `overturn_count` from any set other than the three exact types;
+11. order the window by time/name/id, use a default other than 10, admit a bound
+    outside 2..50, renumber a deletion gap, reuse a sequence, or auto-evict;
+12. mutate/upsert a sealed run through the CLI, accept a sealed run whose
+    retained record/event digests are stale, write or bump revision for an
+    identical retained run/input retry, accept the same run id with a different
+    input receipt or the same input receipt under a different run id, truncate
+    at a cap, or leave a partial store after injected write failure;
+13. render, append, or range-delete a corrupt store; delete with a wrong id,
+    raw hash, token, id set, or range; or leave a tombstone/aggregate;
+14. omit or paraphrase either exact §1 sentence; render pass, health, score,
+    benchmark, rate, target, threshold, diagnosis, or attention/ownership claim;
+15. read the store from a gate, checkpoint selector, decision, verdict,
+    terminal transition, model prompt, or dispatch; or let recorder failure
+    affect terminal state; and
+16. add a legacy migration, backfill scan, default store path, clock, network,
+    model, judge, API, directory walk, or glob.
+
+## 13. Required P2 boundary mutations
+
+Boundary coverage includes:
+
+- duplicate JSON keys, invalid UTF-8/BOM, non-finite/float values, trailing
+  data, non-canonical object order, and a contract digest that wrongly includes
+  the persisted LF;
+- all exact maximums and maximum-plus-one cases for bytes, artifacts, records,
+  events, runs, store events, store size, ids, refs, and error detail;
+- empty store, one run, exactly two runs, fewer-than-window, exactly 10, exactly
+  50, window 1, and window 51;
+- completed Stage 6 `completed`, completed Stage 6 `skipped`, and an aborted run
+  at every closed stage including `pipeline_stage_4_prime`;
+- five captured-zero sources, five unavailable sources, a mix of captured,
+  not-applicable, and unavailable, and one unavailable source in an otherwise
+  captured run;
+- two identical author-input strings with distinct `author_event_id` occurrence
+  ids and therefore distinct interaction hashes, the same non-null interaction
+  in two families, multiple per-item events for one winning-family interaction,
+  and null interaction hashes;
+- first append, append after sequence gaps, delete one id, delete several ids,
+  inclusive range endpoints, delete all retained runs, raw-hash race, lock
+  contention, and corrupt whole-store recovery; and
+- deterministic output and digests under a changed locale, timezone, file
+  mtime, directory enumeration order, and unavailable network.
+
+## 14. Acceptance
+
+#673 is accepted only when all of the following are green without a live model,
+judge, network, API, filesystem scan, or clock dependency:
+
+1. both schemas are Draft 2020-12 valid and closed;
+2. input fixtures cover all three capture states and all five source families;
+3. source fixtures produce all seven event types, captured-zero, unavailable,
+   and the exact re-review chain;
+4. event ids and all three contract digest families match independent golden
+   vectors;
+5. count tests distinguish `adjudication_count` and `overturn_count` exactly;
+6. window persistence covers completed, aborted, zero-event, unavailable, and
+   deletion-gap runs across process invocations;
+7. immutable append, idempotent exact retry, conflicting duplicate refusal,
+   locking, atomic fault injection, corruption fail-closed behavior, range
+   deletion, and corrupt whole-store deletion pass;
+8. renderer golden tests pin every character of insufficient-history, summary,
+   per-run denominators, and the two exact limitation/advisory sentences;
+9. static non-interference tests prove no gate, decision, verdict, checkpoint
+   type, terminal transition, model dispatch, passport, handoff, or Process
+   Record consumes the store or its aggregates;
+10. every P1 kill mutation in §12 fails for the intended reason and the P2
+    boundaries in §13 are exercised; and
+11. ordinary repository schema, spec-consistency, lint, and full pytest suites
+    remain green.
+
+This acceptance is prospective protocol validation only. It authorizes no
+historical reconstruction and requires no engagement, quality, or performance
+claim.

--- a/scripts/_ci_pytest_manifest.toml
+++ b/scripts/_ci_pytest_manifest.toml
@@ -445,6 +445,14 @@ id = "672-cross-document-consistency-integration"
 path = "scripts/test_check_cross_document_consistency_advisory_integration.py"
 
 [[pytest]]
+id = "673-adjudication-activity-runtime"
+path = "scripts/test_adjudication_activity.py"
+
+[[pytest]]
+id = "673-adjudication-activity-integration"
+path = "scripts/test_check_673_adjudication_activity.py"
+
+[[pytest]]
 id = "680-human-subjects-reference-migration"
 path = "scripts/test_check_human_subjects_reference_migration.py"
 

--- a/scripts/adjudication_activity.py
+++ b/scripts/adjudication_activity.py
@@ -1,0 +1,1592 @@
+#!/usr/bin/env python3
+"""Deterministic, advisory-only cross-run adjudication activity recorder.
+
+The runtime intentionally has no default paths, clock, network, model, judge,
+directory scan, or environment-variable inputs.  All authority comes from an
+explicit terminal state, its sealed five-family inventory, and hash-bound
+artifacts beneath an explicit artifact root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterator, Sequence
+
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INPUT_SCHEMA_PATH = REPO_ROOT / "shared/contracts/activity/adjudication_activity_input.schema.json"
+STORE_SCHEMA_PATH = REPO_ROOT / "shared/contracts/activity/adjudication_activity_store.schema.json"
+COMPLIANCE_SCHEMA_PATH = REPO_ROOT / "shared/compliance_report.schema.json"
+REVISION_CONTRACTS = REPO_ROOT / "shared/contracts/revision"
+REREVIEW_CONTRACTS = REPO_ROOT / "shared/contracts/re_review"
+
+INPUT_VERSION = "adjudication-activity-input/1.0"
+STORE_VERSION = "adjudication-activity-store/1.0"
+SOURCE_FAMILIES = (
+    "revision_author_adjudication",
+    "compliance_report",
+    "re_review_traceability",
+    "explicit_user_request",
+    "mandatory_checkpoint_response",
+)
+STAGES = (
+    "pipeline_stage_1", "pipeline_stage_2", "pipeline_stage_2_5",
+    "pipeline_stage_3", "pipeline_stage_3_prime", "pipeline_stage_4",
+    "pipeline_stage_4_prime", "pipeline_stage_4_5", "pipeline_stage_5",
+    "pipeline_stage_6",
+)
+RAW_TO_STAGE = {
+    "1": STAGES[0], "2": STAGES[1], "2.5": STAGES[2], "3": STAGES[3],
+    "3p": STAGES[4], "4": STAGES[5], "4p": STAGES[6], "4.5": STAGES[7],
+    "5": STAGES[8], "6": STAGES[9],
+}
+STAGE_TO_RAW = {value: key for key, value in RAW_TO_STAGE.items()}
+STATUS_VALUES = {"pending", "in_progress", "completed", "skipped", "blocked"}
+REASON_UNAVAILABLE = {
+    "source_not_provided", "source_unreadable", "source_invalid",
+    "capture_not_supported",
+}
+ROLE_ORDER = {
+    "revision_author_adjudication": ("author_adjudication_input", "author_adjudication"),
+    "compliance_report": ("compliance_report", "compliance_override_action_receipt"),
+    "re_review_traceability": ("input_manifest", "precommitment", "verdict_record", "traceability"),
+    "explicit_user_request": ("explicit_user_request_log",),
+    "mandatory_checkpoint_response": ("mandatory_checkpoint_response_log",),
+}
+OVERTURN_TYPES = {
+    "author_triage_not_on_point", "compliance_block_override",
+    "re_review_verdict_changed",
+}
+MAX_INPUT = 1 << 20
+MAX_ARTIFACT = 8 << 20
+MAX_ARTIFACT_TOTAL = 64 << 20
+MAX_STORE = 16 << 20
+MAX_EVENTS_RUN = 4096
+MAX_EVENTS_STORE = 100000
+MAX_RUNS = 10000
+LIMITATION = "This records explicit adjudication activity only. It cannot determine correctness, attentiveness, engagement, or whether human ownership is real; genuine agreement and non-review can produce the same history."
+ADVISORY = "This series is advisory only; it never gates, blocks, scores, or changes any verdict."
+COVERAGE = "Coverage: only successfully retained records in this explicitly selected store are shown; runs without this store selection or whose append failed are not represented."
+DATA_MINIMIZATION = {
+    "raw_prose_embedded": False,
+    "user_identity_embedded": False,
+    "absolute_paths_embedded": False,
+}
+HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+GROUP_RE = re.compile(r"^SOURCE-GROUP-[A-Za-z0-9][A-Za-z0-9._-]{0,95}$")
+
+
+class ActivityError(Exception):
+    """Bounded public failure with a closed CLI error code."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail[:500]
+
+
+EXIT_BY_CODE = {
+    "USAGE": 2, "PATH": 3, "INPUT": 3, "SOURCE": 3, "STORE": 4,
+    "CONFLICT": 5, "CAP": 5, "DELETE_CONFIRMATION": 6,
+    "LOCK": 7, "WRITE": 7,
+}
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate object key")
+        result[key] = value
+    return result
+
+
+def _reject_number(token: str) -> None:
+    raise ValueError(f"forbidden JSON number {token}")
+
+
+def strict_json(raw: bytes, *, code: str) -> Any:
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raise ActivityError(code, "UTF-8 BOM is forbidden")
+    try:
+        value = json.loads(
+            raw.decode("utf-8"), object_pairs_hook=_pairs,
+            parse_float=_reject_number, parse_constant=_reject_number,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ActivityError(code, f"invalid strict JSON: {exc.__class__.__name__}") from None
+    _canonical_domain(value, code=code)
+    return value
+
+
+def _canonical_domain(value: Any, *, code: str, depth: int = 0) -> None:
+    if depth > 256:
+        raise ActivityError(code, "JSON nesting exceeds contract bound")
+    if isinstance(value, str):
+        if any(0xD800 <= ord(char) <= 0xDFFF for char in value):
+            raise ActivityError(code, "lone UTF-16 surrogate is forbidden")
+        return
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, int) and not isinstance(value, bool):
+        return
+    if isinstance(value, list):
+        for child in value:
+            _canonical_domain(child, code=code, depth=depth + 1)
+        return
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str) or not key.isascii():
+                raise ActivityError(code, "contract object keys must be ASCII")
+            _canonical_domain(child, code=code, depth=depth + 1)
+        return
+    raise ActivityError(code, "floats and non-contract JSON values are forbidden")
+
+
+def canonical_bytes(value: Any, *, code: str = "INPUT") -> bytes:
+    _canonical_domain(value, code=code)
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(domain: bytes, value: Any) -> str:
+    return hashlib.sha256(domain + canonical_bytes(value)).hexdigest()
+
+
+def interaction_sha256(run_id: str, interaction_id: str) -> str:
+    return _digest(
+        b"ars.adjudication-activity.interaction/1.0\0",
+        {"run_id": run_id, "interaction_id": interaction_id},
+    )
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    value = strict_json(path.read_bytes(), code="SOURCE")
+    if not isinstance(value, dict):
+        raise ActivityError("SOURCE", "schema root is not an object")
+    return value
+
+
+def _validator(path: Path, *, revision_registry: bool = False) -> Draft202012Validator:
+    schema = _load_schema(path)
+    registry = Registry()
+    if revision_registry:
+        for candidate_path in (
+            REVISION_CONTRACTS / "author_adjudication.schema.json",
+            REVISION_CONTRACTS / "author_adjudication_input.schema.json",
+        ):
+            candidate = _load_schema(candidate_path)
+            if "$id" in candidate:
+                registry = registry.with_resource(candidate["$id"], Resource.from_contents(candidate))
+    return Draft202012Validator(schema, registry=registry, format_checker=FormatChecker())
+
+
+def _schema_validate(value: Any, path: Path, *, code: str, revision_registry: bool = False) -> None:
+    errors = sorted(
+        _validator(path, revision_registry=revision_registry).iter_errors(value),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if errors:
+        raise ActivityError(code, f"schema validation failed at {list(errors[0].absolute_path)!r}")
+
+
+def _read_limited_identity(path: Path, limit: int, *, code: str) -> tuple[bytes, tuple[int, int, int]]:
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+                raise ActivityError("PATH", "selected path is not a single-linked regular file")
+            identity = (info.st_dev, info.st_ino, info.st_size)
+            if info.st_size > limit:
+                raise ActivityError("CAP", "file exceeds hard byte cap")
+            chunks: list[bytes] = []
+            size = 0
+            while True:
+                chunk = os.read(fd, min(1024 * 1024, limit + 1 - size))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                size += len(chunk)
+                if size > limit:
+                    raise ActivityError("CAP", "file exceeds hard byte cap")
+            after = os.fstat(fd)
+            if (after.st_dev, after.st_ino, after.st_size) != identity or size != info.st_size:
+                raise ActivityError(code, "file changed while being read")
+            return b"".join(chunks), identity
+        finally:
+            os.close(fd)
+    except ActivityError:
+        raise
+    except OSError as exc:
+        raise ActivityError(code, f"file read failed: {exc.__class__.__name__}") from None
+
+
+def _read_limited(path: Path, limit: int, *, code: str) -> bytes:
+    return _read_limited_identity(path, limit, code=code)[0]
+
+
+def _path_identity(path: Path) -> tuple[int, int, int]:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ActivityError("WRITE", f"target identity check failed: {exc.__class__.__name__}") from None
+    return info.st_dev, info.st_ino, info.st_size
+
+
+def _assert_identity(path: Path, expected: tuple[int, int, int]) -> None:
+    if _path_identity(path) != expected:
+        raise ActivityError("CONFLICT", "target changed after validated read")
+
+
+def _relative_binding(root: Path, path: Path) -> str:
+    try:
+        root_real = root.resolve(strict=True)
+        path_real = path.resolve(strict=True)
+        relative = path_real.relative_to(root_real).as_posix()
+    except (OSError, ValueError):
+        raise ActivityError("PATH", "path is not contained beneath artifact root") from None
+    _safe_relative(root, relative)
+    return relative
+
+
+def _safe_relative(root: Path, relative: str) -> Path:
+    if not isinstance(relative, str) or not relative or len(relative) > 512:
+        raise ActivityError("PATH", "invalid relative artifact path")
+    pure = PurePosixPath(relative)
+    if pure.is_absolute() or "\\" in relative or relative.endswith("/"):
+        raise ActivityError("PATH", "unsafe relative artifact path")
+    if re.match(r"^[A-Za-z]:/", relative) or any(part in {"", ".", ".."} for part in pure.parts):
+        raise ActivityError("PATH", "unsafe relative artifact path")
+    if any(ord(char) < 32 or ord(char) == 127 for char in relative):
+        raise ActivityError("PATH", "unsafe relative artifact path")
+    try:
+        root_info = root.lstat()
+        if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
+            raise ActivityError("PATH", "artifact root must be a non-symlink directory")
+        cursor = root
+        for part in pure.parts:
+            cursor = cursor / part
+            info = cursor.lstat()
+            if stat.S_ISLNK(info.st_mode):
+                raise ActivityError("PATH", "symlink artifact path is forbidden")
+        resolved = cursor.resolve(strict=True)
+        resolved.relative_to(root.resolve(strict=True))
+        if not stat.S_ISREG(cursor.stat().st_mode):
+            raise ActivityError("PATH", "artifact must be a regular file")
+        return cursor
+    except ActivityError:
+        raise
+    except (OSError, ValueError):
+        raise ActivityError("PATH", "artifact path cannot be safely resolved") from None
+
+
+def _read_artifact_relative(root: Path, relative: str, limit: int) -> bytes:
+    """Descriptor-relative no-follow traversal prevents parent-component swaps."""
+    if not isinstance(relative, str) or not relative or len(relative) > 512:
+        raise ActivityError("PATH", "invalid relative artifact path")
+    pure = PurePosixPath(relative)
+    if (
+        pure.is_absolute() or "\\" in relative or relative.endswith("/")
+        or re.match(r"^[A-Za-z]:/", relative)
+        or any(part in {"", ".", ".."} for part in pure.parts)
+        or any(ord(char) < 32 or ord(char) == 127 for char in relative)
+    ):
+        raise ActivityError("PATH", "unsafe relative artifact path")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    opened: list[int] = []
+    try:
+        directory_fd = os.open(root, directory_flags)
+        opened.append(directory_fd)
+        for part in pure.parts[:-1]:
+            directory_fd = os.open(part, directory_flags, dir_fd=directory_fd)
+            opened.append(directory_fd)
+        fd = os.open(
+            pure.parts[-1], os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory_fd,
+        )
+        opened.append(fd)
+        info = os.fstat(fd)
+        identity = (info.st_dev, info.st_ino, info.st_size)
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise ActivityError("PATH", "artifact must be a single-linked regular file")
+        if info.st_size > limit:
+            raise ActivityError("CAP", "artifact exceeds hard byte cap")
+        chunks: list[bytes] = []
+        size = 0
+        while True:
+            chunk = os.read(fd, min(1024 * 1024, limit + 1 - size))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            size += len(chunk)
+            if size > limit:
+                raise ActivityError("CAP", "artifact exceeds hard byte cap")
+        after = os.fstat(fd)
+        if (after.st_dev, after.st_ino, after.st_size) != identity or size != info.st_size:
+            raise ActivityError("SOURCE", "artifact changed while being read")
+        return b"".join(chunks)
+    except ActivityError:
+        raise
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise ActivityError("PATH", "symlink artifact path is forbidden") from None
+        raise ActivityError("PATH", f"artifact traversal failed: {exc.__class__.__name__}") from None
+    finally:
+        for opened_fd in reversed(opened):
+            os.close(opened_fd)
+
+
+@contextmanager
+def _store_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
+    lock_path = path.with_name(path.name + ".lock")
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or info.st_size != 0:
+            raise ActivityError("LOCK", "lock metadata is not an empty single-linked regular file")
+        operation = (fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH) | fcntl.LOCK_NB
+        fcntl.flock(fd, operation)
+    except ActivityError:
+        if "fd" in locals():
+            os.close(fd)
+        raise
+    except OSError as exc:
+        if "fd" in locals():
+            os.close(fd)
+        raise ActivityError("LOCK", f"lock acquisition failed: {exc.__class__.__name__}") from None
+    try:
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _write_all(fd: int, raw: bytes) -> None:
+    view = memoryview(raw)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("write made no progress")
+        view = view[written:]
+
+
+def _atomic_replace(path: Path, raw: bytes, *, expected_identity: tuple[int, int, int] | None = None) -> None:
+    path.parent.mkdir(parents=False, exist_ok=True)
+    temporary: str | None = None
+    try:
+        fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        try:
+            os.fchmod(fd, 0o600)
+            _write_all(fd, raw)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        if os.stat(temporary).st_size != len(raw):
+            raise OSError("temporary file size mismatch")
+        if expected_identity is not None:
+            _assert_identity(path, expected_identity)
+        os.replace(temporary, path)
+        temporary = None
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError as exc:
+        raise ActivityError("WRITE", f"atomic write failed: {exc.__class__.__name__}") from None
+    finally:
+        if temporary is not None:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+
+
+def _atomic_create(path: Path, raw: bytes) -> None:
+    if path.exists() or path.is_symlink():
+        raise ActivityError("CONFLICT", "output path already exists")
+    temporary: str | None = None
+    try:
+        fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        try:
+            os.fchmod(fd, 0o600)
+            _write_all(fd, raw)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        if os.stat(temporary).st_size != len(raw):
+            raise OSError("temporary file size mismatch")
+        os.link(temporary, path)
+        os.unlink(temporary)
+        temporary = None
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except FileExistsError:
+        raise ActivityError("CONFLICT", "output path already exists") from None
+    except OSError as exc:
+        raise ActivityError("WRITE", f"atomic create failed: {exc.__class__.__name__}") from None
+    finally:
+        if temporary:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+
+
+def _state_replay(state: dict[str, Any]) -> tuple[str, str, str, str]:
+    if not isinstance(state, dict) or not ID_RE.fullmatch(str(state.get("run_id", ""))):
+        raise ActivityError("INPUT", "terminal state lacks a valid stable run_id")
+    pipeline_state = state.get("pipeline_state")
+    if pipeline_state not in {"completed", "aborted"}:
+        raise ActivityError("INPUT", "pipeline state is not eligible terminal state")
+    raw_stage = str(state.get("current_stage", ""))
+    stage = RAW_TO_STAGE.get(raw_stage)
+    stages = state.get("stages")
+    if stage is None or not isinstance(stages, dict) or not isinstance(stages.get(raw_stage), dict):
+        raise ActivityError("INPUT", "current stage cannot be strictly replayed")
+    status = stages[raw_stage].get("status")
+    if status not in STATUS_VALUES:
+        raise ActivityError("INPUT", "current stage status is outside the closed vocabulary")
+    if pipeline_state == "completed" and not (raw_stage == "6" and status in {"completed", "skipped"}):
+        raise ActivityError("INPUT", "completed state must replay Stage 6 completed or skipped")
+    return state["run_id"], pipeline_state, stage, status
+
+
+def _terminal_receipt(state: dict[str, Any], state_raw: bytes, relative_path: str) -> dict[str, Any]:
+    run_id, pipeline_state, stage, status = _state_replay(state)
+    return {
+        "artifact_id": "pipeline-state-terminal-receipt",
+        "relative_path": relative_path,
+        "sha256": hashlib.sha256(state_raw).hexdigest(),
+        "run_id": run_id,
+        "pipeline_state": pipeline_state,
+        "current_stage": stage,
+        "current_stage_status": status,
+    }
+
+
+def _validate_source_rows(rows: Any, *, pending: bool = False) -> None:
+    if not isinstance(rows, list) or len(rows) != 5:
+        raise ActivityError("SOURCE", "source inventory must contain exactly five rows")
+    for index, (row, family) in enumerate(zip(rows, SOURCE_FAMILIES)):
+        if not isinstance(row, dict) or row.get("source_family") != family:
+            raise ActivityError("SOURCE", f"source family order mismatch at row {index}")
+        if set(row) != {"source_family", "capture_state", "reason_code", "artifacts"}:
+            raise ActivityError("SOURCE", "source row has unknown or missing fields")
+        state = row.get("capture_state")
+        reason = row.get("reason_code")
+        artifacts = row.get("artifacts")
+        if not isinstance(artifacts, list) or len(artifacts) > 64:
+            raise ActivityError("SOURCE", "invalid source artifact list")
+        if state == "captured":
+            if reason is not None or not artifacts:
+                raise ActivityError("SOURCE", "captured source requires artifacts and null reason")
+        elif state == "not_applicable":
+            if reason != "not_applicable_for_run" or artifacts:
+                raise ActivityError("SOURCE", "not-applicable source shape is invalid")
+        elif state == "unavailable":
+            if reason not in REASON_UNAVAILABLE or artifacts:
+                raise ActivityError("SOURCE", "unavailable source shape is invalid")
+        else:
+            raise ActivityError("SOURCE", "unknown capture state")
+        for artifact in artifacts:
+            expected = {
+                "artifact_id", "artifact_role", "artifact_group_id",
+                "artifact_group_stage", "relative_path",
+            }
+            if not pending:
+                expected.add("sha256")
+            if not isinstance(artifact, dict) or set(artifact) != expected:
+                raise ActivityError("SOURCE", "artifact binding has unknown or missing fields")
+            if not isinstance(artifact.get("artifact_id"), str) or not ID_RE.fullmatch(artifact["artifact_id"]):
+                raise ActivityError("SOURCE", "artifact id is outside the closed identifier grammar")
+            if artifact.get("artifact_role") not in ROLE_ORDER[family]:
+                raise ActivityError("SOURCE", "artifact role is outside the source-family vocabulary")
+            if not isinstance(artifact.get("artifact_group_id"), str) or not GROUP_RE.fullmatch(artifact["artifact_group_id"]):
+                raise ActivityError("SOURCE", "artifact group id is invalid")
+            group_stage = artifact.get("artifact_group_stage")
+            if family == SOURCE_FAMILIES[0]:
+                if group_stage not in {"pipeline_stage_3", "pipeline_stage_3_prime"}:
+                    raise ActivityError("SOURCE", "author artifact group stage is invalid")
+            elif group_stage is not None:
+                raise ActivityError("SOURCE", "non-author artifact group stage must be null")
+            relative_path = artifact.get("relative_path")
+            if not isinstance(relative_path, str):
+                raise ActivityError("SOURCE", "artifact relative path must be a string")
+            if not pending and (not isinstance(artifact.get("sha256"), str) or not HEX_RE.fullmatch(artifact["sha256"])):
+                raise ActivityError("SOURCE", "artifact hash is invalid")
+
+
+def _group_artifacts(row: dict[str, Any]) -> list[list[dict[str, Any]]]:
+    family = row["source_family"]
+    artifacts = row["artifacts"]
+    groups: list[list[dict[str, Any]]] = []
+    seen_ids: set[str] = set()
+    cursor = 0
+    while cursor < len(artifacts):
+        group_id = artifacts[cursor].get("artifact_group_id")
+        if not isinstance(group_id, str) or not GROUP_RE.fullmatch(group_id) or group_id in seen_ids:
+            raise ActivityError("SOURCE", "invalid or repeated artifact group id")
+        seen_ids.add(group_id)
+        group: list[dict[str, Any]] = []
+        while cursor < len(artifacts) and artifacts[cursor].get("artifact_group_id") == group_id:
+            group.append(artifacts[cursor])
+            cursor += 1
+        groups.append(group)
+    if row["capture_state"] != "captured":
+        return groups
+    expected_roles = ROLE_ORDER[family]
+    if family == "revision_author_adjudication":
+        if len(groups) not in {1, 2}:
+            raise ActivityError("SOURCE", "author family requires one or two groups")
+        expected_stages = ["pipeline_stage_3", "pipeline_stage_3_prime"] if len(groups) == 2 else None
+        for index, group in enumerate(groups):
+            if tuple(item.get("artifact_role") for item in group) != expected_roles:
+                raise ActivityError("SOURCE", "author group role order is invalid")
+            stages = {item.get("artifact_group_stage") for item in group}
+            if len(stages) != 1 or next(iter(stages)) not in {"pipeline_stage_3", "pipeline_stage_3_prime"}:
+                raise ActivityError("SOURCE", "author group stage is invalid")
+            if expected_stages and next(iter(stages)) != expected_stages[index]:
+                raise ActivityError("SOURCE", "author group stage order is invalid")
+    elif family == "compliance_report":
+        if not 1 <= len(groups) <= 16:
+            raise ActivityError("SOURCE", "compliance family requires 1..16 groups")
+        for group in groups:
+            roles = tuple(item.get("artifact_role") for item in group)
+            if roles not in {(expected_roles[0],), expected_roles}:
+                raise ActivityError("SOURCE", "compliance group role set/order is invalid")
+            if any(item.get("artifact_group_stage") is not None for item in group):
+                raise ActivityError("SOURCE", "non-author artifact stage must be null")
+    else:
+        if len(groups) != 1 or tuple(item.get("artifact_role") for item in groups[0]) != expected_roles:
+            raise ActivityError("SOURCE", "captured family has invalid exact group roles")
+        if any(item.get("artifact_group_stage") is not None for item in groups[0]):
+            raise ActivityError("SOURCE", "non-author artifact stage must be null")
+    return groups
+
+
+def seal_terminal_inventory(state_path: str | Path, artifact_root: str | Path, pending_bindings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Post-terminal best-effort helper: hash explicit pending rows and seal them.
+
+    ``pending_bindings`` is authority supplied by the state tracker's sole
+    writer.  It contains no hashes.  This helper performs no discovery.
+    """
+    state_file = Path(state_path)
+    root = Path(artifact_root)
+    _validate_source_rows(pending_bindings, pending=True)
+    with _store_lock(state_file, exclusive=True):
+        state_raw, state_identity = _read_limited_identity(state_file, MAX_STORE, code="INPUT")
+        state = strict_json(state_raw, code="INPUT")
+        _state_replay(state)
+        sealed_rows = copy.deepcopy(pending_bindings)
+        total = 0
+        for row in sealed_rows:
+            _group_artifacts(row)
+            for artifact in row["artifacts"]:
+                raw = _read_artifact_relative(root, artifact["relative_path"], MAX_ARTIFACT)
+                total += len(raw)
+                if total > MAX_ARTIFACT_TOTAL:
+                    raise ActivityError("CAP", "referenced artifacts exceed per-run byte cap")
+                artifact["sha256"] = hashlib.sha256(raw).hexdigest()
+        _validate_source_rows(sealed_rows)
+        candidate = copy.deepcopy(state)
+        existing = candidate.get("adjudication_activity_sources")
+        if existing is not None and existing != sealed_rows:
+            raise ActivityError("CONFLICT", "terminal source inventory is already sealed differently")
+        if existing == sealed_rows:
+            return sealed_rows
+        candidate["adjudication_activity_sources"] = sealed_rows
+        _atomic_replace(
+            state_file, canonical_bytes(candidate) + b"\n",
+            expected_identity=state_identity,
+        )
+    return sealed_rows
+
+
+def author_source_record(adjudication: dict[str, Any], event: dict[str, Any], digest: str) -> dict[str, Any]:
+    return {
+        "item_id": adjudication["item_id"],
+        "author_event_id": adjudication["author_event_id"],
+        "author_triage": adjudication["author_triage"],
+        "input_sha256": event["input_sha256"],
+        "interaction_sha256": digest,
+    }
+
+
+def compliance_source_record(
+    group_id: str, stage: str, blockers: list[str], report_hash: str,
+    receipt_hash: str, receipt: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "artifact_group_id": group_id,
+        "stage": stage,
+        "blocking_contributor_ids": blockers,
+        "report_sha256": report_hash,
+        "action_receipt_sha256": receipt_hash,
+        "interaction_id": receipt["interaction_id"],
+        "interaction_sha256": receipt["interaction_sha256"],
+    }
+
+
+def re_review_source_record(
+    round_id: str, dissent_id: str, item_id: str, reapplication_id: str,
+    adjustment: dict[str, Any], traceability_hash: str,
+) -> dict[str, Any]:
+    return {
+        "round_id": round_id,
+        "dissent_id": dissent_id,
+        "item_id": item_id,
+        "reapplication_id": reapplication_id,
+        "adjustment_id": adjustment["adjustment_id"],
+        "from_verdict": adjustment["from_verdict"],
+        "to_verdict": adjustment["to_verdict"],
+        "traceability_sha256": traceability_hash,
+    }
+
+
+def explicit_source_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {key: record[key] for key in (
+        "request_id", "actor_role", "source", "action", "stage", "finding_id",
+        "interaction_id", "interaction_sha256",
+    )}
+
+
+def mandatory_source_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {key: record[key] for key in (
+        "response_id", "checkpoint_id", "checkpoint_type", "actor_role", "source",
+        "stage", "disposition", "interaction_id", "interaction_sha256",
+    )}
+
+
+def _event(
+    run_id: str, family: str, event_type: str, stage: str, disposition: str,
+    interaction: str | None, source_record: dict[str, Any],
+) -> dict[str, Any]:
+    source_hash = _digest(
+        b"ars.adjudication-activity.source-event/1.0\0",
+        {"source_family": family, "source_record": source_record},
+    )
+    payload = {
+        "run_id": run_id, "source_family": family, "event_type": event_type,
+        "stage": stage, "disposition": disposition,
+        "interaction_sha256": interaction, "source_event_sha256": source_hash,
+    }
+    return {
+        "event_id": "ACTIVITY-EVENT-" + _digest(b"ars.adjudication-activity.event-id/1.0\0", payload),
+        "event_type": event_type, "stage": stage, "disposition": disposition,
+        "interaction_sha256": interaction, "source_event_sha256": source_hash,
+    }
+
+
+def _load_artifact(root: Path, binding: dict[str, Any], total: list[int]) -> tuple[dict[str, Any], bytes]:
+    raw = _read_artifact_relative(root, binding["relative_path"], MAX_ARTIFACT)
+    total[0] += len(raw)
+    if total[0] > MAX_ARTIFACT_TOTAL:
+        raise ActivityError("CAP", "referenced artifacts exceed per-run byte cap")
+    if hashlib.sha256(raw).hexdigest() != binding["sha256"]:
+        raise ActivityError("SOURCE", "artifact raw-byte hash mismatch")
+    value = strict_json(raw, code="SOURCE")
+    if not isinstance(value, dict):
+        raise ActivityError("SOURCE", "source artifact root must be an object")
+    return value, raw
+
+
+def _author_events(run_id: str, stage: str, group: list[dict[str, Any]], root: Path, total: list[int]) -> list[dict[str, Any]]:
+    input_value, _ = _load_artifact(root, group[0], total)
+    output_value, _ = _load_artifact(root, group[1], total)
+    _schema_validate(input_value, REVISION_CONTRACTS / "author_adjudication_input.schema.json", code="SOURCE", revision_registry=True)
+    _schema_validate(output_value, REVISION_CONTRACTS / "author_adjudication.schema.json", code="SOURCE", revision_registry=True)
+    projection_keys = ("author_events", "author_adjudications", "display_order", "collateral_authorizations")
+    if any(input_value[key] != output_value[key] for key in projection_keys):
+        raise ActivityError("SOURCE", "author input/output projection mismatch")
+    event_by_id: dict[str, dict[str, Any]] = {}
+    for source_event in output_value["author_events"]:
+        event_id = source_event["event_id"]
+        if event_id in event_by_id:
+            raise ActivityError("SOURCE", "duplicate author event id")
+        event_by_id[event_id] = source_event
+    derived: list[dict[str, Any]] = []
+    for adjudication in output_value["author_adjudications"]:
+        event_id = adjudication["author_event_id"]
+        if event_id not in event_by_id:
+            raise ActivityError("SOURCE", "author adjudication event id is unresolved")
+        triage = adjudication["author_triage"]
+        if triage == "will_address":
+            continue
+        digest = interaction_sha256(run_id, event_id)
+        event_type, disposition = (
+            ("author_triage_wont_address", "wont_address") if triage == "wont_address"
+            else ("author_triage_not_on_point", "not_on_point")
+        )
+        derived.append(_event(
+            run_id, SOURCE_FAMILIES[0], event_type, stage, disposition, digest,
+            author_source_record(adjudication, event_by_id[event_id], digest),
+        ))
+    return derived
+
+
+def _receipt_shape(value: dict[str, Any], keys: set[str], version: str) -> None:
+    if set(value) != keys or value.get("schema_version") != version:
+        raise ActivityError("SOURCE", "closed action receipt shape/version is invalid")
+
+
+def _blocking_contributors(report: dict[str, Any]) -> list[str]:
+    if report.get("mode") != "systematic_review":
+        return []
+    result: set[str] = set()
+    prisma = report.get("prisma_trAIce")
+    if isinstance(prisma, dict) and prisma.get("block_decision") == "block":
+        failed = prisma["by_tier"]["mandatory"]["fail"]
+        if len(failed) != len(set(failed)):
+            raise ActivityError("SOURCE", "PRISMA blocking contributor ids must be unique")
+        result.update(failed)
+    raise_part = report.get("raise")
+    if isinstance(raise_part, dict) and raise_part.get("block_decision") == "block":
+        result.update(name for name, status_value in raise_part["principles"].items() if status_value == "fail")
+    return sorted(result)
+
+
+def _compliance_events(run_id: str, groups: list[list[dict[str, Any]]], root: Path, total: list[int]) -> list[dict[str, Any]]:
+    derived: list[dict[str, Any]] = []
+    expected_ordinal = {"pipeline_stage_2_5": 1, "pipeline_stage_4_5": 1}
+    receipt_ids: set[str] = set()
+    receipt_keys = {
+        "schema_version", "receipt_id", "run_id", "actor_role", "source", "action",
+        "stage", "scope", "report_sha256", "override_ordinal", "interaction_id",
+        "interaction_sha256",
+    }
+    for group in groups:
+        report, _ = _load_artifact(root, group[0], total)
+        _schema_validate(report, COMPLIANCE_SCHEMA_PATH, code="SOURCE")
+        has_override = "user_override" in report
+        if not has_override and len(group) == 1:
+            continue
+        if not has_override or len(group) != 2:
+            raise ActivityError("SOURCE", "compliance action receipt pairing is invalid")
+        receipt, _ = _load_artifact(root, group[1], total)
+        _receipt_shape(receipt, receipt_keys, "adjudication-compliance-override-action/1.0")
+        receipt_id = receipt.get("receipt_id")
+        interaction_id = receipt.get("interaction_id")
+        scope = receipt.get("scope")
+        ordinal = receipt.get("override_ordinal")
+        if (
+            not isinstance(receipt_id, str) or not ID_RE.fullmatch(receipt_id)
+            or not isinstance(interaction_id, str) or not ID_RE.fullmatch(interaction_id)
+            or not isinstance(scope, list) or not scope
+            or any(not isinstance(item, str) or not ID_RE.fullmatch(item) for item in scope)
+            or len(scope) != len(set(scope))
+            or not isinstance(ordinal, int) or isinstance(ordinal, bool) or ordinal < 1
+            or not isinstance(receipt.get("report_sha256"), str)
+            or not HEX_RE.fullmatch(receipt["report_sha256"])
+            or not isinstance(receipt.get("interaction_sha256"), str)
+            or not HEX_RE.fullmatch(receipt["interaction_sha256"])
+        ):
+            raise ActivityError("SOURCE", "compliance action receipt field types are invalid")
+        blockers = _blocking_contributors(report)
+        report_stage = {"2.5": "pipeline_stage_2_5", "4.5": "pipeline_stage_4_5"}.get(report.get("stage"))
+        override = report["user_override"]
+        valid = (
+            report.get("overall_decision") == "block"
+            and report.get("user_action_required") is True
+            and bool(blockers)
+            and override.get("decision") is True
+            and report_stage == receipt.get("stage")
+            and receipt.get("run_id") == run_id
+            and receipt.get("actor_role") == "user"
+            and receipt.get("source") == "explicit_session_user_action"
+            and receipt.get("action") == "acknowledge_compliance_limitation"
+            and receipt.get("report_sha256") == group[0]["sha256"]
+        )
+        scopes = (override.get("scope"), receipt.get("scope"))
+        for candidate_scope in scopes:
+            if (
+                not isinstance(candidate_scope, list)
+                or any(not isinstance(item, str) for item in candidate_scope)
+                or len(candidate_scope) != len(set(candidate_scope))
+                or set(candidate_scope) != set(blockers)
+            ):
+                valid = False
+        stage = receipt.get("stage")
+        if stage not in expected_ordinal or ordinal != expected_ordinal.get(stage):
+            valid = False
+        else:
+            expected_ordinal[stage] += 1
+        rationale = override.get("rationale")
+        if ordinal == 2 and (not isinstance(rationale, str) or not rationale):
+            valid = False
+        if isinstance(ordinal, int) and ordinal >= 3 and (not isinstance(rationale, str) or len(rationale) < 100):
+            valid = False
+        if receipt_id in receipt_ids:
+            valid = False
+        else:
+            receipt_ids.add(receipt_id)
+        expected_digest = interaction_sha256(run_id, interaction_id)
+        if receipt.get("interaction_sha256") != expected_digest:
+            valid = False
+        if not valid:
+            raise ActivityError("SOURCE", "qualifying compliance override replay failed")
+        source = compliance_source_record(
+            group[0]["artifact_group_id"], stage, blockers, group[0]["sha256"],
+            group[1]["sha256"], receipt,
+        )
+        derived.append(_event(
+            run_id, SOURCE_FAMILIES[1], "compliance_block_override", stage,
+            "block_overridden", expected_digest, source,
+        ))
+    return derived
+
+
+def _rereview_events(run_id: str, group: list[dict[str, Any]], root: Path, total: list[int]) -> list[dict[str, Any]]:
+    names = ("input_manifest", "precommitment", "verdict_record", "traceability")
+    values: dict[str, dict[str, Any]] = {}
+    for name, binding in zip(names, group):
+        value, _ = _load_artifact(root, binding, total)
+        _schema_validate(value, REREVIEW_CONTRACTS / f"{name}.schema.json", code="SOURCE")
+        values[name] = value
+    round_ids = {values[name].get("round_id") for name in names}
+    if len(round_ids) != 1:
+        raise ActivityError("SOURCE", "re-review round ids do not agree")
+    if values["precommitment"].get("input_manifest_hash") != hashlib.sha256(canonical_bytes(values["input_manifest"])).hexdigest():
+        raise ActivityError("SOURCE", "re-review input/precommitment hash chain mismatch")
+    if values["verdict_record"].get("precommitment_hash") != hashlib.sha256(canonical_bytes(values["precommitment"])).hexdigest():
+        raise ActivityError("SOURCE", "re-review precommitment/verdict hash chain mismatch")
+    if values["traceability"].get("verdict_record_hash") != hashlib.sha256(canonical_bytes(values["verdict_record"])).hexdigest():
+        raise ActivityError("SOURCE", "re-review verdict/traceability hash chain mismatch")
+    verdict = values["verdict_record"]
+    trace = values["traceability"]
+    dissent_item: dict[str, str] = {}
+    for dissent in verdict["dissents"]:
+        if dissent["dissent_id"] in dissent_item:
+            raise ActivityError("SOURCE", "duplicate re-review dissent id")
+        dissent_item[dissent["dissent_id"]] = dissent["item_id"]
+    adjudications_by_id: dict[str, dict[str, Any]] = {}
+    for item in trace["dissent_adjudications"]:
+        if item["dissent_id"] in adjudications_by_id:
+            raise ActivityError("SOURCE", "duplicate dissent adjudication id")
+        adjudications_by_id[item["dissent_id"]] = item
+    qualifying_dissents = {
+        dissent_id: item for dissent_id, item in adjudications_by_id.items()
+        if item["adjudicator"] == "user" and item["outcome"] == "original_upheld"
+    }
+    reapp_by_id: dict[str, dict[str, Any]] = {}
+    for item in trace["reapplications"]:
+        if item["reapplication_id"] in reapp_by_id:
+            raise ActivityError("SOURCE", "duplicate reapplication id")
+        reapp_by_id[item["reapplication_id"]] = item
+    superseded_by: dict[str, str] = {}
+    for item in trace["reapplications"]:
+        previous = item.get("supersedes_reapplication_id")
+        if previous is not None:
+            previous_item = reapp_by_id.get(previous)
+            if previous_item is None or previous_item["item_id"] != item["item_id"] or previous in superseded_by:
+                raise ActivityError("SOURCE", "invalid reapplication supersession")
+            superseded_by[previous] = item["reapplication_id"]
+    for item in trace["reapplications"]:
+        seen: set[str] = set()
+        cursor: dict[str, Any] | None = item
+        while cursor is not None:
+            cursor_id = cursor["reapplication_id"]
+            if cursor_id in seen:
+                raise ActivityError("SOURCE", "reapplication supersession cycle")
+            seen.add(cursor_id)
+            previous = cursor.get("supersedes_reapplication_id")
+            cursor = reapp_by_id.get(previous) if previous is not None else None
+    current_reapps = [item for item in trace["reapplications"] if item["reapplication_id"] not in superseded_by]
+    for reapp in trace["reapplications"]:
+        for answer_ref in reapp["answer_refs"]:
+            if answer_ref.startswith("adjudication:"):
+                dissent_id = answer_ref.split(":", 1)[1]
+                adjudication = adjudications_by_id.get(dissent_id)
+                if (
+                    adjudication is None
+                    or adjudication["outcome"] != "original_upheld"
+                    or dissent_item.get(dissent_id) != reapp["item_id"]
+                ):
+                    raise ActivityError("SOURCE", "reapplication adjudication ref is unresolved or cross-item")
+    for dissent_id, adjudication in adjudications_by_id.items():
+        if adjudication["outcome"] == "original_upheld":
+            holders = [
+                reapp for reapp in current_reapps
+                if f"adjudication:{dissent_id}" in reapp["answer_refs"]
+            ]
+            if len(holders) != 1:
+                raise ActivityError("SOURCE", "original-upheld dissent requires exactly one current reapplication")
+            if (
+                holders[0]["reapplied_verdict"] == "CANNOT_VERIFY"
+                or holders[0]["reapplied_verdict"] == holders[0]["pre_reapplication_verdict"]
+            ):
+                raise ActivityError("SOURCE", "original-upheld current reapplication must prove a verdict change")
+    adjustments_by_item: dict[str, list[dict[str, Any]]] = {}
+    global_adjustment_ids: set[str] = set()
+    for adjustment in trace["adjustments"]:
+        if adjustment["adjustment_id"] in global_adjustment_ids:
+            raise ActivityError("SOURCE", "duplicate adjustment id")
+        global_adjustment_ids.add(adjustment["adjustment_id"])
+        adjustments_by_item.setdefault(adjustment["item_id"], []).append(adjustment)
+    row_by_item: dict[str, dict[str, Any]] = {}
+    for row in trace["rows"]:
+        if row["item_id"] in row_by_item:
+            raise ActivityError("SOURCE", "duplicate traceability row item id")
+        row_by_item[row["item_id"]] = row
+    adjustments_by_source: dict[str, list[dict[str, Any]]] = {}
+    for adjustment in trace["adjustments"]:
+        source_ref = adjustment.get("source_ref")
+        if source_ref is not None:
+            if source_ref.startswith("reapplication:") and source_ref.split(":", 1)[1] not in reapp_by_id:
+                raise ActivityError("SOURCE", "adjustment source_ref names an unknown reapplication")
+            adjustments_by_source.setdefault(source_ref, []).append(adjustment)
+    for reapp in trace["reapplications"]:
+        derived = adjustments_by_source.get(f"reapplication:{reapp['reapplication_id']}", [])
+        changing = (
+            reapp["reapplied_verdict"] != "CANNOT_VERIFY"
+            and reapp["reapplied_verdict"] != reapp["pre_reapplication_verdict"]
+        )
+        if not changing:
+            if derived:
+                raise ActivityError("SOURCE", "non-changing/CANNOT reapplication has a derived adjustment")
+            continue
+        if len(derived) != 1:
+            raise ActivityError("SOURCE", "verdict-changing reapplication requires exactly one derived adjustment")
+        adjustment = derived[0]
+        if (
+            adjustment["item_id"] != reapp["item_id"]
+            or adjustment["basis"] != "cross_model_adjudication"
+            or adjustment["from_verdict"] != reapp["pre_reapplication_verdict"]
+            or adjustment["to_verdict"] != reapp["reapplied_verdict"]
+            or adjustment["rationale"] != reapp["rationale"]
+            or adjustment.get("residual_gap") != reapp.get("residual_gap")
+            or adjustment.get("evidence_anchor") != reapp.get("evidence_anchor")
+        ):
+            raise ActivityError("SOURCE", "derived adjustment does not mirror its reapplication")
+    candidates: list[tuple[int, dict[str, Any], str, str]] = []
+    counted_adjustments: set[str] = set()
+    for dissent_id in qualifying_dissents:
+        item_id = dissent_item.get(dissent_id)
+        if item_id is None:
+            raise ActivityError("SOURCE", "adjudicated dissent does not resolve to verdict dissent")
+        reapps = [item for item in current_reapps if item["item_id"] == item_id and f"adjudication:{dissent_id}" in item["answer_refs"]]
+        if len(reapps) != 1:
+            raise ActivityError("SOURCE", "dissent must resolve to one current reapplication")
+        if (
+            reapps[0]["reapplied_verdict"] == "CANNOT_VERIFY"
+            or reapps[0]["reapplied_verdict"] == reapps[0]["pre_reapplication_verdict"]
+        ):
+            raise ActivityError("SOURCE", "original-upheld current reapplication must prove a verdict change")
+        records = adjustments_by_item.get(item_id, [])
+        by_id = {item["adjustment_id"]: item for item in records}
+        if len(by_id) != len(records):
+            raise ActivityError("SOURCE", "duplicate adjustment id")
+        followers: dict[str, dict[str, Any]] = {}
+        heads: list[dict[str, Any]] = []
+        for adjustment in records:
+            previous = adjustment.get("supersedes_adjustment_id")
+            if previous is None:
+                heads.append(adjustment)
+            elif previous not in by_id or previous in followers:
+                raise ActivityError("SOURCE", "forked or orphan adjustment chain")
+            else:
+                followers[previous] = adjustment
+        if len(heads) != 1:
+            raise ActivityError("SOURCE", "adjustment chain must have exactly one head")
+        chain = [heads[0]]
+        while chain[-1]["adjustment_id"] in followers:
+            next_item = followers[chain[-1]["adjustment_id"]]
+            if next_item["from_verdict"] != chain[-1]["to_verdict"]:
+                raise ActivityError("SOURCE", "adjustment chain verdict join mismatch")
+            chain.append(next_item)
+        if len(chain) != len(records):
+            raise ActivityError("SOURCE", "adjustment chain contains a cycle or disconnected record")
+        row = row_by_item.get(item_id)
+        if not row or row.get("adjustment_id") != chain[-1]["adjustment_id"] or row.get("final_verdict") != chain[-1]["to_verdict"]:
+            raise ActivityError("SOURCE", "final row does not bind adjustment chain tail")
+        reapp = reapps[0]
+        for adjustment in chain:
+            if (
+                adjustment["basis"] == "cross_model_adjudication"
+                and adjustment.get("source_ref") == f"reapplication:{reapp['reapplication_id']}"
+                and adjustment["from_verdict"] != adjustment["to_verdict"]
+            ):
+                if adjustment["adjustment_id"] in counted_adjustments:
+                    raise ActivityError("SOURCE", "one adjustment cannot produce multiple activity events")
+                counted_adjustments.add(adjustment["adjustment_id"])
+                numeric = int(adjustment["adjustment_id"].split("-", 1)[1])
+                candidates.append((numeric, adjustment, dissent_id, reapp["reapplication_id"]))
+    trace_hash = group[3]["sha256"]
+    return [
+        _event(
+            run_id, SOURCE_FAMILIES[2], "re_review_verdict_changed",
+            "pipeline_stage_3_prime", "verdict_changed", None,
+            re_review_source_record(
+                values["input_manifest"]["round_id"], dissent_id,
+                adjustment["item_id"], reapplication_id, adjustment, trace_hash,
+            ),
+        )
+        for _, adjustment, dissent_id, reapplication_id in sorted(candidates, key=lambda item: item[0])
+    ]
+
+
+def _validate_action_log(value: dict[str, Any], *, run_id: str, mandatory: bool) -> list[dict[str, Any]]:
+    version = "adjudication-mandatory-checkpoint-log/1.0" if mandatory else "adjudication-explicit-user-request-log/1.0"
+    if set(value) != {"schema_version", "run_id", "records"} or value.get("schema_version") != version or value.get("run_id") != run_id:
+        raise ActivityError("SOURCE", "action log root is invalid")
+    records = value.get("records")
+    if not isinstance(records, list) or len(records) > MAX_EVENTS_RUN:
+        raise ActivityError("SOURCE", "action log record list is invalid")
+    ids: set[str] = set()
+    for record in records:
+        common = {"actor_role", "source", "stage", "interaction_id", "interaction_sha256"}
+        expected = common | (
+            {"response_id", "checkpoint_id", "checkpoint_type", "disposition"}
+            if mandatory else {"request_id", "action", "finding_id"}
+        )
+        if not isinstance(record, dict) or set(record) != expected:
+            raise ActivityError("SOURCE", "action log record closed shape is invalid")
+        record_id = record["response_id" if mandatory else "request_id"]
+        if not isinstance(record_id, str) or not ID_RE.fullmatch(record_id) or record_id in ids:
+            raise ActivityError("SOURCE", "action log record id is invalid or repeated")
+        ids.add(record_id)
+        identifier_fields = (
+            ("checkpoint_id", "interaction_id")
+            if mandatory else ("finding_id", "interaction_id")
+        )
+        if any(
+            not isinstance(record.get(field), str) or not ID_RE.fullmatch(record[field])
+            for field in identifier_fields
+        ):
+            raise ActivityError("SOURCE", "action log identifier is outside the closed grammar")
+        if record.get("actor_role") != "user" or record.get("source") != "explicit_session_user_action" or record.get("stage") not in STAGES:
+            raise ActivityError("SOURCE", "action log authority/stage is invalid")
+        interaction_id = record.get("interaction_id")
+        if not isinstance(interaction_id, str) or not ID_RE.fullmatch(interaction_id) or record.get("interaction_sha256") != interaction_sha256(run_id, interaction_id):
+            raise ActivityError("SOURCE", "action log interaction digest is invalid")
+        if mandatory:
+            if record.get("checkpoint_type") != "MANDATORY" or record.get("disposition") not in {"proceed", "skip", "pause", "adjust", "view_progress", "redo", "abort"}:
+                raise ActivityError("SOURCE", "mandatory checkpoint record is invalid")
+        elif record.get("action") not in {"justify_finding", "redo_finding"}:
+            raise ActivityError("SOURCE", "explicit request action is invalid")
+    return records
+
+
+def _log_events(run_id: str, family: str, group: list[dict[str, Any]], root: Path, total: list[int]) -> tuple[list[dict[str, Any]], int]:
+    value, _ = _load_artifact(root, group[0], total)
+    mandatory = family == SOURCE_FAMILIES[4]
+    records = _validate_action_log(value, run_id=run_id, mandatory=mandatory)
+    result: list[dict[str, Any]] = []
+    for record in records:
+        if mandatory:
+            source_disposition = record["disposition"]
+            if source_disposition == "proceed":
+                continue
+            disposition = "skip_refused" if source_disposition == "skip" else source_disposition
+            result.append(_event(
+                run_id, family, "mandatory_checkpoint_non_proceed", record["stage"],
+                disposition, record["interaction_sha256"], mandatory_source_record(record),
+            ))
+        else:
+            event_type, disposition = (
+                ("finding_justification_requested", "justification_requested")
+                if record["action"] == "justify_finding"
+                else ("finding_redo_requested", "redo_requested")
+            )
+            result.append(_event(
+                run_id, family, event_type, record["stage"], disposition,
+                record["interaction_sha256"], explicit_source_record(record),
+            ))
+    return result, len(records)
+
+
+def _validate_manifest_authority(manifest: dict[str, Any], root: Path) -> tuple[dict[str, Any], bytes]:
+    _schema_validate(manifest, INPUT_SCHEMA_PATH, code="INPUT")
+    terminal = manifest["terminal_receipt"]
+    state_raw = _read_artifact_relative(root, terminal["relative_path"], MAX_STORE)
+    if hashlib.sha256(state_raw).hexdigest() != terminal["sha256"]:
+        raise ActivityError("INPUT", "terminal receipt raw-byte hash mismatch")
+    state = strict_json(state_raw, code="INPUT")
+    run_id, pipeline_state, stage, status = _state_replay(state)
+    exact = {
+        "artifact_id": "pipeline-state-terminal-receipt",
+        "relative_path": terminal["relative_path"],
+        "sha256": hashlib.sha256(state_raw).hexdigest(),
+        "run_id": run_id, "pipeline_state": pipeline_state,
+        "current_stage": stage, "current_stage_status": status,
+    }
+    if terminal != exact:
+        raise ActivityError("INPUT", "terminal receipt projection does not exactly replay")
+    if manifest["run_id"] != run_id or manifest["terminal_state"] != pipeline_state or manifest["terminal_stage"] != stage:
+        raise ActivityError("INPUT", "input root does not match terminal state authority")
+    inventory = state.get("adjudication_activity_sources")
+    if inventory != manifest["sources"]:
+        raise ActivityError("INPUT", "input sources differ from sealed terminal inventory")
+    _validate_source_rows(inventory)
+    for row in inventory:
+        _group_artifacts(row)
+        if row["source_family"] == SOURCE_FAMILIES[0] and row["capture_state"] == "captured":
+            for group in _group_artifacts(row):
+                raw_stage = STAGE_TO_RAW[group[0]["artifact_group_stage"]]
+                stage_row = state.get("stages", {}).get(raw_stage)
+                if not isinstance(stage_row, dict) or stage_row.get("status") != "completed":
+                    raise ActivityError("INPUT", "author source stage is not completed in terminal state")
+    return state, state_raw
+
+
+def _extract_run(manifest: dict[str, Any], root: Path, sequence: int) -> dict[str, Any]:
+    _, _ = _validate_manifest_authority(manifest, root)
+    run_id = manifest["run_id"]
+    total = [0]
+    source_rows: list[dict[str, Any]] = []
+    all_events: list[list[dict[str, Any]]] = []
+    action_log_record_count = 0
+    for row in manifest["sources"]:
+        groups = _group_artifacts(row)
+        events: list[dict[str, Any]] = []
+        if row["capture_state"] == "captured":
+            family = row["source_family"]
+            if family == SOURCE_FAMILIES[0]:
+                for group in groups:
+                    events.extend(_author_events(run_id, group[0]["artifact_group_stage"], group, root, total))
+            elif family == SOURCE_FAMILIES[1]:
+                events = _compliance_events(run_id, groups, root, total)
+            elif family == SOURCE_FAMILIES[2]:
+                events = _rereview_events(run_id, groups[0], root, total)
+            else:
+                events, source_record_count = _log_events(run_id, family, groups[0], root, total)
+                action_log_record_count += source_record_count
+                if action_log_record_count > MAX_EVENTS_RUN:
+                    raise ActivityError("CAP", "combined action-log records exceed per-run cap")
+        all_events.append(events)
+        source_rows.append({
+            "source_family": row["source_family"],
+            "capture_state": row["capture_state"],
+            "reason_code": row["reason_code"],
+            "artifact_sha256s": [item["sha256"] for item in row["artifacts"]],
+            "events": events,
+        })
+    winner: dict[str, int] = {}
+    for family_index, events in enumerate(all_events):
+        for event in events:
+            digest = event["interaction_sha256"]
+            if digest is not None and digest not in winner:
+                winner[digest] = family_index
+    for family_index, source in enumerate(source_rows):
+        source["events"] = [
+            event for event in source["events"]
+            if event["interaction_sha256"] is None or winner[event["interaction_sha256"]] == family_index
+        ]
+    event_count = sum(len(row["events"]) for row in source_rows)
+    if event_count > MAX_EVENTS_RUN:
+        raise ActivityError("CAP", "derived events exceed per-run cap")
+    record: dict[str, Any] = {
+        "append_sequence": sequence,
+        "run_id": run_id,
+        "terminal_state": manifest["terminal_state"],
+        "terminal_stage": manifest["terminal_stage"],
+        "terminal_receipt_sha256": manifest["terminal_receipt"]["sha256"],
+        "input_receipt_sha256": _digest(b"ars.adjudication-activity.input/1.0\0", manifest),
+        "record_sha256": "",
+        "sealed": True,
+        "sources": source_rows,
+    }
+    preimage = {key: value for key, value in record.items() if key != "record_sha256"}
+    record["record_sha256"] = _digest(b"ars.adjudication-activity.run/1.0\0", preimage)
+    return record
+
+
+def _empty_store(store_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": STORE_VERSION, "store_id": store_id,
+        "revision": 0, "next_sequence": 1, "runs": [],
+        "data_minimization": copy.deepcopy(DATA_MINIMIZATION),
+    }
+
+
+def _validate_store(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ActivityError("STORE", "store root must be an object")
+    _schema_validate(value, STORE_SCHEMA_PATH, code="STORE")
+    runs = value["runs"]
+    if len(runs) > MAX_RUNS:
+        raise ActivityError("CAP", "retained runs exceed hard cap")
+    sequences: list[int] = []
+    identities: dict[str, set[Any]] = {
+        "run": set(), "input": set(), "record": set(), "event": set(),
+    }
+    total_events = 0
+    for run in runs:
+        sequences.append(run["append_sequence"])
+        checks = (("run", run["run_id"]), ("input", run["input_receipt_sha256"]), ("record", run["record_sha256"]))
+        for kind, identity in checks:
+            if identity in identities[kind]:
+                raise ActivityError("STORE", f"duplicate {kind} identity")
+            identities[kind].add(identity)
+        preimage = {key: item for key, item in run.items() if key != "record_sha256"}
+        if run["record_sha256"] != _digest(b"ars.adjudication-activity.run/1.0\0", preimage):
+            raise ActivityError("STORE", "run record digest mismatch")
+        if [row["source_family"] for row in run["sources"]] != list(SOURCE_FAMILIES):
+            raise ActivityError("STORE", "stored source family order mismatch")
+        captured_counts = (
+            {2, 4}, set(range(1, 33)), {4}, {1}, {1},
+        )
+        cross_family: dict[str, int] = {}
+        for family_index, row in enumerate(run["sources"]):
+            artifact_count = len(row["artifact_sha256s"])
+            if row["capture_state"] == "captured" and artifact_count not in captured_counts[family_index]:
+                raise ActivityError("STORE", "captured source artifact count violates family contract")
+            if row["capture_state"] != "captured" and artifact_count != 0:
+                raise ActivityError("STORE", "non-captured source retains artifact hashes")
+            for event in row["events"]:
+                if event["event_id"] in identities["event"]:
+                    raise ActivityError("STORE", "duplicate event id")
+                identities["event"].add(event["event_id"])
+                digest = event["interaction_sha256"]
+                if digest is not None and digest in cross_family and cross_family[digest] != family_index:
+                    raise ActivityError("STORE", "cross-family causal duplicate remains in store")
+                if digest is not None:
+                    cross_family[digest] = family_index
+                payload = {
+                    "run_id": run["run_id"], "source_family": row["source_family"],
+                    "event_type": event["event_type"], "stage": event["stage"],
+                    "disposition": event["disposition"],
+                    "interaction_sha256": digest,
+                    "source_event_sha256": event["source_event_sha256"],
+                }
+                expected_id = "ACTIVITY-EVENT-" + _digest(b"ars.adjudication-activity.event-id/1.0\0", payload)
+                if event["event_id"] != expected_id:
+                    raise ActivityError("STORE", "event id digest mismatch")
+                total_events += 1
+    if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
+        raise ActivityError("STORE", "append sequences are not strictly increasing")
+    if sequences and value["next_sequence"] <= sequences[-1]:
+        raise ActivityError("STORE", "next_sequence does not exceed retained sequences")
+    if value["revision"] < len(runs):
+        raise ActivityError("STORE", "revision cannot be below retained append count")
+    if value["revision"] < value["next_sequence"] - 1:
+        raise ActivityError("STORE", "revision cannot be below allocated append sequences")
+    if total_events > MAX_EVENTS_STORE:
+        raise ActivityError("CAP", "store event count exceeds hard cap")
+    return value
+
+
+def _read_store(path: Path) -> tuple[dict[str, Any], bytes, tuple[int, int, int]]:
+    raw, identity = _read_limited_identity(path, MAX_STORE, code="STORE")
+    value = strict_json(raw, code="STORE")
+    if raw != canonical_bytes(value, code="STORE") + b"\n":
+        raise ActivityError("STORE", "store bytes are not canonical JSON plus one LF")
+    return _validate_store(value), raw, identity
+
+
+def _store_bytes(value: dict[str, Any]) -> bytes:
+    _validate_store(value)
+    raw = canonical_bytes(value, code="STORE") + b"\n"
+    if len(raw) > MAX_STORE:
+        raise ActivityError("CAP", "persisted store exceeds hard byte cap")
+    return raw
+
+
+def _json_id(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _cmd_init(args: argparse.Namespace) -> str:
+    path = Path(args.store)
+    with _store_lock(path, exclusive=True):
+        if path.exists() or path.is_symlink():
+            raise ActivityError("CONFLICT", "store path already exists")
+        store = _empty_store(args.store_id)
+        _schema_validate(store, STORE_SCHEMA_PATH, code="STORE")
+        _atomic_create(path, _store_bytes(store))
+    return f"[ARS-ADJUDICATION-ACTIVITY] initialized store_id={_json_id(args.store_id)}; revision=0; next_sequence=1"
+
+
+def _cmd_build(args: argparse.Namespace) -> str:
+    state_path, root = Path(args.state), Path(args.artifact_root)
+    state_raw = _read_limited(state_path, MAX_STORE, code="INPUT")
+    state = strict_json(state_raw, code="INPUT")
+    run_id, pipeline_state, stage, _ = _state_replay(state)
+    inventory = state.get("adjudication_activity_sources")
+    _validate_source_rows(inventory)
+    relative = _relative_binding(root, state_path)
+    manifest = {
+        "schema_version": INPUT_VERSION, "store_id": args.store_id,
+        "run_id": run_id, "terminal_state": pipeline_state,
+        "terminal_stage": stage,
+        "terminal_receipt": _terminal_receipt(state, state_raw, relative),
+        "sources": copy.deepcopy(inventory),
+        "data_minimization": copy.deepcopy(DATA_MINIMIZATION),
+    }
+    _validate_manifest_authority(manifest, root)
+    # Full extraction here proves every projected artifact before publishing input.
+    _extract_run(manifest, root, 1)
+    _atomic_create(Path(args.output), canonical_bytes(manifest) + b"\n")
+    return f"[ARS-ADJUDICATION-ACTIVITY] built_input run_id={_json_id(run_id)}; source_count=5"
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    raw = _read_limited(path, MAX_INPUT, code="INPUT")
+    value = strict_json(raw, code="INPUT")
+    if not isinstance(value, dict):
+        raise ActivityError("INPUT", "input manifest root must be an object")
+    _schema_validate(value, INPUT_SCHEMA_PATH, code="INPUT")
+    return value
+
+
+def _cmd_append(args: argparse.Namespace) -> str:
+    manifest = _load_manifest(Path(args.input))
+    root, path = Path(args.artifact_root), Path(args.store)
+    receipt = _digest(b"ars.adjudication-activity.input/1.0\0", manifest)
+    with _store_lock(path, exclusive=True):
+        if path.exists() or path.is_symlink():
+            store, _, store_identity = _read_store(path)
+            if store["store_id"] != manifest["store_id"]:
+                raise ActivityError("CONFLICT", "store id differs from input store id")
+        else:
+            store = _empty_store(manifest["store_id"])
+            store_identity = None
+        for retained in store["runs"]:
+            if retained["run_id"] == manifest["run_id"]:
+                if retained["input_receipt_sha256"] == receipt:
+                    return (
+                        f"[ARS-ADJUDICATION-ACTIVITY] already_appended run_id={_json_id(retained['run_id'])}; "
+                        f"append_sequence={retained['append_sequence']}; revision={store['revision']}"
+                    )
+                raise ActivityError("CONFLICT", "run id is retained with a different input receipt")
+            if retained["input_receipt_sha256"] == receipt:
+                raise ActivityError("CONFLICT", "input receipt is retained under a different run id")
+        if len(store["runs"]) >= MAX_RUNS:
+            raise ActivityError("CAP", "retained run cap reached")
+        # Source and terminal replay occurs only for a genuinely new identity.
+        record = _extract_run(manifest, root, store["next_sequence"])
+        candidate = copy.deepcopy(store)
+        candidate["runs"].append(record)
+        candidate["next_sequence"] += 1
+        candidate["revision"] += 1
+        raw = _store_bytes(candidate)
+        if store_identity is not None:
+            _atomic_replace(path, raw, expected_identity=store_identity)
+        else:
+            _atomic_create(path, raw)
+    return (
+        f"[ARS-ADJUDICATION-ACTIVITY] appended run_id={_json_id(record['run_id'])}; "
+        f"append_sequence={record['append_sequence']}; revision={candidate['revision']}"
+    )
+
+
+def _render(store: dict[str, Any], window: int) -> str:
+    selected = store["runs"][-window:]
+    count = sum(len(source["events"]) for run in selected for source in run["sources"])
+    overturn = sum(
+        event["event_type"] in OVERTURN_TYPES
+        for run in selected for source in run["sources"] for event in source["events"]
+    )
+    unavailable_runs = sum(any(source["capture_state"] == "unavailable" for source in run["sources"]) for run in selected)
+    lines: list[str] = []
+    if len(selected) < 2:
+        lines.append(
+            f"[ARS-ADJUDICATION-ACTIVITY INSUFFICIENT_HISTORY] selected_retained_eligible_run_count={len(selected)}; "
+            f"minimum_required=2; requested_window={window}."
+        )
+        lines.append(
+            f"[ARS-ADJUDICATION-ACTIVITY COUNTS] adjudication_count={count} (denominator: {len(selected)} retained eligible terminal run records); "
+            f"overturn_count={overturn} (denominator: {count} recorded adjudications); unavailable_run_count={unavailable_runs} "
+            f"(denominator: {len(selected)} retained eligible terminal run records)."
+        )
+    else:
+        lines.append(
+            f"[ARS-ADJUDICATION-ACTIVITY] selected_retained_eligible_run_count={len(selected)}; requested_window={window}; "
+            f"adjudication_count={count} (denominator: {len(selected)} retained eligible terminal run records); "
+            f"overturn_count={overturn} (denominator: {count} recorded adjudications); unavailable_run_count={unavailable_runs} "
+            f"(denominator: {len(selected)} retained eligible terminal run records)."
+        )
+    for run in selected:
+        run_count = sum(len(source["events"]) for source in run["sources"])
+        run_overturn = sum(event["event_type"] in OVERTURN_TYPES for source in run["sources"] for event in source["events"])
+        unavailable = sum(source["capture_state"] == "unavailable" for source in run["sources"])
+        lines.append(
+            f"sequence={run['append_sequence']}; run_id={_json_id(run['run_id'])}; terminal_state={run['terminal_state']}; "
+            f"adjudication_count={run_count} (denominator: 1 retained eligible terminal run record); "
+            f"overturn_count={run_overturn} (denominator: {run_count} recorded adjudications); "
+            f"unavailable_source_count={unavailable} (denominator: 5 source families)."
+        )
+    lines.extend((COVERAGE, LIMITATION, ADVISORY))
+    return "\n".join(lines)
+
+
+def _cmd_render(args: argparse.Namespace) -> str:
+    path = Path(args.store)
+    with _store_lock(path, exclusive=False):
+        store, _, _ = _read_store(path)
+    return _render(store, args.window)
+
+
+def _cmd_validate(args: argparse.Namespace) -> str:
+    path = Path(args.store)
+    with _store_lock(path, exclusive=False):
+        store, _, _ = _read_store(path)
+    return (
+        f"[ARS-ADJUDICATION-ACTIVITY] valid store_id={_json_id(store['store_id'])}; "
+        f"retained_runs={len(store['runs'])}; revision={store['revision']}; next_sequence={store['next_sequence']}"
+    )
+
+
+def _confirmation(store_id: str, expected_hash: str, raw: bytes) -> None:
+    if not HEX_RE.fullmatch(expected_hash) or hashlib.sha256(raw).hexdigest() != expected_hash:
+        raise ActivityError("DELETE_CONFIRMATION", "store raw-byte hash confirmation mismatch")
+    if store_id is None:
+        raise ActivityError("DELETE_CONFIRMATION", "store id confirmation is required")
+
+
+def _cmd_delete_runs(args: argparse.Namespace) -> str:
+    path = Path(args.store)
+    with _store_lock(path, exclusive=True):
+        store, raw, store_identity = _read_store(path)
+        _confirmation(args.store_id, args.expect_store_sha256, raw)
+        if store["store_id"] != args.store_id:
+            raise ActivityError("DELETE_CONFIRMATION", "store id confirmation mismatch")
+        if args.run_id:
+            if len(args.run_id) != len(set(args.run_id)):
+                raise ActivityError("DELETE_CONFIRMATION", "run id deletion set has duplicates")
+            wanted = set(args.run_id)
+            existing = {run["run_id"] for run in store["runs"]}
+            if not wanted or not wanted <= existing:
+                raise ActivityError("DELETE_CONFIRMATION", "run id deletion target mismatch")
+            survivors = [run for run in store["runs"] if run["run_id"] not in wanted]
+        else:
+            try:
+                first_text, last_text = args.sequence_range.split(":", 1)
+                first, last = int(first_text), int(last_text)
+            except (AttributeError, ValueError):
+                raise ActivityError("DELETE_CONFIRMATION", "invalid sequence range") from None
+            if first < 1 or first > last:
+                raise ActivityError("DELETE_CONFIRMATION", "invalid sequence range")
+            selected = {run["append_sequence"] for run in store["runs"] if first <= run["append_sequence"] <= last}
+            if not selected:
+                raise ActivityError("DELETE_CONFIRMATION", "sequence range selects no retained run")
+            survivors = [run for run in store["runs"] if run["append_sequence"] not in selected]
+        deleted = len(store["runs"]) - len(survivors)
+        candidate = copy.deepcopy(store)
+        candidate["runs"] = survivors
+        candidate["revision"] += 1
+        _atomic_replace(path, _store_bytes(candidate), expected_identity=store_identity)
+    return f"[ARS-ADJUDICATION-ACTIVITY] deleted_runs={deleted}; revision={candidate['revision']}; next_sequence={candidate['next_sequence']}"
+
+
+def _cmd_delete_store(args: argparse.Namespace) -> str:
+    if args.confirm != "DELETE-ADJUDICATION-ACTIVITY-STORE":
+        raise ActivityError("DELETE_CONFIRMATION", "whole-store confirmation token mismatch")
+    path = Path(args.store)
+    with _store_lock(path, exclusive=True):
+        raw, store_identity = _read_limited_identity(path, MAX_STORE, code="STORE")
+        _confirmation(args.store_id, args.expect_store_sha256, raw)
+        try:
+            parsed = strict_json(raw, code="STORE")
+            if raw != canonical_bytes(parsed, code="STORE") + b"\n":
+                raise ActivityError("STORE", "store bytes are noncanonical")
+            store = _validate_store(parsed)
+        except ActivityError:
+            store = None
+        if store is not None and store["store_id"] != args.store_id:
+            raise ActivityError("DELETE_CONFIRMATION", "store id confirmation mismatch")
+        try:
+            _assert_identity(path, store_identity)
+            os.unlink(path)
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError as exc:
+            raise ActivityError("WRITE", f"store deletion failed: {exc.__class__.__name__}") from None
+    return "[ARS-ADJUDICATION-ACTIVITY] deleted_store=true"
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise ActivityError("USAGE", message)
+
+
+def build_cli_parser() -> argparse.ArgumentParser:
+    parser = _Parser(prog="adjudication_activity.py")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init-store")
+    init_parser.add_argument("--store", required=True)
+    init_parser.add_argument("--store-id", required=True)
+    init_parser.set_defaults(handler=_cmd_init)
+
+    build_parser = subparsers.add_parser("build-input")
+    build_parser.add_argument("--state", required=True)
+    build_parser.add_argument("--artifact-root", required=True)
+    build_parser.add_argument("--store-id", required=True)
+    build_parser.add_argument("--output", required=True)
+    build_parser.set_defaults(handler=_cmd_build)
+
+    append_parser = subparsers.add_parser("append-run")
+    append_parser.add_argument("--store", required=True)
+    append_parser.add_argument("--artifact-root", required=True)
+    append_parser.add_argument("--input", required=True)
+    append_parser.set_defaults(handler=_cmd_append)
+
+    render_parser = subparsers.add_parser("render")
+    render_parser.add_argument("--store", required=True)
+    render_parser.add_argument("--window", type=int, default=10)
+    render_parser.set_defaults(handler=_cmd_render)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--store", required=True)
+    validate_parser.set_defaults(handler=_cmd_validate)
+
+    delete_runs_parser = subparsers.add_parser("delete-runs")
+    delete_runs_parser.add_argument("--store", required=True)
+    delete_runs_parser.add_argument("--store-id", required=True)
+    delete_runs_parser.add_argument("--expect-store-sha256", required=True)
+    selection = delete_runs_parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--run-id", action="append")
+    selection.add_argument("--sequence-range")
+    delete_runs_parser.set_defaults(handler=_cmd_delete_runs)
+
+    delete_store_parser = subparsers.add_parser("delete-store")
+    delete_store_parser.add_argument("--store", required=True)
+    delete_store_parser.add_argument("--store-id", required=True)
+    delete_store_parser.add_argument("--expect-store-sha256", required=True)
+    delete_store_parser.add_argument("--confirm", required=True)
+    delete_store_parser.set_defaults(handler=_cmd_delete_store)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = build_cli_parser().parse_args(argv)
+        if getattr(args, "window", 10) not in range(2, 51):
+            raise ActivityError("USAGE", "window must be in the closed range 2..50")
+        output = args.handler(args)
+        if output:
+            print(output)
+        return 0
+    except ActivityError as exc:
+        print(f"[ARS-ADJUDICATION-ACTIVITY ERROR:{exc.code}] {exc.detail}", file=sys.stderr)
+        return EXIT_BY_CODE[exc.code]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_673_adjudication_activity.py
+++ b/scripts/check_673_adjudication_activity.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""Deterministic static integration guard for #673 adjudication activity.
+
+This checker deliberately does not execute the recorder.  It pins the closed
+schemas, exact renderer language, hermetic CLI surface, terminal-first wiring,
+terminal source authority, and the advisory-only/non-consumer boundary that
+could otherwise drift independently of the focused runtime tests.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SPEC = Path("docs/design/2026-08-10-673-cross-run-adjudication-activity-spec.md")
+INPUT_SCHEMA = Path(
+    "shared/contracts/activity/adjudication_activity_input.schema.json"
+)
+STORE_SCHEMA = Path(
+    "shared/contracts/activity/adjudication_activity_store.schema.json"
+)
+RUNTIME = Path("scripts/adjudication_activity.py")
+
+STATE_TRACKER = Path("academic-pipeline/agents/state_tracker_agent.md")
+ORCHESTRATOR = Path("academic-pipeline/agents/pipeline_orchestrator_agent.md")
+PIPELINE_SKILL = Path("academic-pipeline/SKILL.md")
+STATE_MACHINE = Path("academic-pipeline/references/pipeline_state_machine.md")
+PROCESS_SUMMARY = Path("academic-pipeline/references/process_summary_protocol.md")
+COMPLIANCE = Path("shared/compliance_checkpoint_protocol.md")
+HANDOFFS = Path("shared/handoff_schemas.md")
+
+FROZEN_FILES = (SPEC, INPUT_SCHEMA, STORE_SCHEMA)
+WIRING_FILES = (
+    STATE_TRACKER,
+    ORCHESTRATOR,
+    PIPELINE_SKILL,
+    STATE_MACHINE,
+    PROCESS_SUMMARY,
+    COMPLIANCE,
+    HANDOFFS,
+)
+NON_CONSUMER_GLOBS = (
+    "academic-paper/**/*.md",
+    "academic-paper-reviewer/**/*.md",
+    "academic-pipeline/**/*.md",
+    "shared/**/*.md",
+    "shared/contracts/**/*.json",
+)
+EXECUTION_GLOBS = (
+    "scripts/**/*.py",
+    "scripts/**/*.sh",
+    "hooks/**/*.sh",
+    "tools/**/*.sh",
+    ".github/**/*.sh",
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+)
+PYTHON_EXECUTION_WHITELIST = {
+    RUNTIME,
+    Path("scripts/check_673_adjudication_activity.py"),
+    Path("scripts/test_adjudication_activity.py"),
+    Path("scripts/test_check_673_adjudication_activity.py"),
+    # Prompt-size regression test names the bounded #673 documentation block;
+    # it neither imports nor executes the activity runtime.
+    Path("scripts/test_v3_6_7_phase_6_6.py"),
+}
+
+LIMITATION_SENTENCE = (
+    "This records explicit adjudication activity only. It cannot determine "
+    "correctness, attentiveness, engagement, or whether human ownership is real; "
+    "genuine agreement and non-review can produce the same history."
+)
+ADVISORY_SENTENCE = (
+    "This series is advisory only; it never gates, blocks, scores, or changes any "
+    "verdict."
+)
+COVERAGE_LINE = (
+    "Coverage: only successfully retained records in this explicitly selected "
+    "store are shown; runs without this store selection or whose append failed "
+    "are not represented."
+)
+
+STAGES = [
+    "pipeline_stage_1",
+    "pipeline_stage_2",
+    "pipeline_stage_2_5",
+    "pipeline_stage_3",
+    "pipeline_stage_3_prime",
+    "pipeline_stage_4",
+    "pipeline_stage_4_prime",
+    "pipeline_stage_4_5",
+    "pipeline_stage_5",
+    "pipeline_stage_6",
+]
+
+CLI_COMMANDS = {
+    "init-store",
+    "build-input",
+    "append-run",
+    "render",
+    "validate",
+    "delete-runs",
+    "delete-store",
+}
+BUILD_INPUT_OPTIONS = {"--state", "--artifact-root", "--store-id", "--output"}
+
+FORBIDDEN_IMPORT_ROOTS = {
+    "anthropic",
+    "datetime",
+    "http",
+    "openai",
+    "requests",
+    "socket",
+    "subprocess",
+    "time",
+    "urllib",
+}
+FORBIDDEN_SCAN_CALLS = {
+    "glob",
+    "iglob",
+    "iterdir",
+    "listdir",
+    "rglob",
+    "scandir",
+    "walk",
+}
+
+FEATURE_RE = re.compile(
+    r"adjudication[_ -]activity|ADJUDICATION-ACTIVITY|activity[_ -](?:store|count)|"
+    r"overturn_count|adjudication_count|selected_retained_eligible_run_count",
+    re.IGNORECASE,
+)
+CONSUMER_RE = re.compile(
+    r"\b(?:input|consum(?:e|es|ed|ing)|consult|read|load|require|gate|block|score|rank|selector|select|"
+    r"determine|change|affect|dispatch|prompt|passport|handoff|process record|"
+    r"verdict)\b",
+    re.IGNORECASE,
+)
+NEGATION_RE = re.compile(
+    r"\b(?:never|not|no|cannot|must not|do not|does not|isn't|aren't|excluded|"
+    r"prohibited|forbidden|unauthorized|advisory only|observability only)\b",
+    re.IGNORECASE,
+)
+CLAUSE_SPLIT_RE = re.compile(
+    r"\s*(?:;|；)\s*|\s*,?\s*\b(?:but|however|and)\b\s*|\s*(?:，?但|，?然而)\s*",
+    re.IGNORECASE,
+)
+USER_RENDER_READ_RE = re.compile(
+    r"\busers?\s+(?:may|can)\s+(?:read|view)\b.*\brender(?:er|ed)?\s+output\b",
+    re.IGNORECASE,
+)
+RUNTIME_IMPORT_RE = re.compile(
+    r"(?:from\s+scripts\.adjudication_activity\s+import\b|"
+    r"from\s+scripts\s+import\s+adjudication_activity\b|"
+    r"import\s+(?:scripts\.)?adjudication_activity\b)"
+)
+
+
+class DuplicateKeyError(ValueError):
+    """Raised when strict JSON loading observes a duplicate object key."""
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise DuplicateKeyError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(
+        path.read_text(encoding="utf-8"),
+        object_pairs_hook=_pairs,
+        parse_constant=lambda token: (_ for _ in ()).throw(
+            ValueError(f"non-finite JSON constant {token!r}")
+        ),
+    )
+    if not isinstance(value, dict):
+        raise ValueError("top level must be an object")
+    return value
+
+
+def check_schema_contracts(input_schema: dict[str, Any], store_schema: dict[str, Any]) -> list[str]:
+    """Return closed-schema errors for the cross-file frozen invariants."""
+    errors: list[str] = []
+    for label, schema in (("input", input_schema), ("store", store_schema)):
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:  # SchemaError varies across jsonschema releases.
+            errors.append(f"{label} schema is not Draft 2020-12 valid: {exc}")
+        if schema.get("additionalProperties") is not False:
+            errors.append(f"{label} schema root is not closed")
+        stage_enum = schema.get("$defs", {}).get("pipeline_stage", {}).get("enum")
+        if stage_enum != STAGES:
+            errors.append(f"{label} schema full Stage 1..6 enum drifted")
+
+    input_text = json.dumps(input_schema, ensure_ascii=False, sort_keys=True)
+    store_text = json.dumps(store_schema, ensure_ascii=False, sort_keys=True)
+    if "source_stage" in input_text or "source_stage" in store_text:
+        errors.append("retired source_stage reappeared in an activity schema")
+    if "pipeline_stage_0" in input_text or "pipeline_stage_0" in store_text:
+        errors.append("retired pipeline_stage_0 reappeared in an activity schema")
+
+    forbidden_input_properties = {
+        "events",
+        "event_count",
+        "adjudication_count",
+        "overturn_count",
+        "overturn",
+        "rate",
+        "score",
+        "target",
+        "threshold",
+    }
+    root_properties = set(input_schema.get("properties", {}))
+    leaked = sorted(root_properties & forbidden_input_properties)
+    if leaked:
+        errors.append(f"input schema accepts caller-derived fields: {', '.join(leaked)}")
+
+    artifact_hashes = store_schema.get("$defs", {}).get("source_receipt", {}).get(
+        "properties", {}
+    ).get("artifact_sha256s", {})
+    if artifact_hashes.get("uniqueItems") is True:
+        errors.append("store artifact_sha256s illegally reject legitimate repeated hashes")
+
+    run_record = store_schema.get("$defs", {}).get("run_record", {})
+    if run_record.get("properties", {}).get("sealed", {}).get("const") is not True:
+        errors.append("store run records are no longer sealed")
+    return errors
+
+
+def _call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _parser_surface(tree: ast.AST) -> tuple[set[str], dict[str, set[str]]]:
+    """Extract argparse add_parser commands and long options by parser variable."""
+    commands: set[str] = set()
+    parser_vars: dict[str, str] = {}
+    options: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Call) or _call_name(value) != "add_parser":
+            continue
+        if not value.args or not isinstance(value.args[0], ast.Constant):
+            continue
+        command = value.args[0].value
+        if not isinstance(command, str):
+            continue
+        commands.add(command)
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                parser_vars[target.id] = command
+                options.setdefault(command, set())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_name(node) != "add_argument":
+            continue
+        if not isinstance(node.func, ast.Attribute) or not isinstance(node.func.value, ast.Name):
+            continue
+        command = parser_vars.get(node.func.value.id)
+        if command is None:
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                if arg.value.startswith("--"):
+                    options[command].add(arg.value)
+    return commands, options
+
+
+def _subscript_key(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Subscript):
+        return None
+    value = node.slice
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value.value
+    return None
+
+
+def _authority_ast_checks(
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+) -> list[str]:
+    """Pin the state-inventory read and exact manifest-source comparison."""
+    errors: list[str] = []
+    validator = functions.get("_validate_manifest_authority")
+    if validator is None:
+        return ["runtime missing _validate_manifest_authority"]
+
+    inventory_names: set[str] = set()
+    for node in ast.walk(validator):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Attribute)
+            and isinstance(value.func.value, ast.Name)
+            and value.func.value.id == "state"
+            and value.func.attr == "get"
+            and value.args
+            and isinstance(value.args[0], ast.Constant)
+            and value.args[0].value == "adjudication_activity_sources"
+        ):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        inventory_names.update(
+            target.id for target in targets if isinstance(target, ast.Name)
+        )
+    if not inventory_names:
+        errors.append(
+            "_validate_manifest_authority does not read state adjudication_activity_sources"
+        )
+
+    exact_compare = False
+    for node in ast.walk(validator):
+        if not (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and len(node.test.ops) == 1
+            and isinstance(node.test.ops[0], ast.NotEq)
+            and len(node.test.comparators) == 1
+            and any(isinstance(child, ast.Raise) for child in ast.walk(node))
+        ):
+            continue
+        sides = (node.test.left, node.test.comparators[0])
+        has_inventory = any(
+            isinstance(side, ast.Name) and side.id in inventory_names for side in sides
+        )
+        has_manifest_sources = any(
+            isinstance(side, ast.Subscript)
+            and isinstance(side.value, ast.Name)
+            and side.value.id == "manifest"
+            and _subscript_key(side) == "sources"
+            for side in sides
+        )
+        if has_inventory and has_manifest_sources:
+            exact_compare = True
+            break
+    if not exact_compare:
+        errors.append(
+            "_validate_manifest_authority does not exact-compare sealed inventory "
+            "with manifest sources"
+        )
+
+    build = functions.get("_cmd_build")
+    if build is None:
+        errors.append("runtime missing build-input handler _cmd_build")
+    else:
+        used_args = {
+            node.attr
+            for node in ast.walk(build)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "args"
+        }
+        allowed_args = {"state", "artifact_root", "store_id", "output"}
+        indirect_args = any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "vars"}
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "args"
+            for node in ast.walk(build)
+        )
+        unexpected = sorted(used_args - allowed_args)
+        if unexpected or indirect_args or used_args != allowed_args:
+            errors.append(
+                "build-input handler reads caller source/hash arguments: "
+                + (", ".join(unexpected) if unexpected else "indirect or incomplete args")
+            )
+    return errors
+
+
+def check_runtime_text(text: str) -> list[str]:
+    """Check the hermetic runtime and exact public surface without executing it."""
+    errors: list[str] = []
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as exc:
+        return [f"runtime is not valid Python: {exc}"]
+
+    commands, options = _parser_surface(tree)
+    if commands != CLI_COMMANDS:
+        errors.append(
+            "CLI command surface drifted: expected "
+            f"{sorted(CLI_COMMANDS)}, got {sorted(commands)}"
+        )
+    build_options = options.get("build-input", set())
+    if build_options != BUILD_INPUT_OPTIONS:
+        errors.append(
+            "build-input must accept only explicit state/artifact-root/store-id/output; "
+            f"got {sorted(build_options)}"
+        )
+
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    errors.extend(_authority_ast_checks(functions))
+    seal_function = functions.get("seal_terminal_inventory")
+    if seal_function is None:
+        errors.append("runtime missing deterministic seal_terminal_inventory entry point")
+    else:
+        positional = [
+            *seal_function.args.posonlyargs,
+            *seal_function.args.args,
+        ]
+        if [argument.arg for argument in positional] != [
+            "state_path",
+            "artifact_root",
+            "pending_bindings",
+        ] or seal_function.args.defaults:
+            errors.append(
+                "seal_terminal_inventory must require exactly "
+                "(state_path, artifact_root, pending_bindings)"
+            )
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name.split(".", 1)[0] for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [(node.module or "").split(".", 1)[0]]
+        else:
+            names = []
+        for name in names:
+            if name in FORBIDDEN_IMPORT_ROOTS:
+                errors.append(f"runtime imports forbidden model/network/clock/process module {name}")
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            if name in FORBIDDEN_SCAN_CALLS:
+                errors.append(f"runtime performs forbidden ambient scan {name}()")
+            if name == "getenv":
+                errors.append("runtime reads environment state")
+        if isinstance(node, ast.Attribute) and node.attr == "environ":
+            errors.append("runtime reads environment state")
+
+    for exact in (LIMITATION_SENTENCE, ADVISORY_SENTENCE, COVERAGE_LINE):
+        if exact not in text:
+            errors.append(f"runtime missing exact renderer text: {exact}")
+    for authority in ("run_id", "adjudication_activity_sources", "sealed"):
+        if authority not in text:
+            errors.append(f"runtime missing terminal source authority token {authority}")
+    return sorted(set(errors))
+
+
+def _has_all(text: str, needles: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return all(needle.lower() in lowered for needle in needles)
+
+
+def check_spec_text(text: str) -> list[str]:
+    """Pin the three exact public renderer strings in the frozen contract."""
+    return [
+        f"frozen spec missing exact renderer text: {exact}"
+        for exact in (LIMITATION_SENTENCE, ADVISORY_SENTENCE, COVERAGE_LINE)
+        if exact not in text
+    ]
+
+
+def check_retired_tokens(path: Path, text: str) -> list[str]:
+    """Reject the two retired stage spellings across the production surface."""
+    return [
+        f"{path}: retired token {token} reappeared"
+        for token in ("source_stage", "pipeline_stage_0")
+        if token in text
+    ]
+
+
+def check_wiring_texts(texts: dict[Path, str]) -> list[str]:
+    """Pin producer, terminal-first, exact-authority, and advisory integration."""
+    errors: list[str] = []
+    state = texts.get(STATE_TRACKER, "")
+    if not _has_all(
+        state,
+        (
+            "run_id",
+            "pending_adjudication_activity_bindings",
+            "adjudication_activity_sources",
+            "sealed",
+            "five",
+        ),
+    ):
+        errors.append("state tracker missing pending producer wiring or sealed five-row authority")
+
+    orchestrator = texts.get(ORCHESTRATOR, "")
+    terminal_bundle = "\n".join(
+        texts.get(path, "")
+        for path in (ORCHESTRATOR, PIPELINE_SKILL, STATE_MACHINE, PROCESS_SUMMARY)
+    )
+    for needle in (
+        "seal_terminal_inventory",
+        "build-input",
+        "append-run",
+        "render",
+        "post-terminal",
+        "best-effort",
+    ):
+        if needle.lower() not in terminal_bundle.lower():
+            errors.append(f"post-terminal wiring missing {needle}")
+    first = terminal_bundle.lower().find("terminal transition")
+    seal = terminal_bundle.lower().find("seal_terminal_inventory")
+    if first < 0 or seal < 0 or first > seal:
+        errors.append("terminal-first order is not explicit before inventory sealing")
+    if not _has_all(orchestrator, ("already", "terminal", "advisory")):
+        errors.append("orchestrator does not preserve the already-durable terminal outcome")
+
+    authority_bundle = state + "\n" + orchestrator
+    if not _has_all(
+        authority_bundle,
+        ("run_id", "adjudication_activity_sources", "exact", "sealed", "build-input"),
+    ):
+        errors.append("run_id plus sealed adjudication_activity_sources authority drifted")
+
+    compliance = texts.get(COMPLIANCE, "")
+    if not _has_all(
+        compliance,
+        ("compliance_override_action_receipt", "best-effort", "after"),
+    ):
+        errors.append("compliance producer lacks paired post-action best-effort receipt wiring")
+
+    handoffs = texts.get(HANDOFFS, "")
+    if not _has_all(handoffs, ("adjudication activity", "never", "material passport", "handoff")):
+        errors.append("handoff contract lacks explicit activity-store non-consumer boundary")
+    process_summary = texts.get(PROCESS_SUMMARY, "")
+    if not (
+        FEATURE_RE.search(process_summary)
+        and "process record" in process_summary.lower()
+        and re.search(r"\b(?:never|must not|does not)\b", process_summary, re.I)
+    ):
+        errors.append("Process Record contract lacks explicit activity-store exclusion")
+    return errors
+
+
+def check_non_consumer_text(path: Path, text: str) -> list[str]:
+    """Reject affirmative activity consumers while allowing explicit prohibitions."""
+    errors: list[str] = []
+    offset = 1
+    for paragraph in re.split(r"\n\s*\n", text):
+        number = offset
+        offset += paragraph.count("\n") + 2
+        flattened = " ".join(line.strip() for line in paragraph.splitlines())
+        for sentence in re.split(r"(?<=[.!?])\s+", flattened):
+            for clause in CLAUSE_SPLIT_RE.split(sentence):
+                if not clause:
+                    continue
+            # `build-input` is the closed post-terminal producer command, not
+            # an assertion that the activity artifact is a downstream input.
+                consumer_view = re.sub(
+                    r"\bbuild-input\b", "producer-command", clause, flags=re.I
+                )
+                if not FEATURE_RE.search(clause) or not CONSUMER_RE.search(consumer_view):
+                    continue
+                if USER_RENDER_READ_RE.search(clause):
+                    continue
+                if NEGATION_RE.search(clause):
+                    continue
+                errors.append(
+                    f"{path}:{number}: affirmative activity consumer: {clause[:180]}"
+                )
+    return errors
+
+
+def check_execution_surface(path: Path, text: str) -> list[str]:
+    """Reject hidden Python/workflow/shell consumers outside exact owners."""
+    feature = bool(FEATURE_RE.search(text))
+    runtime_import = bool(RUNTIME_IMPORT_RE.search(text))
+    if path.suffix == ".py":
+        if path in PYTHON_EXECUTION_WHITELIST:
+            return []
+        if feature or runtime_import:
+            return [f"{path}: non-whitelisted production Python activity consumer"]
+        return []
+
+    errors: list[str] = []
+    if "scripts/adjudication_activity.py" in text or runtime_import:
+        errors.append(f"{path}: execution surface invokes/imports activity runtime")
+    for number, line in enumerate(text.splitlines(), start=1):
+        if not FEATURE_RE.search(line):
+            continue
+        allowed_workflow_line = path == Path(".github/workflows/spec-consistency.yml") and (
+            "Check adjudication-activity advisory integration (#673)" in line
+            or "python3 scripts/check_673_adjudication_activity.py" in line
+        )
+        if not allowed_workflow_line:
+            errors.append(f"{path}:{number}: non-whitelisted execution-surface activity token")
+    errors.extend(check_non_consumer_text(path, text))
+    return errors
+
+
+def run_checks(root: Path = REPO_ROOT) -> list[str]:
+    errors: list[str] = []
+    for relative in (*FROZEN_FILES, RUNTIME, *WIRING_FILES):
+        if not (root / relative).is_file():
+            errors.append(f"missing required #673 file: {relative}")
+    if errors:
+        return errors
+
+    try:
+        spec = (root / SPEC).read_text(encoding="utf-8")
+        input_schema = _load_json(root / INPUT_SCHEMA)
+        store_schema = _load_json(root / STORE_SCHEMA)
+        runtime = (root / RUNTIME).read_text(encoding="utf-8")
+        wiring = {
+            path: (root / path).read_text(encoding="utf-8") for path in WIRING_FILES
+        }
+    except (OSError, UnicodeError, ValueError, DuplicateKeyError) as exc:
+        return [f"#673 file load failed: {exc}"]
+
+    errors.extend(check_spec_text(spec))
+    errors.extend(check_retired_tokens(SPEC, spec))
+    errors.extend(check_schema_contracts(input_schema, store_schema))
+    errors.extend(check_runtime_text(runtime))
+    errors.extend(check_retired_tokens(RUNTIME, runtime))
+    errors.extend(check_wiring_texts(wiring))
+    for path, text in wiring.items():
+        errors.extend(check_retired_tokens(path, text))
+    scanned: set[Path] = set()
+    for pattern in NON_CONSUMER_GLOBS:
+        for absolute in sorted(root.glob(pattern)):
+            if not absolute.is_file():
+                continue
+            relative = absolute.relative_to(root)
+            if relative in (INPUT_SCHEMA, STORE_SCHEMA) or relative in scanned:
+                continue
+            scanned.add(relative)
+            try:
+                text = absolute.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                errors.append(f"{relative}: non-consumer scan failed: {exc}")
+                continue
+            errors.extend(check_non_consumer_text(relative, text))
+    execution_scanned: set[Path] = set()
+    for pattern in EXECUTION_GLOBS:
+        for absolute in sorted(root.glob(pattern)):
+            if not absolute.is_file():
+                continue
+            relative = absolute.relative_to(root)
+            if relative in execution_scanned:
+                continue
+            execution_scanned.add(relative)
+            try:
+                text = absolute.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                errors.append(f"{relative}: execution-surface scan failed: {exc}")
+                continue
+            errors.extend(check_execution_surface(relative, text))
+    return sorted(set(errors))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args(argv)
+    errors = run_checks(args.root.resolve())
+    if errors:
+        print("check_673_adjudication_activity: FAIL", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("check_673_adjudication_activity: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pipeline_boundary_semantics.py
+++ b/scripts/check_pipeline_boundary_semantics.py
@@ -70,11 +70,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # reviewed against the #528 resolutions.
 # ---------------------------------------------------------------------------
 CONTENT_LOCKS = {
-    "academic-pipeline/SKILL.md": "c97cf0d8772263eae57e708afb3184e6f811c9001313cbe7e7dddf47f6a4b04f",
-    "academic-pipeline/agents/pipeline_orchestrator_agent.md": "6de8026e035006cf5adc990162c819ff3b3c69a14125aeecdbe9cd44c31921a1",
-    "academic-pipeline/agents/state_tracker_agent.md": "1222cf0ca75646cb5e0a5e27fba344e15f45ea45df4ed5ce10301cbf5bf265d8",
-    "academic-pipeline/references/pipeline_state_machine.md": "e47fc3fc2b883a06b68f8cc1dec8896463be3bee8858e319448f9e03c085e3a0",
-    "academic-pipeline/references/process_summary_protocol.md": "5c7053230d73b39d0a5d9d6f5e9f339c12570ae6d3aa2eae2eaf74f51d571e94",
+    "academic-pipeline/SKILL.md": "e86d4ecd991fbcebeb01b4595b62544deca92f123b9d4689c8c309f4413f4406",
+    "academic-pipeline/agents/pipeline_orchestrator_agent.md": "722f38126d54a65cef641f686ba8ba2b3d54bc6f97fbd4fecf3841cd0630884d",
+    "academic-pipeline/agents/state_tracker_agent.md": "2274abada1be9eaabbbfcb762ab75610121993b7e6fe4a7d5af4c4f975ce464b",
+    "academic-pipeline/references/pipeline_state_machine.md": "a9bfad44e24f6553cb42b77190eea64e2db796d9caeae08bd3df233cb4ef93e6",
+    "academic-pipeline/references/process_summary_protocol.md": "1052d8cb8ee00c1cd0fcc70a18aee5a0f92db2ebe0a74930b04d4b05d888cfdf",
 }
 
 SKILL = "academic-pipeline/SKILL.md"
@@ -180,7 +180,7 @@ PROTO_DECLINE_PIN = "Stage 6 is non-mandatory — the user may decline it at tha
 # Type-bearing completion-checkpoint triggers on the mirrors (codex round-6
 # P1: a (FULL)->(MANDATORY) flip on either mirror stayed green).
 ORCH_STAGE56_TRIGGER_PIN = "Dispatched only after the user confirms the Stage 5 completion checkpoint (FULL)"
-ORCH_STAGE56_HANDOFF_ROW = "| Stage 5 -> 6 | Final deliverables list + pipeline state history (state_tracker JSON, agent logs) | — (Process Record; no numbered schema) | Dispatched only after the user confirms the Stage 5 completion checkpoint (FULL). User may decline Stage 6 there: mark it `skipped`, set pipeline state `completed`. Protocol: `../references/process_summary_protocol.md`; terminal semantics: `../references/pipeline_state_machine.md` § Stage 6 terminal semantics |"
+ORCH_STAGE56_HANDOFF_ROW = "| Stage 5 -> 6 | Final deliverables list + Process-Summary projection of pipeline state history and agent logs, explicitly omitting the #673 activity projection of terminal root `run_id`, pending/sealed activity fields, selected-store data, renderer output, and diagnostics | — (Process Record; no numbered schema) | Dispatched only after the user confirms the Stage 5 completion checkpoint (FULL). User may decline Stage 6 there: mark it `skipped`, set pipeline state `completed`. Protocol: `../references/process_summary_protocol.md`; terminal semantics: `../references/pipeline_state_machine.md` § Stage 6 terminal semantics |"
 PROTO_TRIGGER_PIN = "After the user confirms the Stage 5 completion checkpoint (FULL)"
 # Delivery-before-acknowledgement sequencing (codex round-6 P1: on->before /
 # After->Before mutations stayed green).
@@ -191,7 +191,7 @@ PROTO_STEP5_HEADER = "5. Terminal acknowledgement (pipeline terminal checkpoint)
 PROTO_NO_NEXT_STAGE = "There is no next stage."
 # SKILL Step 4 handoff line (codex round-7 P1: the executing transition list
 # could reverse the decline option while the Stage 6 section stayed pinned).
-SKILL_STEP4_HANDOFF = "- Stage 5  --> 6: Pass final deliverables list + pipeline state history to Process Summary (user may decline Stage 6 at the Stage 5 completion checkpoint)"
+SKILL_STEP4_HANDOFF = "- Stage 5  --> 6: Pass final deliverables list + the Process-Summary projection of pipeline state history, omitting the #673 activity projection of terminal root `run_id`, pending/sealed activity fields, selected-store data, renderer output, and diagnostics (user may decline Stage 6 at the Stage 5 completion checkpoint)"
 
 # The #528/#529 diagram edges (codex round-7 P1: the ASCII diagram is an
 # operative surface too — a /Minor -> /Reject or relabeled terminal edge

--- a/scripts/fixtures/adjudication_activity/author_stage3.json
+++ b/scripts/fixtures/adjudication_activity/author_stage3.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "author-adjudication/1.0",
+  "revision_round": 1,
+  "roadmap_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "base_draft_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "claim_surface_manifest_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+  "adjudication_status": "complete",
+  "author_events": [
+    {
+      "event_id": "AUTHOR-EVENT-ONE",
+      "source": "explicit_session_user_message",
+      "actor_role": "author",
+      "input_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "display_order": {
+    "mode": "source_traceability",
+    "item_ids": ["REV-001"],
+    "author_event_id": "AUTHOR-EVENT-ONE"
+  },
+  "author_adjudications": [
+    {
+      "item_id": "REV-001",
+      "author_event_id": "AUTHOR-EVENT-ONE",
+      "author_triage": "wont_address",
+      "author_reason": "Fixture rationale is transient and must not enter the store.",
+      "authorized_targets": [],
+      "claim_strength_authorizations": []
+    }
+  ],
+  "collateral_authorizations": []
+}

--- a/scripts/fixtures/adjudication_activity/author_stage3_input.json
+++ b/scripts/fixtures/adjudication_activity/author_stage3_input.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "author-adjudication-input/1.0",
+  "author_events": [
+    {
+      "event_id": "AUTHOR-EVENT-ONE",
+      "source": "explicit_session_user_message",
+      "actor_role": "author",
+      "input_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "display_order": {
+    "mode": "source_traceability",
+    "item_ids": ["REV-001"],
+    "author_event_id": "AUTHOR-EVENT-ONE"
+  },
+  "author_adjudications": [
+    {
+      "item_id": "REV-001",
+      "author_event_id": "AUTHOR-EVENT-ONE",
+      "author_triage": "wont_address",
+      "author_reason": "Fixture rationale is transient and must not enter the store.",
+      "authorized_targets": [],
+      "claim_strength_authorizations": []
+    }
+  ],
+  "collateral_authorizations": []
+}

--- a/scripts/fixtures/adjudication_activity/author_stage3_prime.json
+++ b/scripts/fixtures/adjudication_activity/author_stage3_prime.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "author-adjudication/1.0",
+  "revision_round": 2,
+  "roadmap_sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+  "base_draft_sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+  "claim_surface_manifest_sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+  "adjudication_status": "complete",
+  "author_events": [
+    {
+      "event_id": "AUTHOR-EVENT-TWO",
+      "source": "explicit_session_user_message",
+      "actor_role": "author",
+      "input_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "display_order": {
+    "mode": "source_traceability",
+    "item_ids": ["REV-002"],
+    "author_event_id": "AUTHOR-EVENT-TWO"
+  },
+  "author_adjudications": [
+    {
+      "item_id": "REV-002",
+      "author_event_id": "AUTHOR-EVENT-TWO",
+      "author_triage": "not_on_point",
+      "author_reason": "Second transient fixture rationale.",
+      "authorized_targets": [],
+      "claim_strength_authorizations": []
+    }
+  ],
+  "collateral_authorizations": []
+}

--- a/scripts/fixtures/adjudication_activity/author_stage3_prime_input.json
+++ b/scripts/fixtures/adjudication_activity/author_stage3_prime_input.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "author-adjudication-input/1.0",
+  "author_events": [
+    {
+      "event_id": "AUTHOR-EVENT-TWO",
+      "source": "explicit_session_user_message",
+      "actor_role": "author",
+      "input_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "display_order": {
+    "mode": "source_traceability",
+    "item_ids": ["REV-002"],
+    "author_event_id": "AUTHOR-EVENT-TWO"
+  },
+  "author_adjudications": [
+    {
+      "item_id": "REV-002",
+      "author_event_id": "AUTHOR-EVENT-TWO",
+      "author_triage": "not_on_point",
+      "author_reason": "Second transient fixture rationale.",
+      "authorized_targets": [],
+      "claim_strength_authorizations": []
+    }
+  ],
+  "collateral_authorizations": []
+}

--- a/scripts/fixtures/adjudication_activity/compliance_override.json
+++ b/scripts/fixtures/adjudication_activity/compliance_override.json
@@ -1,0 +1,50 @@
+{
+  "mode": "systematic_review",
+  "stage": "2.5",
+  "generated_at": "2026-04-20T10:00:00Z",
+  "prisma_trAIce": {
+    "items_total": 17,
+    "by_tier": {
+      "mandatory": {"total": 9, "pass": 8, "fail": ["M4"]},
+      "highly_recommended": {"total": 1, "pass": 1, "fail": []},
+      "recommended": {"total": 4, "pass": 4, "fail": []},
+      "optional": {"total": 3, "pass": 3, "fail": []}
+    },
+    "block_decision": "block"
+  },
+  "raise": {
+    "mode": "full",
+    "principles": {
+      "human_oversight": "pass",
+      "transparency": "pass",
+      "reproducibility": "pass",
+      "fit_for_purpose": "pass"
+    },
+    "principle_evidence": {
+      "human_oversight": ["fixture"],
+      "transparency": ["fixture"],
+      "reproducibility": ["fixture"],
+      "fit_for_purpose": ["fixture"]
+    },
+    "roles": {
+      "evidence_synthesists": ["fixture"],
+      "ai_development_teams": [],
+      "methodologists": [],
+      "publishers": [],
+      "users": [],
+      "trainers": [],
+      "organisations": [],
+      "funders": []
+    },
+    "block_decision": "pass"
+  },
+  "overall_decision": "block",
+  "user_action_required": true,
+  "evidence": ["fixture"],
+  "user_override": {
+    "decision": true,
+    "timestamp": "2026-04-20T10:01:00Z",
+    "rationale": "Fixture override for the one recomputed blocking contributor.",
+    "scope": ["M4"]
+  }
+}

--- a/scripts/fixtures/adjudication_activity/compliance_override_action.json
+++ b/scripts/fixtures/adjudication_activity/compliance_override_action.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "adjudication-compliance-override-action/1.0",
+  "receipt_id": "COMPLIANCE-OVERRIDE-1",
+  "run_id": "run-all-events",
+  "actor_role": "user",
+  "source": "explicit_session_user_action",
+  "action": "acknowledge_compliance_limitation",
+  "stage": "pipeline_stage_2_5",
+  "scope": ["M4"],
+  "report_sha256": "0d67c5d3847d6b002e0a23288d7f6a58222abc800fccb959e37e9f04a479cd8d",
+  "override_ordinal": 1,
+  "interaction_id": "USER-COMPLIANCE-1",
+  "interaction_sha256": "ef0a0dcdceb0eccb9a2aaa68124b73cfaf547f65f5447f812a425457c71a55d6"
+}

--- a/scripts/fixtures/adjudication_activity/compliance_pass.json
+++ b/scripts/fixtures/adjudication_activity/compliance_pass.json
@@ -1,0 +1,44 @@
+{
+  "mode": "systematic_review",
+  "stage": "2.5",
+  "generated_at": "2026-04-20T10:00:00Z",
+  "prisma_trAIce": {
+    "items_total": 17,
+    "by_tier": {
+      "mandatory": {"total": 9, "pass": 9, "fail": []},
+      "highly_recommended": {"total": 1, "pass": 1, "fail": []},
+      "recommended": {"total": 4, "pass": 4, "fail": []},
+      "optional": {"total": 3, "pass": 3, "fail": []}
+    },
+    "block_decision": "pass"
+  },
+  "raise": {
+    "mode": "full",
+    "principles": {
+      "human_oversight": "pass",
+      "transparency": "pass",
+      "reproducibility": "pass",
+      "fit_for_purpose": "pass"
+    },
+    "principle_evidence": {
+      "human_oversight": ["fixture"],
+      "transparency": ["fixture"],
+      "reproducibility": ["fixture"],
+      "fit_for_purpose": ["fixture"]
+    },
+    "roles": {
+      "evidence_synthesists": ["fixture"],
+      "ai_development_teams": [],
+      "methodologists": [],
+      "publishers": [],
+      "users": [],
+      "trainers": [],
+      "organisations": [],
+      "funders": []
+    },
+    "block_decision": "pass"
+  },
+  "overall_decision": "pass",
+  "user_action_required": false,
+  "evidence": ["fixture"]
+}

--- a/scripts/fixtures/adjudication_activity/explicit_user_request_log.json
+++ b/scripts/fixtures/adjudication_activity/explicit_user_request_log.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "adjudication-explicit-user-request-log/1.0",
+  "run_id": "run-all-events",
+  "records": [
+    {
+      "request_id": "REQUEST-1",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "action": "justify_finding",
+      "stage": "pipeline_stage_3",
+      "finding_id": "REV-001",
+      "interaction_id": "USER-REQUEST-SHARED",
+      "interaction_sha256": "ecdb25466fbd5c0580ca4821a7b280637ab022c19c80dc260242836569b8a7b0"
+    },
+    {
+      "request_id": "REQUEST-2",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "action": "redo_finding",
+      "stage": "pipeline_stage_3_prime",
+      "finding_id": "REV-002",
+      "interaction_id": "USER-REQUEST-REDO",
+      "interaction_sha256": "77ee95953c5b664d667d281098209757ae0505ca9ba01dc02ac2d0231732714a"
+    }
+  ]
+}

--- a/scripts/fixtures/adjudication_activity/mandatory_checkpoint_log.json
+++ b/scripts/fixtures/adjudication_activity/mandatory_checkpoint_log.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "adjudication-mandatory-checkpoint-log/1.0",
+  "run_id": "run-all-events",
+  "records": [
+    {
+      "response_id": "RESPONSE-1",
+      "checkpoint_id": "stage-1",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_1",
+      "disposition": "proceed",
+      "interaction_id": "USER-MANDATORY-1",
+      "interaction_sha256": "9f0df35414059b150ceb7c96bdca9a0e039905734ca4154c82ea968d5cb39c4f"
+    },
+    {
+      "response_id": "RESPONSE-2",
+      "checkpoint_id": "stage-2",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_2",
+      "disposition": "skip",
+      "interaction_id": "USER-MANDATORY-2",
+      "interaction_sha256": "59e7782ba9a58e3c5c148c456c967f7661d0336b444467d77f3f812bffa90db0"
+    },
+    {
+      "response_id": "RESPONSE-3",
+      "checkpoint_id": "stage-2.5",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_2_5",
+      "disposition": "pause",
+      "interaction_id": "USER-MANDATORY-3",
+      "interaction_sha256": "5457b04643bdd484c83f55fae68d274960f61331c7d08a2ca9631453d2f1976a"
+    },
+    {
+      "response_id": "RESPONSE-4",
+      "checkpoint_id": "stage-3",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_3",
+      "disposition": "adjust",
+      "interaction_id": "USER-REQUEST-SHARED",
+      "interaction_sha256": "ecdb25466fbd5c0580ca4821a7b280637ab022c19c80dc260242836569b8a7b0"
+    },
+    {
+      "response_id": "RESPONSE-5",
+      "checkpoint_id": "stage-3-prime",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_3_prime",
+      "disposition": "view_progress",
+      "interaction_id": "USER-MANDATORY-5",
+      "interaction_sha256": "60b1c7779abbc6e756049b83d5dac53c67fd625399f0daea696d6f4415b4ada3"
+    },
+    {
+      "response_id": "RESPONSE-6",
+      "checkpoint_id": "stage-4",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_4",
+      "disposition": "redo",
+      "interaction_id": "USER-MANDATORY-6",
+      "interaction_sha256": "eac55e0845623714a75beb596266b9d799d268575355af5cf07116e1bf2d519b"
+    },
+    {
+      "response_id": "RESPONSE-7",
+      "checkpoint_id": "stage-4-prime",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_4_prime",
+      "disposition": "abort",
+      "interaction_id": "USER-MANDATORY-7",
+      "interaction_sha256": "fba035a6fbd9a40d887688e3e29fe8bbc05d2bfab98d4934d567a55599d1ea3e"
+    },
+    {
+      "response_id": "RESPONSE-8",
+      "checkpoint_id": "stage-4.5",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_4_5",
+      "disposition": "proceed",
+      "interaction_id": "USER-MANDATORY-8",
+      "interaction_sha256": "66b12ee5e3b00db2927e099e3a6d6683e2deebda6d5c0957b14d3d0bf1b4526a"
+    },
+    {
+      "response_id": "RESPONSE-9",
+      "checkpoint_id": "stage-5",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_5",
+      "disposition": "pause",
+      "interaction_id": "USER-MANDATORY-9",
+      "interaction_sha256": "d02020a9bc154468a29dfc6c7c8fb211c32a27c9bab9ff2784d7b93e545d2468"
+    },
+    {
+      "response_id": "RESPONSE-10",
+      "checkpoint_id": "stage-6",
+      "checkpoint_type": "MANDATORY",
+      "actor_role": "user",
+      "source": "explicit_session_user_action",
+      "stage": "pipeline_stage_6",
+      "disposition": "adjust",
+      "interaction_id": "USER-MANDATORY-10",
+      "interaction_sha256": "ce6816fd63c208fc00a6a7883b5b4ceaab5e0e3bc27bb9cc3e7466df72d0ecfa"
+    }
+  ]
+}

--- a/scripts/test_adjudication_activity.py
+++ b/scripts/test_adjudication_activity.py
@@ -1,0 +1,1515 @@
+#!/usr/bin/env python3
+"""Hermetic black-box and library tests for #673 adjudication activity."""
+from __future__ import annotations
+
+import copy
+import fcntl
+import hashlib
+import json
+from pathlib import Path
+from collections.abc import Callable
+from typing import Any
+
+import jsonschema
+import pytest
+
+from scripts import adjudication_activity as activity
+from scripts import check_re_review_synthesis as re_review
+from scripts.test_check_re_review_synthesis import emit, scenario_g2d
+
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts/fixtures/adjudication_activity"
+INPUT_SCHEMA = REPO / "shared/contracts/activity/adjudication_activity_input.schema.json"
+STORE_SCHEMA = REPO / "shared/contracts/activity/adjudication_activity_store.schema.json"
+STORE_ID = "ADJ-ACTIVITY-STORE-focused-tests"
+LIMITATION = (
+    "This records explicit adjudication activity only. It cannot determine correctness, "
+    "attentiveness, engagement, or whether human ownership is real; genuine agreement and "
+    "non-review can produce the same history."
+)
+ADVISORY = "This series is advisory only; it never gates, blocks, scores, or changes any verdict."
+COVERAGE = (
+    "Coverage: only successfully retained records in this explicitly selected store are "
+    "shown; runs without this store selection or whose append failed are not represented."
+)
+STAGES = (
+    "pipeline_stage_1",
+    "pipeline_stage_2",
+    "pipeline_stage_2_5",
+    "pipeline_stage_3",
+    "pipeline_stage_3_prime",
+    "pipeline_stage_4",
+    "pipeline_stage_4_prime",
+    "pipeline_stage_4_5",
+    "pipeline_stage_5",
+    "pipeline_stage_6",
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(activity.canonical_bytes(value) + b"\n")
+
+
+def _independent_digest(domain: bytes, value: Any) -> str:
+    canonical = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(domain + canonical).hexdigest()
+
+
+def _independent_interaction(run_id: str, interaction_id: str) -> str:
+    return _independent_digest(
+        b"ars.adjudication-activity.interaction/1.0\0",
+        {"run_id": run_id, "interaction_id": interaction_id},
+    )
+
+
+def _copy_fixture(root: Path, name: str) -> str:
+    destination = root / "sources" / name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes((FIXTURES / name).read_bytes())
+    return destination.relative_to(root).as_posix()
+
+
+def _artifact(
+    artifact_id: str,
+    role: str,
+    group_id: str,
+    relative_path: str,
+    stage: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "artifact_id": artifact_id,
+        "artifact_role": role,
+        "artifact_group_id": group_id,
+        "artifact_group_stage": stage,
+        "relative_path": relative_path,
+    }
+
+
+def _empty_rows(capture_state: str = "not_applicable") -> list[dict[str, Any]]:
+    reason = (
+        "not_applicable_for_run"
+        if capture_state == "not_applicable"
+        else "source_not_provided"
+    )
+    return [
+        {
+            "source_family": family,
+            "capture_state": capture_state,
+            "reason_code": reason,
+            "artifacts": [],
+        }
+        for family in activity.SOURCE_FAMILIES
+    ]
+
+
+def _terminal_state(
+    root: Path,
+    run_id: str,
+    *,
+    pipeline_state: str = "completed",
+    current_stage: str = "6",
+    status: str = "completed",
+    extra_completed: tuple[str, ...] = (),
+) -> Path:
+    stages = {current_stage: {"status": status}}
+    stages.update({stage: {"status": "completed"} for stage in extra_completed})
+    state = {
+        "run_id": run_id,
+        "pipeline_state": pipeline_state,
+        "current_stage": current_stage,
+        "stages": stages,
+    }
+    path = root / "state" / f"{run_id}.json"
+    _write(path, state)
+    return path
+
+
+def _call(capsys: pytest.CaptureFixture[str], *argv: str) -> tuple[int, str, str]:
+    code = activity.main(list(argv))
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+def _seal_and_build(
+    capsys: pytest.CaptureFixture[str],
+    root: Path,
+    state: Path,
+    rows: list[dict[str, Any]],
+    *,
+    output_name: str = "input.json",
+) -> Path:
+    activity.seal_terminal_inventory(state, root, rows)
+    output = root / output_name
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(output),
+    )
+    assert code == 0, stderr
+    assert stdout.startswith("[ARS-ADJUDICATION-ACTIVITY] built_input run_id=")
+    return output
+
+
+def _append(
+    capsys: pytest.CaptureFixture[str], root: Path, store: Path, manifest: Path
+) -> tuple[int, str, str]:
+    return _call(
+        capsys,
+        "append-run",
+        "--store",
+        str(store),
+        "--artifact-root",
+        str(root),
+        "--input",
+        str(manifest),
+    )
+
+
+def _make_re_review_chain(root: Path) -> tuple[str, str, str, str]:
+    generated = root / "generated_re_review"
+    generated.mkdir()
+    emit(generated, scenario_g2d(False))
+    manifest = _load(generated / "manifest.json")
+    precommitment = _load(generated / "precommitment.json")
+    verdict = _load(generated / "verdict_record.json")
+    traceability = _load(generated / "traceability.json")
+
+    traceability["dissent_adjudications"][0]["adjudicator"] = "user"
+    reapplication = traceability["reapplications"][0]
+    reapplication["reapplied_verdict"] = "NOT_ADDRESSED"
+    reapplication.pop("cannot_verify_reason")
+    anchor = {
+        "anchor": 'text: §6 "procedure evidence"',
+        "anchor_artifact": "manuscript",
+    }
+    reapplication["evidence_anchor"] = [anchor]
+    traceability["adjustments"] = [
+        {
+            "adjustment_id": "ADJ-1",
+            "item_id": "REV-001",
+            "from_verdict": "FULLY_ADDRESSED",
+            "to_verdict": "NOT_ADDRESSED",
+            "basis": "cross_model_adjudication",
+            "evidence_anchor": [anchor],
+            "rationale": reapplication["rationale"],
+            "source_ref": "reapplication:RAP-1",
+        }
+    ]
+    first_row = traceability["rows"][0]
+    first_row.update(
+        {
+            "verified": "NO",
+            "status": "NOT_ADDRESSED",
+            "final_verdict": "NOT_ADDRESSED",
+            "adjustment_id": "ADJ-1",
+        }
+    )
+    traceability["decision_inputs"]["per_item"][0]["final_verdict"] = "NOT_ADDRESSED"
+
+    precommitment["input_manifest_hash"] = re_review.canonical_hash(manifest)
+    verdict["precommitment_hash"] = re_review.canonical_hash(precommitment)
+    traceability["verdict_record_hash"] = re_review.canonical_hash(verdict)
+    _write(generated / "manifest.json", manifest)
+    _write(generated / "precommitment.json", precommitment)
+    _write(generated / "verdict_record.json", verdict)
+    _write(generated / "traceability.json", traceability)
+
+    for name in ("input_manifest", "precommitment", "verdict_record", "traceability"):
+        schema = REPO / "shared/contracts/re_review" / f"{name}.schema.json"
+        artifact_name = "manifest" if name == "input_manifest" else name
+        jsonschema.Draft202012Validator(_load(schema)).validate(
+            _load(generated / f"{artifact_name}.json")
+        )
+    return tuple(
+        (generated / name).relative_to(root).as_posix()
+        for name in (
+            "manifest.json",
+            "precommitment.json",
+            "verdict_record.json",
+            "traceability.json",
+        )
+    )  # type: ignore[return-value]
+
+
+def _all_event_rows(root: Path) -> list[dict[str, Any]]:
+    author_paths = [
+        _copy_fixture(root, "author_stage3_input.json"),
+        _copy_fixture(root, "author_stage3.json"),
+        _copy_fixture(root, "author_stage3_prime_input.json"),
+        _copy_fixture(root, "author_stage3_prime.json"),
+    ]
+    override_report = _copy_fixture(root, "compliance_override.json")
+    override_action = _copy_fixture(root, "compliance_override_action.json")
+    pass_report = _copy_fixture(root, "compliance_pass.json")
+    explicit_log = _copy_fixture(root, "explicit_user_request_log.json")
+    mandatory_log = _copy_fixture(root, "mandatory_checkpoint_log.json")
+    manifest, precommitment, verdict, traceability = _make_re_review_chain(root)
+    return [
+        {
+            "source_family": "revision_author_adjudication",
+            "capture_state": "captured",
+            "reason_code": None,
+            "artifacts": [
+                _artifact("author-input-3", "author_adjudication_input", "SOURCE-GROUP-author-3", author_paths[0], "pipeline_stage_3"),
+                _artifact("author-output-3", "author_adjudication", "SOURCE-GROUP-author-3", author_paths[1], "pipeline_stage_3"),
+                _artifact("author-input-3p", "author_adjudication_input", "SOURCE-GROUP-author-3p", author_paths[2], "pipeline_stage_3_prime"),
+                _artifact("author-output-3p", "author_adjudication", "SOURCE-GROUP-author-3p", author_paths[3], "pipeline_stage_3_prime"),
+            ],
+        },
+        {
+            "source_family": "compliance_report",
+            "capture_state": "captured",
+            "reason_code": None,
+            "artifacts": [
+                _artifact("compliance-override-report", "compliance_report", "SOURCE-GROUP-compliance-1", override_report),
+                _artifact("compliance-override-action", "compliance_override_action_receipt", "SOURCE-GROUP-compliance-1", override_action),
+                _artifact("compliance-pass-a", "compliance_report", "SOURCE-GROUP-compliance-2", pass_report),
+                _artifact("compliance-pass-b", "compliance_report", "SOURCE-GROUP-compliance-3", pass_report),
+            ],
+        },
+        {
+            "source_family": "re_review_traceability",
+            "capture_state": "captured",
+            "reason_code": None,
+            "artifacts": [
+                _artifact("rereview-manifest", "input_manifest", "SOURCE-GROUP-rereview", manifest),
+                _artifact("rereview-precommitment", "precommitment", "SOURCE-GROUP-rereview", precommitment),
+                _artifact("rereview-verdict", "verdict_record", "SOURCE-GROUP-rereview", verdict),
+                _artifact("rereview-traceability", "traceability", "SOURCE-GROUP-rereview", traceability),
+            ],
+        },
+        {
+            "source_family": "explicit_user_request",
+            "capture_state": "captured",
+            "reason_code": None,
+            "artifacts": [
+                _artifact("explicit-log", "explicit_user_request_log", "SOURCE-GROUP-explicit", explicit_log)
+            ],
+        },
+        {
+            "source_family": "mandatory_checkpoint_response",
+            "capture_state": "captured",
+            "reason_code": None,
+            "artifacts": [
+                _artifact("mandatory-log", "mandatory_checkpoint_response_log", "SOURCE-GROUP-mandatory", mandatory_log)
+            ],
+        },
+    ]
+
+
+def _compliance_rows(
+    root: Path,
+    run_id: str,
+    mutate_action: Callable[[dict[str, Any]], None] | None = None,
+) -> list[dict[str, Any]]:
+    report_path = _copy_fixture(root, "compliance_override.json")
+    action = _load(FIXTURES / "compliance_override_action.json")
+    action["run_id"] = run_id
+    action["interaction_sha256"] = _independent_interaction(
+        run_id, action["interaction_id"]
+    )
+    action["report_sha256"] = hashlib.sha256((root / report_path).read_bytes()).hexdigest()
+    if mutate_action is not None:
+        mutate_action(action)
+    action_path = root / "sources" / "compliance-action-dynamic.json"
+    _write(action_path, action)
+    rows = _empty_rows()
+    rows[1] = {
+        "source_family": "compliance_report",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact(
+                "compliance-report",
+                "compliance_report",
+                "SOURCE-GROUP-compliance",
+                report_path,
+            ),
+            _artifact(
+                "compliance-action",
+                "compliance_override_action_receipt",
+                "SOURCE-GROUP-compliance",
+                action_path.relative_to(root).as_posix(),
+            ),
+        ],
+    }
+    return rows
+
+
+def _single_log_rows(
+    root: Path,
+    run_id: str,
+    *,
+    mandatory: bool,
+    mutate_record: Callable[[dict[str, Any]], None] | None = None,
+) -> list[dict[str, Any]]:
+    interaction_id = "USER-LOG-1"
+    common = {
+        "actor_role": "user",
+        "source": "explicit_session_user_action",
+        "stage": "pipeline_stage_3",
+        "interaction_id": interaction_id,
+        "interaction_sha256": _independent_interaction(run_id, interaction_id),
+    }
+    if mandatory:
+        record = {
+            **common,
+            "response_id": "RESPONSE-1",
+            "checkpoint_id": "checkpoint-1",
+            "checkpoint_type": "MANDATORY",
+            "disposition": "pause",
+        }
+        version = "adjudication-mandatory-checkpoint-log/1.0"
+        family_index = 4
+        family = "mandatory_checkpoint_response"
+        role = "mandatory_checkpoint_response_log"
+    else:
+        record = {
+            **common,
+            "request_id": "REQUEST-1",
+            "action": "justify_finding",
+            "finding_id": "REV-001",
+        }
+        version = "adjudication-explicit-user-request-log/1.0"
+        family_index = 3
+        family = "explicit_user_request"
+        role = "explicit_user_request_log"
+    if mutate_record is not None:
+        mutate_record(record)
+    log_path = root / "sources" / f"{family}-dynamic.json"
+    _write(
+        log_path,
+        {"schema_version": version, "run_id": run_id, "records": [record]},
+    )
+    rows = _empty_rows()
+    rows[family_index] = {
+        "source_family": family,
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact(
+                "action-log",
+                role,
+                f"SOURCE-GROUP-{'mandatory' if mandatory else 'explicit'}",
+                log_path.relative_to(root).as_posix(),
+            )
+        ],
+    }
+    return rows
+
+
+def _re_review_rows(
+    root: Path,
+    mutate: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> list[dict[str, Any]]:
+    paths = _make_re_review_chain(root)
+    verdict_path = root / paths[2]
+    trace_path = root / paths[3]
+    verdict = _load(verdict_path)
+    trace = _load(trace_path)
+    mutate(verdict, trace)
+    trace["verdict_record_hash"] = re_review.canonical_hash(verdict)
+    _write(verdict_path, verdict)
+    _write(trace_path, trace)
+    rows = _empty_rows()
+    rows[2] = {
+        "source_family": "re_review_traceability",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact("rereview-manifest", "input_manifest", "SOURCE-GROUP-rereview", paths[0]),
+            _artifact("rereview-precommitment", "precommitment", "SOURCE-GROUP-rereview", paths[1]),
+            _artifact("rereview-verdict", "verdict_record", "SOURCE-GROUP-rereview", paths[2]),
+            _artifact("rereview-trace", "traceability", "SOURCE-GROUP-rereview", paths[3]),
+        ],
+    }
+    return rows
+
+
+def _recompute_record(run: dict[str, Any]) -> None:
+    preimage = {key: value for key, value in run.items() if key != "record_sha256"}
+    run["record_sha256"] = _independent_digest(
+        b"ars.adjudication-activity.run/1.0\0", preimage
+    )
+
+
+def test_contract_schemas_and_closed_positive_negative_payloads() -> None:
+    input_schema = _load(INPUT_SCHEMA)
+    store_schema = _load(STORE_SCHEMA)
+    jsonschema.Draft202012Validator.check_schema(input_schema)
+    jsonschema.Draft202012Validator.check_schema(store_schema)
+
+    input_payload = {
+        "schema_version": "adjudication-activity-input/1.0",
+        "store_id": STORE_ID,
+        "run_id": "run-schema",
+        "terminal_state": "completed",
+        "terminal_stage": "pipeline_stage_6",
+        "terminal_receipt": {
+            "artifact_id": "pipeline-state-terminal-receipt",
+            "relative_path": "state/run-schema.json",
+            "sha256": "0" * 64,
+            "run_id": "run-schema",
+            "pipeline_state": "completed",
+            "current_stage": "pipeline_stage_6",
+            "current_stage_status": "completed",
+        },
+        "sources": _empty_rows(),
+        "data_minimization": copy.deepcopy(activity.DATA_MINIMIZATION),
+    }
+    jsonschema.Draft202012Validator(input_schema).validate(input_payload)
+    poisoned = copy.deepcopy(input_payload)
+    poisoned["events"] = []
+    assert list(jsonschema.Draft202012Validator(input_schema).iter_errors(poisoned))
+
+    empty_store = {
+        "schema_version": "adjudication-activity-store/1.0",
+        "store_id": STORE_ID,
+        "revision": 0,
+        "next_sequence": 1,
+        "runs": [],
+        "data_minimization": copy.deepcopy(activity.DATA_MINIMIZATION),
+    }
+    jsonschema.Draft202012Validator(store_schema).validate(empty_store)
+    poisoned_store = copy.deepcopy(empty_store)
+    poisoned_store["score"] = 100
+    assert list(jsonschema.Draft202012Validator(store_schema).iter_errors(poisoned_store))
+
+
+def test_init_build_append_validate_render_and_exact_retry_no_write(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    state = _terminal_state(root, "run-zero")
+    manifest = _seal_and_build(capsys, root, state, _empty_rows("unavailable"))
+    store = tmp_path / "activity.json"
+
+    code, stdout, stderr = _call(capsys, "init-store", "--store", str(store), "--store-id", STORE_ID)
+    assert (code, stderr) == (0, "")
+    assert stdout == f'[ARS-ADJUDICATION-ACTIVITY] initialized store_id="{STORE_ID}"; revision=0; next_sequence=1\n'
+    code, stdout, stderr = _append(capsys, root, store, manifest)
+    assert (code, stderr) == (0, "")
+    assert "append_sequence=1; revision=1" in stdout
+    before = store.read_bytes()
+    code, stdout, stderr = _append(capsys, root, store, manifest)
+    assert (code, stderr) == (0, "")
+    assert "already_appended" in stdout
+    assert store.read_bytes() == before
+
+    code, stdout, stderr = _call(capsys, "validate", "--store", str(store))
+    assert (code, stderr) == (0, "")
+    assert "retained_runs=1; revision=1; next_sequence=2" in stdout
+    code, stdout, stderr = _call(capsys, "render", "--store", str(store))
+    assert (code, stderr) == (0, "")
+    lines = stdout.splitlines()
+    assert lines[0] == (
+        "[ARS-ADJUDICATION-ACTIVITY INSUFFICIENT_HISTORY] "
+        "selected_retained_eligible_run_count=1; minimum_required=2; requested_window=10."
+    )
+    assert lines[-3:] == [COVERAGE, LIMITATION, ADVISORY]
+    assert "unavailable_source_count=5 (denominator: 5 source families)" in stdout
+
+
+def test_all_seven_event_types_occurrence_digest_dedup_and_repeated_hashes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    state = _terminal_state(root, "run-all-events", extra_completed=("3", "3p"))
+    manifest = _seal_and_build(capsys, root, state, _all_event_rows(root))
+    store = tmp_path / "activity.json"
+    code, _stdout, stderr = _append(capsys, root, store, manifest)
+    assert code == 0, stderr
+    payload = _load(store)
+    run = payload["runs"][0]
+    events = [event for source in run["sources"] for event in source["events"]]
+    assert {event["event_type"] for event in events} == {
+        "author_triage_wont_address",
+        "author_triage_not_on_point",
+        "compliance_block_override",
+        "re_review_verdict_changed",
+        "finding_justification_requested",
+        "finding_redo_requested",
+        "mandatory_checkpoint_non_proceed",
+    }
+    author_events = run["sources"][0]["events"]
+    assert author_events[0]["interaction_sha256"] == _independent_interaction(
+        "run-all-events", "AUTHOR-EVENT-ONE"
+    )
+    assert author_events[1]["interaction_sha256"] == _independent_interaction(
+        "run-all-events", "AUTHOR-EVENT-TWO"
+    )
+    assert author_events[0]["interaction_sha256"] != author_events[1]["interaction_sha256"]
+    assert run["sources"][1]["artifact_sha256s"][2] == run["sources"][1]["artifact_sha256s"][3]
+    shared = _independent_interaction("run-all-events", "USER-REQUEST-SHARED")
+    assert sum(event["interaction_sha256"] == shared for event in events) == 1
+    assert any(
+        event["event_type"] == "finding_justification_requested"
+        and event["interaction_sha256"] == shared
+        for event in events
+    )
+    assert not any(
+        event["event_type"] == "mandatory_checkpoint_non_proceed"
+        and event["stage"] == "pipeline_stage_3"
+        for event in events
+    )
+    assert {event["stage"] for event in run["sources"][4]["events"]} == set(STAGES) - {
+        "pipeline_stage_1",
+        "pipeline_stage_3",
+        "pipeline_stage_4_5",
+    }
+
+    expected_input_digest = _independent_digest(
+        b"ars.adjudication-activity.input/1.0\0", _load(manifest)
+    )
+    assert run["input_receipt_sha256"] == expected_input_digest
+    record_without_digest = {
+        key: value for key, value in run.items() if key != "record_sha256"
+    }
+    assert run["record_sha256"] == _independent_digest(
+        b"ars.adjudication-activity.run/1.0\0", record_without_digest
+    )
+    first_author_source_record = {
+        "item_id": "REV-001",
+        "author_event_id": "AUTHOR-EVENT-ONE",
+        "author_triage": "wont_address",
+        "input_sha256": "a" * 64,
+        "interaction_sha256": author_events[0]["interaction_sha256"],
+    }
+    assert author_events[0]["source_event_sha256"] == _independent_digest(
+        b"ars.adjudication-activity.source-event/1.0\0",
+        {
+            "source_family": "revision_author_adjudication",
+            "source_record": first_author_source_record,
+        },
+    )
+    expected_event_digest = _independent_digest(
+        b"ars.adjudication-activity.event-id/1.0\0",
+        {
+            "run_id": "run-all-events",
+            "source_family": "revision_author_adjudication",
+            "event_type": author_events[0]["event_type"],
+            "stage": author_events[0]["stage"],
+            "disposition": author_events[0]["disposition"],
+            "interaction_sha256": author_events[0]["interaction_sha256"],
+            "source_event_sha256": author_events[0]["source_event_sha256"],
+        },
+    )
+    assert author_events[0]["event_id"] == f"ACTIVITY-EVENT-{expected_event_digest}"
+
+
+def test_terminal_inventory_is_exact_authority_and_conflicting_retry_fails(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    state = _terminal_state(root, "run-authority")
+    manifest = _seal_and_build(capsys, root, state, _empty_rows())
+    store = tmp_path / "activity.json"
+    assert _append(capsys, root, store, manifest)[0] == 0
+
+    forged_root = tmp_path / "forged-root"
+    forged_state = _terminal_state(forged_root, "run-forged-authority")
+    valid_forged_base = _seal_and_build(
+        capsys, forged_root, forged_state, _empty_rows()
+    )
+    forged = _load(valid_forged_base)
+    forged["sources"][0] = {
+        "source_family": "revision_author_adjudication",
+        "capture_state": "unavailable",
+        "reason_code": "source_not_provided",
+        "artifacts": [],
+    }
+    forged_path = forged_root / "forged-input.json"
+    _write(forged_path, forged)
+    before = store.read_bytes()
+    code, stdout, stderr = _append(capsys, forged_root, store, forged_path)
+    assert code == 3
+    assert stdout == ""
+    assert "ERROR:INPUT" in stderr
+    assert store.read_bytes() == before
+
+    second_root = tmp_path / "second-root"
+    second_state = _terminal_state(second_root, "run-authority")
+    conflicting = _seal_and_build(
+        capsys,
+        second_root,
+        second_state,
+        _empty_rows("unavailable"),
+        output_name="different-input.json",
+    )
+    code, stdout, stderr = _append(capsys, second_root, store, conflicting)
+    assert code == 5
+    assert stdout == ""
+    assert "ERROR:CONFLICT" in stderr
+    assert store.read_bytes() == before
+
+
+def test_delete_gap_range_delete_and_delete_store_recovery(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    store = tmp_path / "activity.json"
+    roots: list[Path] = []
+    for ordinal in range(1, 4):
+        root = tmp_path / f"root-{ordinal}"
+        roots.append(root)
+        state = _terminal_state(
+            root,
+            f"run-{ordinal}",
+            pipeline_state="aborted" if ordinal == 2 else "completed",
+            current_stage="4p" if ordinal == 2 else "6",
+            status="blocked" if ordinal == 2 else "completed",
+        )
+        manifest = _seal_and_build(capsys, root, state, _empty_rows())
+        assert _append(capsys, root, store, manifest)[0] == 0
+
+    raw_hash = hashlib.sha256(store.read_bytes()).hexdigest()
+    before = store.read_bytes()
+    code, stdout, stderr = _call(
+        capsys,
+        "delete-runs",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        "0" * 64,
+        "--run-id",
+        "run-2",
+    )
+    assert code == 6
+    assert stdout == ""
+    assert "ERROR:DELETE_CONFIRMATION" in stderr
+    assert store.read_bytes() == before
+    code, stdout, stderr = _call(
+        capsys,
+        "delete-runs",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        raw_hash,
+        "--run-id",
+        "run-2",
+    )
+    assert (code, stderr) == (0, "")
+    assert "deleted_runs=1; revision=4; next_sequence=4" in stdout
+    assert [run["append_sequence"] for run in _load(store)["runs"]] == [1, 3]
+
+    raw_hash = hashlib.sha256(store.read_bytes()).hexdigest()
+    code, _stdout, stderr = _call(
+        capsys,
+        "delete-runs",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        raw_hash,
+        "--sequence-range",
+        "1:3",
+    )
+    assert code == 0, stderr
+    assert _load(store)["next_sequence"] == 4
+    store.write_bytes(b'{"corrupt":true}\n')
+    corrupt_hash = hashlib.sha256(store.read_bytes()).hexdigest()
+    code, stdout, stderr = _call(
+        capsys,
+        "delete-store",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        corrupt_hash,
+        "--confirm",
+        "WRONG-TOKEN",
+    )
+    assert code == 6
+    assert stdout == ""
+    assert "ERROR:DELETE_CONFIRMATION" in stderr
+    assert store.exists()
+    code, stdout, stderr = _call(
+        capsys,
+        "delete-store",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        corrupt_hash,
+        "--confirm",
+        "DELETE-ADJUDICATION-ACTIVITY-STORE",
+    )
+    assert (code, stderr) == (0, "")
+    assert stdout == "[ARS-ADJUDICATION-ACTIVITY] deleted_store=true\n"
+    assert not store.exists()
+
+
+@pytest.mark.parametrize("window", ["1", "51"])
+def test_renderer_rejects_out_of_range_window(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], window: str
+) -> None:
+    store = tmp_path / "activity.json"
+    code, _stdout, _stderr = _call(
+        capsys, "init-store", "--store", str(store), "--store-id", STORE_ID
+    )
+    assert code == 0
+    code, stdout, stderr = _call(
+        capsys, "render", "--store", str(store), "--window", window
+    )
+    assert code == 2
+    assert stdout == ""
+    assert "ERROR:USAGE" in stderr
+
+
+def test_build_input_rejects_caller_sources_and_input_cap_is_fail_closed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    state = _terminal_state(root, "run-no-caller-authority")
+    output = root / "input.json"
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(output),
+        "--source-sha256",
+        "0" * 64,
+    )
+    assert code == 2
+    assert stdout == ""
+    assert "ERROR:USAGE" in stderr
+    assert not output.exists()
+
+    oversized = root / "oversized-input.json"
+    oversized.write_bytes(b" " * ((1 << 20) + 1))
+    store = tmp_path / "activity.json"
+    code, stdout, stderr = _append(capsys, root, store, oversized)
+    assert code == 5
+    assert stdout == ""
+    assert "ERROR:CAP" in stderr
+    assert not store.exists()
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        b'{"schema_version":"adjudication-activity-store/1.0","schema_version":"duplicate"}\n',
+        b"\xef\xbb\xbf{}\n",
+        b"{} trailing\n",
+        b'{"float":1.5}\n',
+    ],
+)
+def test_store_corruption_fails_closed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    corrupt: bytes,
+) -> None:
+    store = tmp_path / "activity.json"
+    store.write_bytes(corrupt)
+    code, stdout, stderr = _call(capsys, "validate", "--store", str(store))
+    assert code == 4
+    assert stdout == ""
+    assert "ERROR:STORE" in stderr
+
+
+def test_symlink_artifact_and_lock_contention_fail_without_mutation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    target = root / "target.json"
+    _write(target, {"fixture": True})
+    link = root / "link.json"
+    link.symlink_to(target)
+    rows = _empty_rows()
+    rows[3] = {
+        "source_family": "explicit_user_request",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact("explicit-log", "explicit_user_request_log", "SOURCE-GROUP-explicit", "link.json")
+        ],
+    }
+    state = _terminal_state(root, "run-path")
+    state_before = state.read_bytes()
+    with pytest.raises(activity.ActivityError, match="symlink"):
+        activity.seal_terminal_inventory(state, root, rows)
+    assert state.read_bytes() == state_before
+
+    store = tmp_path / "activity.json"
+    assert _call(capsys, "init-store", "--store", str(store), "--store-id", STORE_ID)[0] == 0
+    before = store.read_bytes()
+    lock_path = store.with_name(store.name + ".lock")
+    with lock_path.open("r+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        code, stdout, stderr = _call(capsys, "validate", "--store", str(store))
+    assert code == 7
+    assert stdout == ""
+    assert "ERROR:LOCK" in stderr
+    assert store.read_bytes() == before
+
+
+def test_captured_zero_compliance_report_only_is_valid(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    pass_report = _copy_fixture(root, "compliance_pass.json")
+    rows = _empty_rows()
+    rows[1] = {
+        "source_family": "compliance_report",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact("report-only", "compliance_report", "SOURCE-GROUP-pass", pass_report)
+        ],
+    }
+    state = _terminal_state(root, "run-captured-zero")
+    manifest = _seal_and_build(capsys, root, state, rows)
+    store = tmp_path / "activity.json"
+    code, _stdout, stderr = _append(capsys, root, store, manifest)
+    assert code == 0, stderr
+    compliance = _load(store)["runs"][0]["sources"][1]
+    assert compliance["capture_state"] == "captured"
+    assert compliance["events"] == []
+
+
+def test_nonqualifying_compliance_receipt_pair_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    pass_report = _copy_fixture(root, "compliance_pass.json")
+    action = _load(FIXTURES / "compliance_override_action.json")
+    action["report_sha256"] = hashlib.sha256((root / pass_report).read_bytes()).hexdigest()
+    action_path = root / "sources" / "bad-paired-action.json"
+    _write(action_path, action)
+    rows = _empty_rows()
+    rows[1] = {
+        "source_family": "compliance_report",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact("plain-report", "compliance_report", "SOURCE-GROUP-bad-pair", pass_report),
+            _artifact(
+                "forbidden-action",
+                "compliance_override_action_receipt",
+                "SOURCE-GROUP-bad-pair",
+                action_path.relative_to(root).as_posix(),
+            ),
+        ],
+    }
+    state = _terminal_state(root, "run-bad-pair")
+    activity.seal_terminal_inventory(state, root, rows)
+    manifest = root / "input.json"
+    store = tmp_path / "activity.json"
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(manifest),
+    )
+    assert code == 3
+    assert stdout == ""
+    assert "ERROR:SOURCE" in stderr
+    assert not store.exists()
+
+
+def test_exact_retry_ignores_deleted_source_and_terminal_bytes_without_write(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    pass_report = _copy_fixture(root, "compliance_pass.json")
+    rows = _empty_rows()
+    rows[1] = {
+        "source_family": "compliance_report",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact(
+                "report-only",
+                "compliance_report",
+                "SOURCE-GROUP-pass",
+                pass_report,
+            )
+        ],
+    }
+    state = _terminal_state(root, "run-retry-deleted")
+    manifest = _seal_and_build(capsys, root, state, rows)
+    store = tmp_path / "activity.json"
+    assert _append(capsys, root, store, manifest)[0] == 0
+    before_bytes = store.read_bytes()
+    before_mtime = store.stat().st_mtime_ns
+
+    (root / pass_report).unlink()
+    state.unlink()
+    code, stdout, stderr = _append(capsys, root, store, manifest)
+    assert (code, stderr) == (0, "")
+    assert "already_appended" in stdout
+    assert store.read_bytes() == before_bytes
+    assert store.stat().st_mtime_ns == before_mtime
+
+
+def test_short_write_is_completed_and_zero_write_fails_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"short-write-fixture" * 64
+    short_path = tmp_path / "short.bin"
+    original_write = activity.os.write
+
+    def short_write(fd: int, data: bytes | memoryview) -> int:
+        return original_write(fd, data[: max(1, len(data) // 2)])
+
+    monkeypatch.setattr(activity.os, "write", short_write)
+    activity._atomic_create(short_path, payload)
+    assert short_path.read_bytes() == payload
+
+    zero_path = tmp_path / "zero.bin"
+    monkeypatch.setattr(activity.os, "write", lambda _fd, _data: 0)
+    with pytest.raises(activity.ActivityError) as caught:
+        activity._atomic_create(zero_path, payload)
+    assert caught.value.code == "WRITE"
+    assert not zero_path.exists()
+
+
+def test_short_read_is_reassembled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"short-read-fixture" * 64
+    path = tmp_path / "read.bin"
+    path.write_bytes(payload)
+    original_read = activity.os.read
+
+    def short_read(fd: int, count: int) -> bytes:
+        return original_read(fd, max(1, count // 2))
+
+    monkeypatch.setattr(activity.os, "read", short_read)
+    assert activity._read_limited(path, len(payload), code="INPUT") == payload
+
+
+def test_noncanonical_valid_object_delete_store_recovery(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    store = tmp_path / "activity.json"
+    store.write_bytes(b'{ "z": 1, "a": 2 }\n')
+    raw_hash = hashlib.sha256(store.read_bytes()).hexdigest()
+    code, stdout, stderr = _call(
+        capsys,
+        "delete-store",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        raw_hash,
+        "--confirm",
+        "DELETE-ADJUDICATION-ACTIVITY-STORE",
+    )
+    assert (code, stderr) == (0, "")
+    assert stdout == "[ARS-ADJUDICATION-ACTIVITY] deleted_store=true\n"
+    assert not store.exists()
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda action: action.__setitem__("override_ordinal", True),
+        lambda action: action.__setitem__("scope", [["M4"]]),
+    ],
+    ids=("boolean-ordinal", "unhashable-scope"),
+)
+def test_compliance_bad_ordinal_or_scope_is_bounded_source_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    mutation: Callable[[dict[str, Any]], None],
+) -> None:
+    root = tmp_path / "artifacts"
+    run_id = "run-compliance-edge"
+    state = _terminal_state(root, run_id)
+    activity.seal_terminal_inventory(
+        state, root, _compliance_rows(root, run_id, mutation)
+    )
+    output = root / "input.json"
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(output),
+    )
+    assert code == 3
+    assert stdout == ""
+    assert "ERROR:SOURCE" in stderr
+    assert "Traceback" not in stderr
+    assert len(stderr.rstrip("\n").splitlines()) == 1
+    assert len(stderr.rstrip("\n")) <= 560
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("mandatory", [False, True], ids=("finding-id", "checkpoint-id"))
+def test_129_character_finding_or_checkpoint_id_is_rejected(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    mandatory: bool,
+) -> None:
+    root = tmp_path / "artifacts"
+    run_id = f"run-long-{'checkpoint' if mandatory else 'finding'}"
+
+    def mutate(record: dict[str, Any]) -> None:
+        record["checkpoint_id" if mandatory else "finding_id"] = "X" * 129
+
+    state = _terminal_state(root, run_id)
+    activity.seal_terminal_inventory(
+        state,
+        root,
+        _single_log_rows(root, run_id, mandatory=mandatory, mutate_record=mutate),
+    )
+    output = root / "input.json"
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(output),
+    )
+    assert code == 3
+    assert stdout == ""
+    assert "ERROR:SOURCE" in stderr
+    assert not output.exists()
+
+
+def test_explicit_and_mandatory_raw_record_aggregate_4097_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    run_id = "run-aggregate-4097"
+    explicit_id = "EXPLICIT-1"
+    explicit = {
+        "schema_version": "adjudication-explicit-user-request-log/1.0",
+        "run_id": run_id,
+        "records": [
+            {
+                "request_id": "REQUEST-1",
+                "actor_role": "user",
+                "source": "explicit_session_user_action",
+                "action": "justify_finding",
+                "stage": "pipeline_stage_3",
+                "finding_id": "REV-001",
+                "interaction_id": explicit_id,
+                "interaction_sha256": _independent_interaction(run_id, explicit_id),
+            }
+        ],
+    }
+    mandatory_records = []
+    for ordinal in range(4096):
+        interaction_id = f"MANDATORY-{ordinal}"
+        mandatory_records.append(
+            {
+                "response_id": f"RESPONSE-{ordinal}",
+                "checkpoint_id": f"CHECKPOINT-{ordinal}",
+                "checkpoint_type": "MANDATORY",
+                "actor_role": "user",
+                "source": "explicit_session_user_action",
+                "stage": "pipeline_stage_4_5",
+                "disposition": "proceed",
+                "interaction_id": interaction_id,
+                "interaction_sha256": _independent_interaction(run_id, interaction_id),
+            }
+        )
+    mandatory = {
+        "schema_version": "adjudication-mandatory-checkpoint-log/1.0",
+        "run_id": run_id,
+        "records": mandatory_records,
+    }
+    explicit_path = root / "sources" / "explicit-4097.json"
+    mandatory_path = root / "sources" / "mandatory-4097.json"
+    _write(explicit_path, explicit)
+    _write(mandatory_path, mandatory)
+    rows = _empty_rows()
+    rows[3] = {
+        "source_family": "explicit_user_request",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact(
+                "explicit-log",
+                "explicit_user_request_log",
+                "SOURCE-GROUP-explicit",
+                explicit_path.relative_to(root).as_posix(),
+            )
+        ],
+    }
+    rows[4] = {
+        "source_family": "mandatory_checkpoint_response",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact(
+                "mandatory-log",
+                "mandatory_checkpoint_response_log",
+                "SOURCE-GROUP-mandatory",
+                mandatory_path.relative_to(root).as_posix(),
+            )
+        ],
+    }
+    state = _terminal_state(root, run_id)
+    activity.seal_terminal_inventory(state, root, rows)
+    output = root / "input.json"
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(output),
+    )
+    assert code == 5
+    assert stdout == ""
+    assert "ERROR:CAP" in stderr
+    assert not output.exists()
+
+
+def test_lone_surrogate_is_bounded_store_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    store = tmp_path / "activity.json"
+    store.write_bytes(b'{"surrogate":"\\ud800"}\n')
+    code, stdout, stderr = _call(capsys, "validate", "--store", str(store))
+    assert code == 4
+    assert stdout == ""
+    assert "ERROR:STORE" in stderr
+    assert "Traceback" not in stderr
+    assert len(stderr.rstrip("\n").splitlines()) == 1
+    assert len(stderr.rstrip("\n")) <= 560
+
+
+def test_author_store_three_hashes_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    paths = [
+        _copy_fixture(root, "author_stage3_input.json"),
+        _copy_fixture(root, "author_stage3.json"),
+    ]
+    rows = _empty_rows()
+    rows[0] = {
+        "source_family": "revision_author_adjudication",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact("author-input", "author_adjudication_input", "SOURCE-GROUP-author", paths[0], "pipeline_stage_3"),
+            _artifact("author-output", "author_adjudication", "SOURCE-GROUP-author", paths[1], "pipeline_stage_3"),
+        ],
+    }
+    state = _terminal_state(root, "run-author-three-hashes", extra_completed=("3",))
+    manifest = _seal_and_build(capsys, root, state, rows)
+    store = tmp_path / "activity.json"
+    assert _append(capsys, root, store, manifest)[0] == 0
+    payload = _load(store)
+    hashes = payload["runs"][0]["sources"][0]["artifact_sha256s"]
+    hashes.append(hashes[-1])
+    _recompute_record(payload["runs"][0])
+    _write(store, payload)
+    code, stdout, stderr = _call(capsys, "validate", "--store", str(store))
+    assert code == 4
+    assert stdout == ""
+    assert "ERROR:STORE" in stderr
+
+
+def test_store_next_sequence_cannot_exceed_revision_plus_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "artifacts"
+    state = _terminal_state(root, "run-next-sequence")
+    manifest = _seal_and_build(capsys, root, state, _empty_rows())
+    store = tmp_path / "activity.json"
+    assert _append(capsys, root, store, manifest)[0] == 0
+    payload = _load(store)
+    assert payload["revision"] == 1
+    payload["next_sequence"] = 3
+    _write(store, payload)
+    code, stdout, stderr = _call(capsys, "validate", "--store", str(store))
+    assert code == 4
+    assert stdout == ""
+    assert "ERROR:STORE" in stderr
+
+
+def _assert_re_review_mutation_rejected(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    mutation: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    root = tmp_path / "artifacts"
+    state = _terminal_state(root, "run-rereview-negative")
+    rows = _re_review_rows(root, mutation)
+    activity.seal_terminal_inventory(state, root, rows)
+    output = root / "input.json"
+    code, stdout, stderr = _call(
+        capsys,
+        "build-input",
+        "--state",
+        str(state),
+        "--artifact-root",
+        str(root),
+        "--store-id",
+        STORE_ID,
+        "--output",
+        str(output),
+    )
+    assert code == 3
+    assert stdout == ""
+    assert "ERROR:SOURCE" in stderr
+    assert not output.exists()
+
+
+def test_re_review_no_change_adjustment_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def mutate(_verdict: dict[str, Any], trace: dict[str, Any]) -> None:
+        reapplication = trace["reapplications"][0]
+        reapplication["reapplied_verdict"] = "FULLY_ADDRESSED"
+        adjustment = trace["adjustments"][0]
+        adjustment["from_verdict"] = "FULLY_ADDRESSED"
+        adjustment["to_verdict"] = "FULLY_ADDRESSED"
+        trace["rows"][0].update(
+            {"verified": "YES", "status": "FULLY_ADDRESSED", "final_verdict": "FULLY_ADDRESSED"}
+        )
+
+    _assert_re_review_mutation_rejected(tmp_path, capsys, mutate)
+
+
+def test_re_review_adjustment_endpoints_must_mirror_reapplication(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def mutate(_verdict: dict[str, Any], trace: dict[str, Any]) -> None:
+        trace["adjustments"][0]["from_verdict"] = "PARTIALLY_ADDRESSED"
+
+    _assert_re_review_mutation_rejected(tmp_path, capsys, mutate)
+
+
+def test_re_review_reapplication_and_adjustment_are_single_use(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def mutate(verdict: dict[str, Any], trace: dict[str, Any]) -> None:
+        second_dissent = copy.deepcopy(verdict["dissents"][0])
+        second_dissent["dissent_id"] = "DIS-2"
+        verdict["dissents"].append(second_dissent)
+        second_adjudication = copy.deepcopy(trace["dissent_adjudications"][0])
+        second_adjudication["dissent_id"] = "DIS-2"
+        trace["dissent_adjudications"].append(second_adjudication)
+        trace["reapplications"][0]["answer_refs"].append("adjudication:DIS-2")
+
+    _assert_re_review_mutation_rejected(tmp_path, capsys, mutate)
+
+
+def test_seal_rejects_invalid_artifact_id_without_state_write(tmp_path: Path) -> None:
+    root = tmp_path / "artifacts"
+    report = _copy_fixture(root, "compliance_pass.json")
+    rows = _empty_rows()
+    rows[1] = {
+        "source_family": "compliance_report",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact(
+                "invalid artifact id",
+                "compliance_report",
+                "SOURCE-GROUP-invalid-id",
+                report,
+            )
+        ],
+    }
+    state = _terminal_state(root, "run-invalid-artifact-id")
+    before = state.read_bytes()
+    with pytest.raises(activity.ActivityError) as caught:
+        activity.seal_terminal_inventory(state, root, rows)
+    assert caught.value.code == "SOURCE"
+    assert state.read_bytes() == before
+
+
+def test_renderer_empty_one_two_full_golden_and_mixed_denominators(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    store = tmp_path / "activity.json"
+    assert _call(
+        capsys, "init-store", "--store", str(store), "--store-id", STORE_ID
+    )[0] == 0
+    code, stdout, stderr = _call(capsys, "render", "--store", str(store))
+    assert (code, stderr) == (0, "")
+    assert stdout == "\n".join(
+        [
+            "[ARS-ADJUDICATION-ACTIVITY INSUFFICIENT_HISTORY] selected_retained_eligible_run_count=0; minimum_required=2; requested_window=10.",
+            "[ARS-ADJUDICATION-ACTIVITY COUNTS] adjudication_count=0 (denominator: 0 retained eligible terminal run records); overturn_count=0 (denominator: 0 recorded adjudications); unavailable_run_count=0 (denominator: 0 retained eligible terminal run records).",
+            COVERAGE,
+            LIMITATION,
+            ADVISORY,
+            "",
+        ]
+    )
+
+    root_one = tmp_path / "root-one"
+    pass_report = _copy_fixture(root_one, "compliance_pass.json")
+    mixed_rows = _empty_rows()
+    mixed_rows[0] = {
+        "source_family": "revision_author_adjudication",
+        "capture_state": "unavailable",
+        "reason_code": "source_not_provided",
+        "artifacts": [],
+    }
+    mixed_rows[1] = {
+        "source_family": "compliance_report",
+        "capture_state": "captured",
+        "reason_code": None,
+        "artifacts": [
+            _artifact("report-only", "compliance_report", "SOURCE-GROUP-pass", pass_report)
+        ],
+    }
+    state_one = _terminal_state(root_one, "run-mixed-zero")
+    manifest_one = _seal_and_build(capsys, root_one, state_one, mixed_rows)
+    assert _append(capsys, root_one, store, manifest_one)[0] == 0
+    code, stdout, stderr = _call(capsys, "render", "--store", str(store))
+    assert (code, stderr) == (0, "")
+    assert stdout == "\n".join(
+        [
+            "[ARS-ADJUDICATION-ACTIVITY INSUFFICIENT_HISTORY] selected_retained_eligible_run_count=1; minimum_required=2; requested_window=10.",
+            "[ARS-ADJUDICATION-ACTIVITY COUNTS] adjudication_count=0 (denominator: 1 retained eligible terminal run records); overturn_count=0 (denominator: 0 recorded adjudications); unavailable_run_count=1 (denominator: 1 retained eligible terminal run records).",
+            'sequence=1; run_id="run-mixed-zero"; terminal_state=completed; adjudication_count=0 (denominator: 1 retained eligible terminal run record); overturn_count=0 (denominator: 0 recorded adjudications); unavailable_source_count=1 (denominator: 5 source families).',
+            COVERAGE,
+            LIMITATION,
+            ADVISORY,
+            "",
+        ]
+    )
+
+    root_two = tmp_path / "root-two"
+    state_two = _terminal_state(root_two, "run-not-applicable")
+    manifest_two = _seal_and_build(capsys, root_two, state_two, _empty_rows())
+    assert _append(capsys, root_two, store, manifest_two)[0] == 0
+    code, stdout, stderr = _call(capsys, "render", "--store", str(store))
+    assert (code, stderr) == (0, "")
+    assert stdout == "\n".join(
+        [
+            "[ARS-ADJUDICATION-ACTIVITY] selected_retained_eligible_run_count=2; requested_window=10; adjudication_count=0 (denominator: 2 retained eligible terminal run records); overturn_count=0 (denominator: 0 recorded adjudications); unavailable_run_count=1 (denominator: 2 retained eligible terminal run records).",
+            'sequence=1; run_id="run-mixed-zero"; terminal_state=completed; adjudication_count=0 (denominator: 1 retained eligible terminal run record); overturn_count=0 (denominator: 0 recorded adjudications); unavailable_source_count=1 (denominator: 5 source families).',
+            'sequence=2; run_id="run-not-applicable"; terminal_state=completed; adjudication_count=0 (denominator: 1 retained eligible terminal run record); overturn_count=0 (denominator: 0 recorded adjudications); unavailable_source_count=0 (denominator: 5 source families).',
+            COVERAGE,
+            LIMITATION,
+            ADVISORY,
+            "",
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("pipeline_state", "raw_stage", "status"),
+    [("completed", "6", "skipped")]
+    + [("aborted", raw_stage, "blocked") for raw_stage in activity.RAW_TO_STAGE],
+)
+def test_completed_stage6_skipped_and_every_aborted_stage_replay(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    pipeline_state: str,
+    raw_stage: str,
+    status: str,
+) -> None:
+    safe_stage = raw_stage.replace(".", "_")
+    root = tmp_path / "artifacts"
+    run_id = f"run-{pipeline_state}-{safe_stage}"
+    state = _terminal_state(
+        root,
+        run_id,
+        pipeline_state=pipeline_state,
+        current_stage=raw_stage,
+        status=status,
+    )
+    manifest = _seal_and_build(capsys, root, state, _empty_rows())
+    store = tmp_path / "activity.json"
+    code, _stdout, stderr = _append(capsys, root, store, manifest)
+    assert code == 0, stderr
+    run = _load(store)["runs"][0]
+    assert run["terminal_state"] == pipeline_state
+    assert run["terminal_stage"] == activity.RAW_TO_STAGE[raw_stage]
+
+
+def test_delete_store_identity_swap_is_detected_before_unlink(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = tmp_path / "activity.json"
+    assert _call(
+        capsys, "init-store", "--store", str(store), "--store-id", STORE_ID
+    )[0] == 0
+    original_hash = hashlib.sha256(store.read_bytes()).hexdigest()
+    replacement = tmp_path / "replacement.json"
+    replacement_bytes = b'{"replacement":true}\n'
+    replacement.write_bytes(replacement_bytes)
+    displaced = tmp_path / "displaced-original.json"
+    original_assert = activity._assert_identity
+    swapped = False
+
+    def swap_then_assert(path: Path, expected: tuple[int, int, int]) -> None:
+        nonlocal swapped
+        if not swapped:
+            path.replace(displaced)
+            replacement.replace(path)
+            swapped = True
+        original_assert(path, expected)
+
+    monkeypatch.setattr(activity, "_assert_identity", swap_then_assert)
+    code, stdout, stderr = _call(
+        capsys,
+        "delete-store",
+        "--store",
+        str(store),
+        "--store-id",
+        STORE_ID,
+        "--expect-store-sha256",
+        original_hash,
+        "--confirm",
+        "DELETE-ADJUDICATION-ACTIVITY-STORE",
+    )
+    assert code == 5
+    assert stdout == ""
+    assert "ERROR:CONFLICT" in stderr
+    assert store.read_bytes() == replacement_bytes
+    assert displaced.exists()

--- a/scripts/test_check_673_adjudication_activity.py
+++ b/scripts/test_check_673_adjudication_activity.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Hermetic mutation tests for the static #673 integration guard."""
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts import check_673_adjudication_activity as guard
+
+
+def _base_schema(version: str) -> dict[str, object]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "schema_version": {"const": version},
+        },
+        "$defs": {
+            "pipeline_stage": {"enum": list(guard.STAGES)},
+        },
+    }
+
+
+def _schemas() -> tuple[dict[str, object], dict[str, object]]:
+    input_schema = _base_schema("adjudication-activity-input/1.0")
+    store_schema = _base_schema("adjudication-activity-store/1.0")
+    store_schema["$defs"].update(  # type: ignore[union-attr]
+        {
+            "source_receipt": {
+                "type": "object",
+                "properties": {
+                    "artifact_sha256s": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    }
+                },
+            },
+            "run_record": {
+                "type": "object",
+                "properties": {"sealed": {"const": True}},
+            },
+        }
+    )
+    return input_schema, store_schema
+
+
+def _runtime() -> str:
+    return f'''
+import argparse
+
+LIMITATION = {guard.LIMITATION_SENTENCE!r}
+ADVISORY = {guard.ADVISORY_SENTENCE!r}
+COVERAGE = {guard.COVERAGE_LINE!r}
+AUTHORITY = "run_id adjudication_activity_sources sealed"
+PENDING_PROJECTION = "pending_adjudication_activity_bindings"
+
+def seal_terminal_inventory(state_path, artifact_root, pending_bindings):
+    return state_path, artifact_root, pending_bindings
+
+def _validate_manifest_authority(manifest, root):
+    state = load_state(root)
+    inventory = state.get("adjudication_activity_sources")
+    if inventory != manifest["sources"]:
+        raise ValueError("authority mismatch")
+
+def _cmd_build(args):
+    return args.state, args.artifact_root, args.store_id, args.output
+
+def parser():
+    root = argparse.ArgumentParser()
+    subs = root.add_subparsers()
+    init = subs.add_parser("init-store")
+    build = subs.add_parser("build-input")
+    append = subs.add_parser("append-run")
+    render = subs.add_parser("render")
+    validate = subs.add_parser("validate")
+    delete_runs = subs.add_parser("delete-runs")
+    delete_store = subs.add_parser("delete-store")
+    build.add_argument("--state")
+    build.add_argument("--artifact-root")
+    build.add_argument("--store-id")
+    build.add_argument("--output")
+    return root
+'''
+
+
+def _wiring() -> dict[Path, str]:
+    return {
+        guard.STATE_TRACKER: (
+            "Stable run_id. pending_adjudication_activity_bindings are producer-only. "
+            "The exact five adjudication_activity_sources rows are sealed."
+        ),
+        guard.ORCHESTRATOR: (
+            "Make the terminal transition durable first; the already terminal "
+            "outcome is preserved. In post-terminal advisory handling call "
+            "seal_terminal_inventory, then build-input, append-run, and optionally "
+            "render as best-effort work. The exact run_id plus sealed "
+            "adjudication_activity_sources is build-input authority."
+        ),
+        guard.PIPELINE_SKILL: "post-terminal best-effort advisory append-run",
+        guard.STATE_MACHINE: "terminal state transition is durable before post-terminal work",
+        guard.PROCESS_SUMMARY: (
+            "The adjudication activity store never enters the Process Record. "
+            "post-terminal best-effort."
+        ),
+        guard.COMPLIANCE: (
+            "After the qualifying action, best-effort write the "
+            "compliance_override_action_receipt."
+        ),
+        guard.HANDOFFS: (
+            "Adjudication activity never enters a Material Passport or handoff."
+        ),
+    }
+
+
+def test_synthetic_contracts_pass() -> None:
+    input_schema, store_schema = _schemas()
+    assert guard.check_schema_contracts(input_schema, store_schema) == []
+    assert guard.check_runtime_text(_runtime()) == []
+    assert guard.check_wiring_texts(_wiring()) == []
+
+
+@pytest.mark.parametrize(
+    "exact",
+    [guard.LIMITATION_SENTENCE, guard.ADVISORY_SENTENCE, guard.COVERAGE_LINE],
+)
+def test_frozen_exact_renderer_language_is_load_bearing(exact: str) -> None:
+    spec = "\n".join(
+        [guard.LIMITATION_SENTENCE, guard.ADVISORY_SENTENCE, guard.COVERAGE_LINE]
+    )
+    assert guard.check_spec_text(spec) == []
+    assert any(
+        "missing exact renderer text" in error
+        for error in guard.check_spec_text(spec.replace(exact, "paraphrased", 1))
+    )
+
+
+@pytest.mark.parametrize("retired", ["source_stage", "pipeline_stage_0"])
+def test_retired_stage_tokens_are_rejected_across_text_surfaces(retired: str) -> None:
+    assert guard.check_retired_tokens(Path("surface.md"), "clean") == []
+    assert any(
+        retired in error
+        for error in guard.check_retired_tokens(
+            Path("surface.md"), f"reintroduced {retired}"
+        )
+    )
+
+
+@pytest.mark.parametrize("schema_name", ["input", "store"])
+def test_full_stage_enum_is_load_bearing(schema_name: str) -> None:
+    input_schema, store_schema = _schemas()
+    target = input_schema if schema_name == "input" else store_schema
+    target["$defs"]["pipeline_stage"]["enum"].append("pipeline_stage_0")  # type: ignore[index,union-attr]
+    errors = guard.check_schema_contracts(input_schema, store_schema)
+    assert any("full Stage 1..6 enum drifted" in error for error in errors)
+    assert any("pipeline_stage_0" in error for error in errors)
+
+
+def test_retired_source_stage_is_rejected() -> None:
+    input_schema, store_schema = _schemas()
+    input_schema["properties"]["source_stage"] = {"type": "string"}  # type: ignore[index]
+    assert any(
+        "source_stage" in error
+        for error in guard.check_schema_contracts(input_schema, store_schema)
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["events", "adjudication_count", "overturn", "rate", "score", "threshold"],
+)
+def test_caller_derived_input_fields_are_rejected(field: str) -> None:
+    input_schema, store_schema = _schemas()
+    input_schema["properties"][field] = {"type": "integer"}  # type: ignore[index]
+    assert any(
+        "caller-derived fields" in error
+        for error in guard.check_schema_contracts(input_schema, store_schema)
+    )
+
+
+def test_store_artifact_hashes_may_repeat() -> None:
+    input_schema, store_schema = _schemas()
+    store_schema["$defs"]["source_receipt"]["properties"]["artifact_sha256s"][  # type: ignore[index]
+        "uniqueItems"
+    ] = True
+    assert any(
+        "legitimate repeated hashes" in error
+        for error in guard.check_schema_contracts(input_schema, store_schema)
+    )
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "expected"),
+    [
+        ("build.add_argument(\"--output\")", "build.add_argument(\"--source-sha256\")", "build-input"),
+        ("subs.add_parser(\"render\")", "subs.add_parser(\"judge\")", "CLI command surface"),
+        ("import argparse", "import argparse\nimport requests", "forbidden model/network"),
+        ("return state_path, artifact_root, pending_bindings", "return artifact_root.rglob('*')", "ambient scan"),
+        (guard.COVERAGE_LINE, "Coverage: available runs shown.", "exact renderer text"),
+    ],
+)
+def test_runtime_mutations_fail(old: str, new: str, expected: str) -> None:
+    source = _runtime()
+    assert old in source
+    errors = guard.check_runtime_text(source.replace(old, new, 1))
+    assert any(expected in error for error in errors)
+
+
+def test_seal_api_requires_three_explicit_inputs() -> None:
+    source = _runtime().replace(
+        "def seal_terminal_inventory(state_path, artifact_root, pending_bindings):",
+        "def seal_terminal_inventory(state_path, artifact_root, pending_bindings=None):",
+    )
+    assert any("must require exactly" in error for error in guard.check_runtime_text(source))
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "expected"),
+    [
+        (
+            "def _validate_manifest_authority(manifest, root):",
+            "def _validate_untrusted_manifest(manifest, root):",
+            "missing _validate_manifest_authority",
+        ),
+        (
+            'state.get("adjudication_activity_sources")',
+            'state.get("pending_adjudication_activity_bindings")',
+            "does not read state adjudication_activity_sources",
+        ),
+        (
+            'inventory != manifest["sources"]',
+            'inventory[:4] != manifest["sources"][:4]',
+            "does not exact-compare sealed inventory",
+        ),
+        (
+            "return args.state, args.artifact_root, args.store_id, args.output",
+            "return args.state, args.source_sha256, args.store_id, args.output",
+            "reads caller source/hash arguments",
+        ),
+        (
+            "return args.state, args.artifact_root, args.store_id, args.output",
+            'return args.state, getattr(args, "source_sha256"), args.store_id, args.output',
+            "reads caller source/hash arguments",
+        ),
+    ],
+)
+def test_authority_ast_mutations_fail(old: str, new: str, expected: str) -> None:
+    source = _runtime()
+    assert old in source
+    errors = guard.check_runtime_text(source.replace(old, new, 1))
+    assert any(expected in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("path", "old", "new", "expected"),
+    [
+        (
+            guard.STATE_TRACKER,
+            "The exact five adjudication_activity_sources rows are sealed.",
+            "Sources may be inferred later.",
+            "sealed five-row authority",
+        ),
+        (
+            guard.ORCHESTRATOR,
+            "Make the terminal transition durable first;",
+            "Maybe make the transition later;",
+            "terminal-first order",
+        ),
+        (
+            guard.COMPLIANCE,
+            "After the qualifying action, best-effort",
+            "Before deciding the action, synchronously",
+            "post-action best-effort",
+        ),
+    ],
+)
+def test_wiring_mutations_fail(
+    path: Path, old: str, new: str, expected: str
+) -> None:
+    texts = deepcopy(_wiring())
+    assert old in texts[path]
+    texts[path] = texts[path].replace(old, new, 1)
+    assert any(expected in error for error in guard.check_wiring_texts(texts))
+
+
+@pytest.mark.parametrize(
+    "consumer",
+    [
+        "Gate input: adjudication_activity_store",
+        "Verdict reads adjudication_count",
+        "Model prompt consumes adjudication activity",
+        "Checkpoint selector loads overturn_count",
+        "Process Record input includes activity store",
+    ],
+)
+def test_affirmative_consumers_are_rejected(consumer: str) -> None:
+    errors = guard.check_non_consumer_text(Path("synthetic.md"), consumer)
+    assert errors and "affirmative activity consumer" in errors[0]
+
+
+def test_explicit_non_consumer_statement_is_allowed() -> None:
+    text = "The adjudication activity store never enters a gate, verdict, or model prompt."
+    assert guard.check_non_consumer_text(Path("synthetic.md"), text) == []
+
+
+def test_affirmative_consumer_cannot_hide_after_a_prohibition() -> None:
+    text = (
+        "The adjudication activity store never enters a gate. "
+        "The model prompt consumes adjudication activity."
+    )
+    errors = guard.check_non_consumer_text(Path("synthetic.md"), text)
+    assert len(errors) == 1
+    assert "model prompt consumes" in errors[0].lower()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Adjudication activity is not optional; the activity store gates the verdict.",
+        "The gate does not ignore the activity store and consumes adjudication_count.",
+    ],
+)
+def test_clause_local_negation_cannot_hide_consumer(text: str) -> None:
+    errors = guard.check_non_consumer_text(Path("synthetic.md"), text)
+    assert errors and "affirmative activity consumer" in errors[0]
+
+
+def test_user_may_read_renderer_output_is_allowed() -> None:
+    text = "The user may read the adjudication activity renderer output."
+    assert guard.check_non_consumer_text(Path("synthetic.md"), text) == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "from scripts.adjudication_activity import render_store\n",
+        "import scripts.adjudication_activity\n",
+        "adjudication_count = 1\n",
+    ],
+)
+def test_non_whitelisted_production_python_consumer_fails(payload: str) -> None:
+    errors = guard.check_execution_surface(Path("scripts/hidden_consumer.py"), payload)
+    assert errors and "non-whitelisted production Python" in errors[0]
+
+
+def test_exact_python_owner_whitelist_is_allowed() -> None:
+    for path in guard.PYTHON_EXECUTION_WHITELIST:
+        assert guard.check_execution_surface(path, "adjudication_activity") == []
+
+
+def test_shell_or_workflow_cannot_execute_activity_runtime() -> None:
+    errors = guard.check_execution_surface(
+        Path("scripts/hidden.sh"), "python3 scripts/adjudication_activity.py render"
+    )
+    assert any("invokes/imports activity runtime" in error for error in errors)
+
+
+def test_workflow_allows_only_direct_guard_step() -> None:
+    path = Path(".github/workflows/spec-consistency.yml")
+    allowed = (
+        "- name: Check adjudication-activity advisory integration (#673)\n"
+        "  run: python3 scripts/check_673_adjudication_activity.py\n"
+    )
+    assert guard.check_execution_surface(path, allowed) == []

--- a/scripts/test_v3_6_7_phase_6_6.py
+++ b/scripts/test_v3_6_7_phase_6_6.py
@@ -178,6 +178,13 @@ LINE_BUDGET_660_ADVISORY_DISPATCH = 60
 # Measured at first write: 60 lines; budget 66 leaves 6 lines of headroom.
 LINE_BUDGET_672_ADVISORY_DISPATCH = 66
 
+# #673 adds three bounded orchestrator surfaces: the stable run-identity
+# paragraph, the action-time receipt hook, and the post-terminal seal/append
+# sequence. They form one independent 2026-08 advisory side-channel scope, so
+# they are subtracted from the historical v3.6.7 budget and receive a dedicated
+# cap. Measured at landing: 51 lines; budget 57 leaves 6 lines of headroom.
+LINE_BUDGET_673_ADJUDICATION_ACTIVITY = 57
+
 # All 24 failure phase IDs from spec §5.6 inventory (7 P-PA-* + 17 P-PB-*).
 # These must each appear at least once in the orchestrator prompt as
 # cross-references to spec §5.6 (NOT inline procedural definitions —
@@ -677,6 +684,41 @@ def _measure_672_advisory_dispatch_block_lines(text: str) -> int:
     return dispatch_lines + sidecar_lines
 
 
+def _measure_673_adjudication_activity_lines(text: str) -> int:
+    """Return the three #673 orchestrator paragraphs/sections."""
+    import re as _re
+
+    run_marker = "**Run identity (#673):**"
+    run_start = text.find(run_marker)
+    if run_start < 0:
+        return 0
+    run_end = text.find("\n\n", run_start)
+    if run_end < 0:
+        return 0
+    total = len(text[run_start:run_end].splitlines())
+
+    for heading, maximum_level in (
+        ("#### Adjudication-activity action-time hook (#673)", 4),
+        ("### Post-terminal adjudication-activity sequence (#673)", 3),
+    ):
+        start = text.find(heading)
+        if start < 0:
+            return 0
+        heading_end = text.find("\n", start)
+        if heading_end < 0:
+            return 0
+        next_heading = _re.search(
+            rf"(?m)^#{{1,{maximum_level}}}[ \t]+", text[heading_end + 1 :]
+        )
+        end = (
+            heading_end + 1 + next_heading.start()
+            if next_heading is not None
+            else len(text)
+        )
+        total += len(text[start:end].splitlines())
+    return total
+
+
 class Advisory660LineBudgetTest(unittest.TestCase):
     """#660 tortured-phrase dispatch block stays independently bounded."""
 
@@ -714,6 +756,26 @@ class Advisory672LineBudgetTest(unittest.TestCase):
             LINE_BUDGET_672_ADVISORY_DISPATCH,
             f"#672 cross-document advisory dispatch block is {block_lines} "
             f"lines, over its {LINE_BUDGET_672_ADVISORY_DISPATCH}-line budget",
+        )
+
+
+class Advisory673LineBudgetTest(unittest.TestCase):
+    """#673 action-time and post-terminal wiring stays independently bounded."""
+
+    def test_673_adjudication_activity_within_budget(self) -> None:
+        text = _read_prompt()
+        block_lines = _measure_673_adjudication_activity_lines(text)
+        self.assertGreater(
+            block_lines,
+            0,
+            "#673 adjudication-activity wiring is missing from "
+            "pipeline_orchestrator_agent.md",
+        )
+        self.assertLessEqual(
+            block_lines,
+            LINE_BUDGET_673_ADJUDICATION_ACTIVITY,
+            f"#673 adjudication-activity wiring is {block_lines} lines, "
+            f"over its {LINE_BUDGET_673_ADJUDICATION_ACTIVITY}-line budget",
         )
 
 
@@ -799,6 +861,7 @@ class Phase66LineBudgetTest(unittest.TestCase):
         evidence_656_lines = _measure_656_evidence_rendering_block_lines(text)
         advisory_660_lines = _measure_660_advisory_dispatch_block_lines(text)
         advisory_672_lines = _measure_672_advisory_dispatch_block_lines(text)
+        advisory_673_lines = _measure_673_adjudication_activity_lines(text)
         # v3.6.7-only line count: total minus v3.7.1 Step 3b, v3.7.3
         # finalizer extension, v3.8 §3.6 audit-gate, v3.9.0 triangulation
         # extension, v3.10 terminal-policy extension, the #394 slice-4
@@ -806,13 +869,14 @@ class Phase66LineBudgetTest(unittest.TestCase):
         # sequencing, the #670 authority/bundle extension, the #576 Spec B
         # Stage 3' contract-dispatch, AND the #656 Phase E evidence-row
         # checkpoint-rendering, the #660 tortured-phrase advisory dispatch,
-        # AND the #672 cross-document advisory dispatch subsections (each has
-        # its own dedicated budget test).
+        # the #672 cross-document advisory dispatch, AND the #673
+        # adjudication-activity wiring (each has its own dedicated budget
+        # test).
         v367_line_count = (
             total_lines - step_3b_lines - v3_7_3_lines - v3_8_lines
             - v3_9_0_lines - v3_10_lines - gate_394_lines - seq_390_lines
             - authority_670_lines - dispatch_576_lines - evidence_656_lines
-            - advisory_660_lines - advisory_672_lines
+            - advisory_660_lines - advisory_672_lines - advisory_673_lines
         )
         ceiling = BASELINE_LINE_COUNT + LINE_BUDGET_OVER_BASELINE
         self.assertLessEqual(
@@ -832,7 +896,9 @@ class Phase66LineBudgetTest(unittest.TestCase):
             f"dispatch subsection, {evidence_656_lines} are in the #656 "
             f"evidence-rendering subsection, and {advisory_660_lines} are in "
             f"the #660 advisory-dispatch subsection, and {advisory_672_lines} "
-            f"are in the #672 advisory-dispatch subsection; "
+            f"are in the #672 advisory-dispatch subsection, and "
+            f"{advisory_673_lines} are in the #673 adjudication-activity "
+            f"wiring; "
             f"v3.6.7-attributed lines = "
             f"{v367_line_count} exceeds {ceiling} (baseline "
             f"{BASELINE_LINE_COUNT} + Phase 6.6 budget "

--- a/shared/compliance_checkpoint_protocol.md
+++ b/shared/compliance_checkpoint_protocol.md
@@ -95,6 +95,34 @@ Round count is per-stage-per-pipeline-run, stored in `compliance_history[].user_
 
 On any successful override, the agent generates `disclosure_addendum` text and the orchestrator **auto-injects** it into the manuscript's AI disclosure section. The addendum is non-removable — this is the concrete form of the `no detection evasion` iron rule in CONTRIBUTING.md.
 
+### Advisory adjudication-activity receipt (#673)
+
+The compliance decision, friction-ladder enforcement, manuscript disclosure,
+and ordinary routing/state effect are completed and made durable first. Only
+afterward may the action-time producer best-effort append a closed activity
+binding through the state tracker's sole-writer path; receipt failure cannot
+change the override or checkpoint outcome.
+
+Every executed compliance report is eligible to be bound as the
+`compliance_report` role. A plain PASS or WARN report with no `user_override`
+is a valid report-only **captured-zero** group. The paired
+`compliance_override_action_receipt` is required only when the report satisfies
+the complete qualifying-override predicate in the frozen #673 spec: a
+systematic-review compliance contribution actually blocks, user action is
+required, the user override is true, and the recomputed blocker scope, stage,
+run, report hash, actor/source/action, ordinal/friction, occurrence id, and
+interaction digest all match. The action receipt contains no rationale. It is
+forbidden for a plain report and may not turn a legacy-only block, PASS/WARN,
+`user_action_required=false`, or malformed/non-qualifying override claim into
+activity.
+
+These receipt bindings remain internal activity metadata under
+`state_tracker_agent.md` § "Adjudication-activity metadata". They never enter
+`compliance_history`, the Material Passport, manuscript disclosure, checkpoint
+decision, gate/verdict input, Process Record, handoff, or model prompt, and are
+never reconstructed from prose. No model/judge/eval, network/API, clock, or
+ambient scan participates in their production.
+
 ### `disclosure_addendum` template
 
 ```

--- a/shared/contracts/activity/adjudication_activity_input.schema.json
+++ b/shared/contracts/activity/adjudication_activity_input.schema.json
@@ -1,0 +1,555 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/activity/adjudication_activity_input.schema.json",
+  "title": "Adjudication Activity Eligible-run Source Manifest",
+  "description": "Closed, data-minimized input to the deterministic adjudication-activity recorder. One manifest represents one terminal eligible run and points only to exact source artifacts. Callers cannot submit activity events, counts, rates, or overturn classifications; the recorder replays the hash-bound artifacts and derives the closed event vocabulary mechanically.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "store_id",
+    "run_id",
+    "terminal_state",
+    "terminal_stage",
+    "terminal_receipt",
+    "sources",
+    "data_minimization"
+  ],
+  "properties": {
+    "schema_version": { "const": "adjudication-activity-input/1.0" },
+    "store_id": { "$ref": "#/$defs/store_id" },
+    "run_id": {
+      "$ref": "#/$defs/run_id",
+      "description": "Stable pipeline run identity. Runtime must match it to the replayed terminal receipt and all captured source artifacts; a caller assertion alone is never accepted."
+    },
+    "terminal_state": {
+      "enum": ["completed", "aborted"],
+      "description": "Claimed terminal state, accepted only after equality with terminal_receipt.pipeline_state."
+    },
+    "terminal_stage": {
+      "$ref": "#/$defs/pipeline_stage",
+      "description": "Claimed terminal stage, accepted only after equality with terminal_receipt.current_stage."
+    },
+    "terminal_receipt": { "$ref": "#/$defs/terminal_receipt" },
+    "sources": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "prefixItems": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/source_receipt" },
+            {
+              "properties": {
+                "source_family": { "const": "revision_author_adjudication" },
+                "artifacts": {
+                  "items": {
+                    "allOf": [
+                      { "$ref": "#/$defs/source_artifact" },
+                      {
+                        "properties": {
+                          "artifact_role": {
+                            "enum": [
+                              "author_adjudication_input",
+                              "author_adjudication"
+                            ]
+                          },
+                          "artifact_group_stage": {
+                            "enum": ["pipeline_stage_3", "pipeline_stage_3_prime"]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "required": ["capture_state"],
+                "properties": { "capture_state": { "const": "captured" } }
+              },
+              "then": {
+                "properties": {
+                  "artifacts": {
+                    "minItems": 2,
+                    "maxItems": 4,
+                    "allOf": [
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "author_adjudication_input" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 2
+                      },
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "author_adjudication" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 2
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/source_receipt" },
+            {
+              "properties": {
+                "source_family": { "const": "compliance_report" },
+                "artifacts": {
+                  "items": {
+                    "allOf": [
+                      { "$ref": "#/$defs/source_artifact" },
+                      {
+                        "properties": {
+                          "artifact_role": {
+                            "enum": [
+                              "compliance_report",
+                              "compliance_override_action_receipt"
+                            ]
+                          },
+                          "artifact_group_stage": { "type": "null" }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "required": ["capture_state"],
+                "properties": { "capture_state": { "const": "captured" } }
+              },
+              "then": {
+                "properties": {
+                  "artifacts": {
+                    "minItems": 1,
+                    "maxItems": 32,
+                    "allOf": [
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "compliance_report" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 16
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/source_receipt" },
+            {
+              "properties": {
+                "source_family": { "const": "re_review_traceability" },
+                "artifacts": {
+                  "items": {
+                    "allOf": [
+                      { "$ref": "#/$defs/source_artifact" },
+                      {
+                        "properties": {
+                          "artifact_role": {
+                            "enum": [
+                              "input_manifest",
+                              "precommitment",
+                              "verdict_record",
+                              "traceability"
+                            ]
+                          },
+                          "artifact_group_stage": { "type": "null" }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "required": ["capture_state"],
+                "properties": { "capture_state": { "const": "captured" } }
+              },
+              "then": {
+                "properties": {
+                  "artifacts": {
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "allOf": [
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "input_manifest" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 1
+                      },
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "precommitment" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 1
+                      },
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "verdict_record" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 1
+                      },
+                      {
+                        "contains": {
+                          "required": ["artifact_role"],
+                          "properties": {
+                            "artifact_role": { "const": "traceability" }
+                          }
+                        },
+                        "minContains": 1,
+                        "maxContains": 1
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/source_receipt" },
+            {
+              "properties": {
+                "source_family": { "const": "explicit_user_request" },
+                "artifacts": {
+                  "items": {
+                    "allOf": [
+                      { "$ref": "#/$defs/source_artifact" },
+                      {
+                        "properties": {
+                          "artifact_role": { "const": "explicit_user_request_log" },
+                          "artifact_group_stage": { "type": "null" }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "required": ["capture_state"],
+                "properties": { "capture_state": { "const": "captured" } }
+              },
+              "then": { "properties": { "artifacts": { "minItems": 1, "maxItems": 1 } } }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/source_receipt" },
+            {
+              "properties": {
+                "source_family": { "const": "mandatory_checkpoint_response" },
+                "artifacts": {
+                  "items": {
+                    "allOf": [
+                      { "$ref": "#/$defs/source_artifact" },
+                      {
+                        "properties": {
+                          "artifact_role": {
+                            "const": "mandatory_checkpoint_response_log"
+                          },
+                          "artifact_group_stage": { "type": "null" }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "required": ["capture_state"],
+                "properties": { "capture_state": { "const": "captured" } }
+              },
+              "then": { "properties": { "artifacts": { "minItems": 1, "maxItems": 1 } } }
+            }
+          ]
+        }
+      ],
+      "items": false,
+      "description": "Exactly one receipt for each source family, in this canonical order. A normally inapplicable family is represented as not_applicable; a captured family with no qualifying records is captured with artifacts and later derives zero events."
+    },
+    "data_minimization": { "$ref": "#/$defs/data_minimization" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["terminal_state"],
+        "properties": { "terminal_state": { "const": "completed" } }
+      },
+      "then": {
+        "properties": {
+          "terminal_stage": { "const": "pipeline_stage_6" },
+          "terminal_receipt": {
+            "properties": {
+              "pipeline_state": { "const": "completed" },
+              "current_stage": { "const": "pipeline_stage_6" },
+              "current_stage_status": { "enum": ["completed", "skipped"] }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "terminal_receipt": {
+            "properties": { "pipeline_state": { "const": "aborted" } }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "store_id": {
+      "type": "string",
+      "pattern": "^ADJ-ACTIVITY-STORE-[A-Za-z0-9][A-Za-z0-9._-]{0,95}$"
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "pipeline_stage": {
+      "enum": [
+        "pipeline_stage_1",
+        "pipeline_stage_2",
+        "pipeline_stage_2_5",
+        "pipeline_stage_3",
+        "pipeline_stage_3_prime",
+        "pipeline_stage_4",
+        "pipeline_stage_4_prime",
+        "pipeline_stage_4_5",
+        "pipeline_stage_5",
+        "pipeline_stage_6"
+      ]
+    },
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:/)(?!.*\\\\)(?!\\.\\.?(?:/|$))(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)(?!.*\\/$)(?!.*[\\u0000-\\u001F\\u007F]).+$",
+      "description": "Canonical POSIX path relative to the explicit artifact root. Absolute paths, drive paths, backslashes, control characters, empty components, trailing separators, and dot or parent-traversal components are forbidden. Runtime resolution must also prove containment beneath the artifact root."
+    },
+    "terminal_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_id",
+        "relative_path",
+        "sha256",
+        "run_id",
+        "pipeline_state",
+        "current_stage",
+        "current_stage_status"
+      ],
+      "properties": {
+        "artifact_id": { "const": "pipeline-state-terminal-receipt" },
+        "relative_path": { "$ref": "#/$defs/relative_path" },
+        "sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "SHA-256 over the exact strict pipeline-state JSON bytes that runtime replays."
+        },
+        "run_id": { "$ref": "#/$defs/run_id" },
+        "pipeline_state": { "enum": ["completed", "aborted"] },
+        "current_stage": { "$ref": "#/$defs/pipeline_stage" },
+        "current_stage_status": {
+          "enum": ["pending", "in_progress", "completed", "skipped", "blocked"]
+        }
+      }
+    },
+    "source_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_id",
+        "artifact_role",
+        "artifact_group_id",
+        "artifact_group_stage",
+        "relative_path",
+        "sha256"
+      ],
+      "properties": {
+        "artifact_id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+          "description": "Opaque identity within the manifest. It is not role authority; artifact_role controls replay semantics."
+        },
+        "artifact_role": {
+          "enum": [
+            "author_adjudication_input",
+            "author_adjudication",
+            "compliance_report",
+            "compliance_override_action_receipt",
+            "input_manifest",
+            "precommitment",
+            "verdict_record",
+            "traceability",
+            "explicit_user_request_log",
+            "mandatory_checkpoint_response_log"
+          ]
+        },
+        "artifact_group_id": {
+          "type": "string",
+          "pattern": "^SOURCE-GROUP-[A-Za-z0-9][A-Za-z0-9._-]{0,95}$",
+          "description": "Stable group join key. Runtime requires each group to contain the exact source-family role set once, rejects mixed families, duplicate roles, partial groups, and more than 16 compliance groups."
+        },
+        "artifact_group_stage": {
+          "oneOf": [
+            { "$ref": "#/$defs/pipeline_stage" },
+            { "type": "null" }
+          ],
+          "description": "Per-group author-stage binding. It is Stage 3 or Stage 3 prime only for revision-author groups and null for every other source family."
+        },
+        "relative_path": { "$ref": "#/$defs/relative_path" },
+        "sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "SHA-256 over the exact artifact bytes that the recorder must replay."
+        }
+      }
+    },
+    "source_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_family",
+        "capture_state",
+        "reason_code",
+        "artifacts"
+      ],
+      "properties": {
+        "source_family": {
+          "enum": [
+            "revision_author_adjudication",
+            "compliance_report",
+            "re_review_traceability",
+            "explicit_user_request",
+            "mandatory_checkpoint_response"
+          ]
+        },
+        "capture_state": {
+          "enum": ["captured", "not_applicable", "unavailable"]
+        },
+        "reason_code": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "enum": [
+                "not_applicable_for_run",
+                "source_not_provided",
+                "source_unreadable",
+                "source_invalid",
+                "capture_not_supported"
+              ]
+            }
+          ]
+        },
+        "artifacts": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/source_artifact" }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["capture_state"],
+            "properties": { "capture_state": { "const": "captured" } }
+          },
+          "then": {
+            "properties": {
+              "reason_code": { "type": "null" },
+              "artifacts": { "minItems": 1 }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["capture_state"],
+            "properties": { "capture_state": { "const": "not_applicable" } }
+          },
+          "then": {
+            "properties": {
+              "reason_code": { "const": "not_applicable_for_run" },
+              "artifacts": { "maxItems": 0 }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["capture_state"],
+            "properties": { "capture_state": { "const": "unavailable" } }
+          },
+          "then": {
+            "properties": {
+              "reason_code": {
+                "enum": [
+                  "source_not_provided",
+                  "source_unreadable",
+                  "source_invalid",
+                  "capture_not_supported"
+                ]
+              },
+              "artifacts": { "maxItems": 0 }
+            }
+          }
+        }
+      ]
+    },
+    "data_minimization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_prose_embedded",
+        "user_identity_embedded",
+        "absolute_paths_embedded"
+      ],
+      "properties": {
+        "raw_prose_embedded": { "const": false },
+        "user_identity_embedded": { "const": false },
+        "absolute_paths_embedded": { "const": false }
+      }
+    }
+  }
+}

--- a/shared/contracts/activity/adjudication_activity_store.schema.json
+++ b/shared/contracts/activity/adjudication_activity_store.schema.json
@@ -1,0 +1,560 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Imbad0202/academic-research-skills/shared/contracts/activity/adjudication_activity_store.schema.json",
+  "title": "Local Adjudication Activity Store",
+  "description": "Closed, user-owned local store of runtime-derived explicit adjudication activity. Runs are sealed immutable records ordered only by append_sequence; no clock, prose, identity, path, aggregate, rate, score, target, threshold, or caller-supplied overturn boolean is stored. Deletion rewrites the selected store without tombstones or derived aggregates, increments revision, and never renumbers or reuses surviving append sequences.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "store_id",
+    "revision",
+    "next_sequence",
+    "runs",
+    "data_minimization"
+  ],
+  "properties": {
+    "schema_version": { "const": "adjudication-activity-store/1.0" },
+    "store_id": { "$ref": "#/$defs/store_id" },
+    "revision": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "An empty initialized store starts at 0. Every successful append or explicit deletion rewrite increments the prior revision by exactly one; cross-revision enforcement is runtime-owned."
+    },
+    "next_sequence": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The sequence assigned to the next append while holding the store lock. It starts at 1 and never decreases or reuses a number after deletion."
+    },
+    "runs": {
+      "type": "array",
+      "maxItems": 10000,
+      "items": { "$ref": "#/$defs/run_record" },
+      "description": "Append-ordered sealed records. Runtime additionally caps derived events at 4,096 per run and 100,000 per store and fails closed at the configured 16 MiB store limit; it never evicts an older run automatically."
+    },
+    "data_minimization": { "$ref": "#/$defs/data_minimization" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["revision"],
+        "properties": { "revision": { "const": 0 } }
+      },
+      "then": {
+        "properties": {
+          "next_sequence": { "const": 1 },
+          "runs": { "maxItems": 0 }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["runs"],
+        "properties": { "runs": { "minItems": 1 } }
+      },
+      "then": {
+        "properties": { "revision": { "minimum": 1 } }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "store_id": {
+      "type": "string",
+      "pattern": "^ADJ-ACTIVITY-STORE-[A-Za-z0-9][A-Za-z0-9._-]{0,95}$"
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^ACTIVITY-EVENT-[0-9a-f]{64}$",
+      "description": "ACTIVITY-EVENT- followed by SHA-256 over the versioned event-id domain separator and restricted JCS-compatible event payload with only event_id omitted; no clock or random source is consulted."
+    },
+    "pipeline_stage": {
+      "enum": [
+        "pipeline_stage_1",
+        "pipeline_stage_2",
+        "pipeline_stage_2_5",
+        "pipeline_stage_3",
+        "pipeline_stage_3_prime",
+        "pipeline_stage_4",
+        "pipeline_stage_4_prime",
+        "pipeline_stage_4_5",
+        "pipeline_stage_5",
+        "pipeline_stage_6"
+      ]
+    },
+    "event_type": {
+      "enum": [
+        "author_triage_wont_address",
+        "author_triage_not_on_point",
+        "compliance_block_override",
+        "re_review_verdict_changed",
+        "finding_justification_requested",
+        "finding_redo_requested",
+        "mandatory_checkpoint_non_proceed"
+      ],
+      "description": "Every row is explicit adjudication activity. The derived overturn subset is exactly author_triage_not_on_point, compliance_block_override, and re_review_verdict_changed; wont_address, requests, and checkpoint non-proceed dispositions remain visible activity but are not overturns."
+    },
+    "disposition": {
+      "enum": [
+        "wont_address",
+        "not_on_point",
+        "block_overridden",
+        "verdict_changed",
+        "justification_requested",
+        "redo_requested",
+        "pause",
+        "adjust",
+        "view_progress",
+        "redo",
+        "abort",
+        "skip_refused"
+      ]
+    },
+    "event_base": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_id",
+        "event_type",
+        "stage",
+        "disposition",
+        "interaction_sha256",
+        "source_event_sha256"
+      ],
+      "properties": {
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "event_type": { "$ref": "#/$defs/event_type" },
+        "stage": { "$ref": "#/$defs/pipeline_stage" },
+        "disposition": { "$ref": "#/$defs/disposition" },
+        "interaction_sha256": {
+          "oneOf": [
+            { "$ref": "#/$defs/sha256" },
+            { "type": "null" }
+          ],
+          "description": "Digest of the same explicit user interaction when a closed source receipt exposes one, else null. Runtime deduplicates equal non-null values across families by canonical source order while retaining every per-item event inside the winning family."
+        },
+        "source_event_sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "SHA-256 over the family-specific canonical source event using the recorder's restricted JCS-compatible serializer (ASCII contract keys, integers only, compact UTF-8) and versioned source-event domain separator. The store retains the digest, never source prose."
+        }
+      }
+    },
+    "author_wont_address_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "author_triage_wont_address" },
+            "stage": {
+              "enum": ["pipeline_stage_3", "pipeline_stage_3_prime"]
+            },
+            "disposition": { "const": "wont_address" },
+            "interaction_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
+    },
+    "author_not_on_point_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "author_triage_not_on_point" },
+            "stage": {
+              "enum": ["pipeline_stage_3", "pipeline_stage_3_prime"]
+            },
+            "disposition": { "const": "not_on_point" },
+            "interaction_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
+    },
+    "compliance_override_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "compliance_block_override" },
+            "stage": {
+              "enum": ["pipeline_stage_2_5", "pipeline_stage_4_5"]
+            },
+            "disposition": { "const": "block_overridden" },
+            "interaction_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
+    },
+    "re_review_changed_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "re_review_verdict_changed" },
+            "stage": { "const": "pipeline_stage_3_prime" },
+            "disposition": { "const": "verdict_changed" },
+            "interaction_sha256": { "type": "null" }
+          }
+        }
+      ]
+    },
+    "justification_requested_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "finding_justification_requested" },
+            "disposition": { "const": "justification_requested" },
+            "interaction_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
+    },
+    "redo_requested_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "finding_redo_requested" },
+            "disposition": { "const": "redo_requested" },
+            "interaction_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
+    },
+    "mandatory_non_proceed_event": {
+      "allOf": [
+        { "$ref": "#/$defs/event_base" },
+        {
+          "properties": {
+            "event_type": { "const": "mandatory_checkpoint_non_proceed" },
+            "stage": { "$ref": "#/$defs/pipeline_stage" },
+            "interaction_sha256": { "$ref": "#/$defs/sha256" },
+            "disposition": {
+              "enum": [
+                "pause",
+                "adjust",
+                "view_progress",
+                "redo",
+                "abort",
+                "skip_refused"
+              ],
+              "description": "skip_refused records an explicit skip command at a MANDATORY checkpoint. It is activity but never an overturn and cannot change checkpoint or pipeline state."
+            }
+          }
+        }
+      ]
+    },
+    "source_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_family",
+        "capture_state",
+        "reason_code",
+        "artifact_sha256s",
+        "events"
+      ],
+      "properties": {
+        "source_family": {
+          "enum": [
+            "revision_author_adjudication",
+            "compliance_report",
+            "re_review_traceability",
+            "explicit_user_request",
+            "mandatory_checkpoint_response"
+          ]
+        },
+        "capture_state": {
+          "enum": ["captured", "not_applicable", "unavailable"]
+        },
+        "reason_code": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "enum": [
+                "not_applicable_for_run",
+                "source_not_provided",
+                "source_unreadable",
+                "source_invalid",
+                "capture_not_supported"
+              ]
+            }
+          ]
+        },
+        "artifact_sha256s": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/sha256" },
+          "description": "Exact artifact-byte digests copied from the validated input receipt in canonical artifact order, including legitimate repeated hashes from distinct role/group identities. Artifact ids and paths are deliberately not retained."
+        },
+        "events": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["capture_state"],
+            "properties": { "capture_state": { "const": "captured" } }
+          },
+          "then": {
+            "properties": {
+              "reason_code": { "type": "null" },
+              "artifact_sha256s": { "minItems": 1 }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["capture_state"],
+            "properties": { "capture_state": { "const": "not_applicable" } }
+          },
+          "then": {
+            "properties": {
+              "reason_code": { "const": "not_applicable_for_run" },
+              "artifact_sha256s": { "maxItems": 0 },
+              "events": { "maxItems": 0 }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["capture_state"],
+            "properties": { "capture_state": { "const": "unavailable" } }
+          },
+          "then": {
+            "properties": {
+              "reason_code": {
+                "enum": [
+                  "source_not_provided",
+                  "source_unreadable",
+                  "source_invalid",
+                  "capture_not_supported"
+                ]
+              },
+              "artifact_sha256s": { "maxItems": 0 },
+              "events": { "maxItems": 0 }
+            }
+          }
+        }
+      ]
+    },
+    "run_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "append_sequence",
+        "run_id",
+        "terminal_state",
+        "terminal_stage",
+        "terminal_receipt_sha256",
+        "input_receipt_sha256",
+        "record_sha256",
+        "sealed",
+        "sources"
+      ],
+      "properties": {
+        "append_sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "run_id": { "$ref": "#/$defs/run_id" },
+        "terminal_state": { "enum": ["completed", "aborted"] },
+        "terminal_stage": { "$ref": "#/$defs/pipeline_stage" },
+        "terminal_receipt_sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "Exact-byte SHA-256 copied from the validated terminal_receipt artifact binding after strict state replay."
+        },
+        "input_receipt_sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "SHA-256 over one NUL-terminated versioned input-receipt domain separator followed by the restricted JCS-compatible serialization (ASCII contract keys, integers only, compact UTF-8) of the complete validated input manifest."
+        },
+        "record_sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "SHA-256 over one NUL-terminated versioned run-record domain separator followed by the restricted JCS-compatible serialization (ASCII contract keys, integers only, compact UTF-8) of this complete run record with only record_sha256 omitted. append_sequence is included."
+        },
+        "sealed": {
+          "const": true,
+          "description": "Runtime seal marker. An existing run record is immutable across store revisions; only whole selected records may be explicitly deleted."
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "prefixItems": [
+            {
+              "allOf": [
+                { "$ref": "#/$defs/source_receipt" },
+                {
+                  "properties": {
+                    "source_family": { "const": "revision_author_adjudication" },
+                    "events": {
+                      "items": {
+                        "oneOf": [
+                          { "$ref": "#/$defs/author_wont_address_event" },
+                          { "$ref": "#/$defs/author_not_on_point_event" }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "required": ["capture_state"],
+                    "properties": { "capture_state": { "const": "captured" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "artifact_sha256s": {
+                        "oneOf": [
+                          { "minItems": 2, "maxItems": 2 },
+                          { "minItems": 4, "maxItems": 4 }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/source_receipt" },
+                {
+                  "properties": {
+                    "source_family": { "const": "compliance_report" },
+                    "events": {
+                      "items": { "$ref": "#/$defs/compliance_override_event" }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "required": ["capture_state"],
+                    "properties": { "capture_state": { "const": "captured" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "artifact_sha256s": { "minItems": 1, "maxItems": 32 }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/source_receipt" },
+                {
+                  "properties": {
+                    "source_family": { "const": "re_review_traceability" },
+                    "events": {
+                      "items": { "$ref": "#/$defs/re_review_changed_event" }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "required": ["capture_state"],
+                    "properties": { "capture_state": { "const": "captured" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "artifact_sha256s": { "minItems": 4, "maxItems": 4 }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/source_receipt" },
+                {
+                  "properties": {
+                    "source_family": { "const": "explicit_user_request" },
+                    "events": {
+                      "items": {
+                        "oneOf": [
+                          { "$ref": "#/$defs/justification_requested_event" },
+                          { "$ref": "#/$defs/redo_requested_event" }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "required": ["capture_state"],
+                    "properties": { "capture_state": { "const": "captured" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "artifact_sha256s": { "minItems": 1, "maxItems": 1 }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/source_receipt" },
+                {
+                  "properties": {
+                    "source_family": { "const": "mandatory_checkpoint_response" },
+                    "events": {
+                      "items": { "$ref": "#/$defs/mandatory_non_proceed_event" }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "required": ["capture_state"],
+                    "properties": { "capture_state": { "const": "captured" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "artifact_sha256s": { "minItems": 1, "maxItems": 1 }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "items": false
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["terminal_state"],
+            "properties": { "terminal_state": { "const": "completed" } }
+          },
+          "then": {
+            "properties": { "terminal_stage": { "const": "pipeline_stage_6" } }
+          }
+        }
+      ]
+    },
+    "data_minimization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_prose_embedded",
+        "user_identity_embedded",
+        "absolute_paths_embedded"
+      ],
+      "properties": {
+        "raw_prose_embedded": { "const": false },
+        "user_identity_embedded": { "const": false },
+        "absolute_paths_embedded": { "const": false }
+      }
+    }
+  }
+}

--- a/shared/handoff_schemas.md
+++ b/shared/handoff_schemas.md
@@ -8,6 +8,18 @@ Consuming agents should validate input and request re-generation if schema viola
 
 > **Convention**: All schemas use Markdown-based structured output. Agents MUST validate required fields before accepting a handoff. Missing required fields trigger a `HANDOFF_INCOMPLETE` failure path.
 
+> **#673 activity exclusion:** adjudication activity is not handoff cargo.
+> the #673 activity projection of the terminal state root `run_id`,
+> `pending_adjudication_activity_bindings[]`, sealed
+> `adjudication_activity_sources`, selected-store information, store records,
+> renderer output, and activity diagnostics remain only in the state tracker's
+> local advisory side channel. They MUST NOT be added to any numbered schema,
+> Material Passport, stage transfer, gate/verdict/checkpoint input, Process
+> Record, or model/observer/compliance input. See
+> `academic-pipeline/agents/state_tracker_agent.md` §
+> "Adjudication-activity metadata". This exclusion does not remove or alter any
+> existing schema-owned `run_id` field used by another contract.
+
 ---
 
 ## Schema 1: RQ Brief (deep-research -> academic-paper)
@@ -601,6 +613,13 @@ equal the carried post draft; matching reported hashes alone are insufficient.
 ## Schema 9: Material Passport (cross-stage metadata)
 
 **Purpose**: Accompanies every artifact as it passes between stages, providing provenance and verification tracking.
+
+The #673 activity fields named in the top-level exclusion are deliberately not
+Schema 9 fields. In particular, the #673 projection of the terminal state
+file's root `run_id` plus sealed root `adjudication_activity_sources` are
+activity source/run authority; copying either activity projection into a
+passport would create an unauthorized second authority. Existing independently
+schema-owned `run_id` fields are unaffected.
 
 ### Required Fields
 


### PR DESCRIPTION
Closes #673

## What changed

- freeze Draft 2020-12 input/store contracts for cross-run adjudication activity
- add a deterministic local CLI for store initialization, sealed input projection, idempotent append, rendering, validation, and explicit deletion
- wire action-time receipts and terminal-first post-terminal sealing into the pipeline protocol without creating a gate or verdict input
- add hermetic fixtures, adversarial runtime tests, a non-consumer integration guard, CI manifest entries, and workflow coverage

## Why

The pipeline needs an opt-in, data-minimized history of explicit adjudication actions across runs. The history must remain local and advisory-only: no model, API, judge, eval, network, clock, ambient scan, or downstream gate may consume it.

## Validation

- `python -m pytest -q`: 7560 passed, 3 skipped, 1 xfailed, 153 subtests passed
- focused #673 and pipeline budget/boundary suites: 175 passed
- Draft 2020-12 metaschema and positive/negative payload validation
- `ruff check` on every changed Python file
- `py_compile` on every changed Python file
- spec consistency, pipeline boundary, pipeline integrity, #673 integration, CI manifest, and diff checks

Note: repository-wide `ruff check .` still reports 116 pre-existing findings in files untouched by this PR; every changed Python file passes Ruff.
