### PR TITLE
Accept Codex subscription status on stderr

### DIFF
--- a/evals/heldout/review_criteria_constructive_value/suite_lock.json
+++ b/evals/heldout/review_criteria_constructive_value/suite_lock.json
@@ -16,7 +16,7 @@
     "evals/heldout/review_criteria_constructive_value/subject_output.schema.json": "2f650570f1b3ea774a38b625ede0cd7e5ad7017403a187c679be094581151c35",
     "evals/heldout/review_criteria_constructive_value/treatment_prompt.md": "16907b4c35d9df226f831a837de0788d47d0790209d6f1a14e7fbebbb0921f22",
     "scripts/fixtures/review_target_context/synthetic-registry.json": "ad8a7892f975842ec99d66e16e4a45fc63bb9da09a14e38d86785532d26f2be1",
-    "scripts/run_review_criteria_constructive_value.py": "f515e8b1eb409431eb02352e395dcd8ab5b61e91edefb55f74148cd8e5df9fe8",
+    "scripts/run_review_criteria_constructive_value.py": "2a26f1ff156dc37425aa4a5449b742895c9910aa252e1dd1e73e8e768db64b21",
     "scripts/score_review_criteria_constructive_value.py": "1f1c2be5844da3be0933d71fd1c305f9d697cf8601efcc582bffddc8e1d1fd7f"
   }
 }

--- a/scripts/run_review_criteria_constructive_value.py
+++ b/scripts/run_review_criteria_constructive_value.py
@@ -660,7 +660,12 @@ def detect(model: str, environ: dict[str, str] | None = None) -> dict[str, Any]:
     if version < MIN_CODEX_VERSION:
         result["reason_code"] = "CODEX_VERSION_TOO_OLD"
         return result
-    if status_run.returncode or status_run.stdout.strip() != "Logged in using ChatGPT":
+    status_lines = {
+        line.strip()
+        for line in (status_run.stdout + "\n" + status_run.stderr).splitlines()
+        if line.strip()
+    }
+    if status_run.returncode or "Logged in using ChatGPT" not in status_lines:
         result["reason_code"] = "AUTH_NOT_CHATGPT_SUBSCRIPTION"
         return result
     result.update(

--- a/scripts/test_run_review_criteria_constructive_value.py
+++ b/scripts/test_run_review_criteria_constructive_value.py
@@ -16,7 +16,8 @@ import score_review_criteria_constructive_value as scorer
 
 def _fake_codex(
     tmp_path: Path, *, status: str = "Logged in using ChatGPT",
-    forbidden_event: bool = False, invalid_output: bool = False,
+    status_to_stderr: bool = False, forbidden_event: bool = False,
+    invalid_output: bool = False,
 ) -> tuple[Path, Path]:
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
@@ -30,6 +31,7 @@ from pathlib import Path
 import sys
 
 STATUS = {status!r}
+STATUS_TO_STDERR = {status_to_stderr!r}
 FORBIDDEN = {forbidden_event!r}
 INVALID = {invalid_output!r}
 CAPTURE = Path(__file__).with_name("capture.jsonl")
@@ -38,7 +40,7 @@ if sys.argv[1:] == ["--version"]:
     print("codex-cli 0.147.0")
     raise SystemExit(0)
 if sys.argv[1:] == ["login", "status"]:
-    print(STATUS)
+    print(STATUS, file=sys.stderr if STATUS_TO_STDERR else sys.stdout)
     raise SystemExit(0)
 if not sys.argv[1:] or sys.argv[1] != "exec":
     raise SystemExit(9)
@@ -190,6 +192,12 @@ def test_detection_requires_exact_chatgpt_subscription_status(tmp_path) -> None:
     unavailable = runner.detect("gpt-5.6", _env(other, fake_bin))
     assert unavailable["available"] is False
     assert unavailable["reason_code"] == "AUTH_NOT_CHATGPT_SUBSCRIPTION"
+
+    stderr_home = tmp_path / "stderr-status"
+    stderr_home.mkdir()
+    fake_bin, _ = _fake_codex(stderr_home, status_to_stderr=True)
+    detected = runner.detect("gpt-5.6", _env(stderr_home, fake_bin))
+    assert detected["auth_mode"] == "chatgpt_subscription"
 
 
 def test_dispatch_requires_flag_and_exact_plan_hash(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- accept the exact Logged in using ChatGPT status line from either stdout or stderr
- retain exact-line matching so warnings, API-key login, and substring lookalikes cannot pass
- update the sealed runner hash and add stderr regression coverage

## Validation
- real preflight: ChatGPT subscription available, Codex CLI 0.147.0, gpt-5.6-terra selected
- focused runner and guard suites: 38 passed
- ruff, py_compile, asset validation, #684 guard, and diff-check passed
- no model prompt or API request was dispatched

Advances #684; the actual 24-call run and human expert evaluation remain outstanding.

[skip-closes-check]
Justification: this transport compatibility fix must land in main before a provenance-valid measurement run can be initialized. Closing #684 before the actual expert-labelled run would be incorrect.