### PR TITLE
Harden #684 provider response schema

### DIFF
--- a/evals/heldout/review_criteria_constructive_value/measurement_plan.md
+++ b/evals/heldout/review_criteria_constructive_value/measurement_plan.md
@@ -1,4 +1,4 @@
-# Frozen measurement plan — review_criteria_constructive_value/1.2
+# Frozen measurement plan — review_criteria_constructive_value/1.3
 
 Status: PRE-REGISTERED / NOT RUN. Issue: #684. Contract:
 `heldout-measurement/1.1`; suite class: `paired_controls`.
@@ -145,3 +145,11 @@ new plan version and new run; results are not pooled.
   removed redundant model-judge calls. The exact subject design remains 24
   contained Codex subscription calls; metered API spend remains USD 0. Plans
   1.0 and 1.1 produced no subject, judge, or expert output.
+- 2026-08-11, plan 1.3, after the first plan 1.2 dispatch attempt: the provider
+  rejected call 1 before subject generation because string `const`/`enum`
+  nodes in `subject_output.schema.json` lacked explicit `type: "string"`.
+  The blocked event stream and stderr are retained; no subject output was
+  produced, calls 2–24 were not dispatched, and the plan 1.2 run is not
+  retried. Plan 1.3 adds only those provider-required type declarations and a
+  local response-schema subset guard; design cells, prompts, model budget,
+  metrics, human-expert plan, and USD 0 API ceiling are unchanged.

--- a/evals/heldout/review_criteria_constructive_value/subject_output.schema.json
+++ b/evals/heldout/review_criteria_constructive_value/subject_output.schema.json
@@ -6,10 +6,10 @@
   "additionalProperties": false,
   "required": ["schema_version", "item_id", "consumer_id", "role", "profile", "applicability", "findings"],
   "properties": {
-    "schema_version": {"const": "review-criteria-subject-output/1.0"},
+    "schema_version": {"type": "string", "const": "review-criteria-subject-output/1.0"},
     "item_id": {"type": "string", "pattern": "^RCV-0[1-6]$"},
-    "consumer_id": {"enum": ["formative_planning", "internal_evaluator", "external_panel"]},
-    "role": {"enum": ["FORMATIVE", "INTERNAL", "EIC", "R1", "R2", "R3", "DA"]},
+    "consumer_id": {"type": "string", "enum": ["formative_planning", "internal_evaluator", "external_panel"]},
+    "role": {"type": "string", "enum": ["FORMATIVE", "INTERNAL", "EIC", "R1", "R2", "R3", "DA"]},
     "profile": {
       "type": "object",
       "additionalProperties": false,
@@ -31,7 +31,7 @@
         "required": ["criterion_id", "predicted", "rationale"],
         "properties": {
           "criterion_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
-          "predicted": {"enum": ["applicable", "not_applicable", "unresolved"]},
+          "predicted": {"type": "string", "enum": ["applicable", "not_applicable", "unresolved"]},
           "rationale": {"type": "string", "minLength": 1, "maxLength": 1200}
         }
       }
@@ -48,7 +48,7 @@
         ],
         "properties": {
           "finding_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
-          "predicted_severity": {"enum": ["critical", "major"]},
+          "predicted_severity": {"type": "string", "enum": ["critical", "major"]},
           "criterion_ids": {
             "type": "array",
             "minItems": 1,
@@ -65,7 +65,7 @@
             }
           },
           "scholarly_relevance": {"type": "string", "minLength": 1, "maxLength": 1200},
-          "predicted_venue_alignment": {"enum": ["aligned", "not_aligned", "not_claimed"]},
+          "predicted_venue_alignment": {"type": "string", "enum": ["aligned", "not_aligned", "not_claimed"]},
           "remedy": {
             "type": "object",
             "additionalProperties": false,
@@ -75,11 +75,11 @@
               "proposed_result_values", "no_honest_reason"
             ],
             "properties": {
-              "status": {"enum": ["available", "none"]},
+              "status": {"type": "string", "enum": ["available", "none"]},
               "minimum_action": {"type": ["string", "null"], "minLength": 1, "maxLength": 1200},
-              "effort_scope": {"enum": ["sentence", "section", "re_analysis", "new_data", "other", "none"]},
+              "effort_scope": {"type": "string", "enum": ["sentence", "section", "re_analysis", "new_data", "other", "none"]},
               "cost_tradeoffs": {"type": "string", "maxLength": 1200},
-              "changes_research_intent": {"enum": ["no", "yes_author_choice_required", "uncertain_author_choice_required", "not_applicable"]},
+              "changes_research_intent": {"type": "string", "enum": ["no", "yes_author_choice_required", "uncertain_author_choice_required", "not_applicable"]},
               "requires_new_data": {"type": "boolean"},
               "proposed_result_values": {"type": "boolean"},
               "no_honest_reason": {"type": ["string", "null"], "minLength": 1, "maxLength": 1200}

--- a/evals/heldout/review_criteria_constructive_value/suite_lock.json
+++ b/evals/heldout/review_criteria_constructive_value/suite_lock.json
@@ -9,14 +9,14 @@
     "evals/heldout/review_criteria_constructive_value/expert_labels.schema.json": "7856c37648372665bd3fd701c793e1a98f94e0be5324671257136bc340baa258",
     "evals/heldout/review_criteria_constructive_value/expert_packet.schema.json": "c3d3a707b3480f8e6b4357f3c5c8ad624396a685778469948a6bfaf8f49a5077",
     "evals/heldout/review_criteria_constructive_value/heldout_set.json": "c7728656b30f626f6c2b487893405d5f7459b77a69d293e7ec70855c43984384",
-    "evals/heldout/review_criteria_constructive_value/measurement_plan.md": "7670624c96d476a752a960e0fd69afd5ec0967a0f3f3617fe2f755e17e71fbc5",
+    "evals/heldout/review_criteria_constructive_value/measurement_plan.md": "db484a5127c629a80ade8f7cb750b2d8780e7bcb4854f893d20eb75ccb547886",
     "evals/heldout/review_criteria_constructive_value/paired_adjudication.schema.json": "0bbcf55e465afdea27d911f295276bbd2ac1a87df2d4ff6b6278a92a3a89d0f1",
     "evals/heldout/review_criteria_constructive_value/scenarios.json": "5dfa559578d27e498285ab33eca2b50237210e69dd6ed39b0cad4a4b2d5c6af9",
     "evals/heldout/review_criteria_constructive_value/scenarios.schema.json": "e592085f097981b9a0308e12c85a41fceba99993fbc72dd9c5a27a10026b159e",
-    "evals/heldout/review_criteria_constructive_value/subject_output.schema.json": "2f650570f1b3ea774a38b625ede0cd7e5ad7017403a187c679be094581151c35",
+    "evals/heldout/review_criteria_constructive_value/subject_output.schema.json": "b3386be4e1eca8f2ce4850a3067c7ab0bc21cc98a938d2e709956cc397c05531",
     "evals/heldout/review_criteria_constructive_value/treatment_prompt.md": "16907b4c35d9df226f831a837de0788d47d0790209d6f1a14e7fbebbb0921f22",
     "scripts/fixtures/review_target_context/synthetic-registry.json": "ad8a7892f975842ec99d66e16e4a45fc63bb9da09a14e38d86785532d26f2be1",
-    "scripts/run_review_criteria_constructive_value.py": "2a26f1ff156dc37425aa4a5449b742895c9910aa252e1dd1e73e8e768db64b21",
+    "scripts/run_review_criteria_constructive_value.py": "7a8fae67beb300195fa10354b423b649f1146196daffc4584f718e6fd248776b",
     "scripts/score_review_criteria_constructive_value.py": "1f1c2be5844da3be0933d71fd1c305f9d697cf8601efcc582bffddc8e1d1fd7f"
   }
 }

--- a/scripts/run_review_criteria_constructive_value.py
+++ b/scripts/run_review_criteria_constructive_value.py
@@ -261,6 +261,27 @@ def _validate(schema_path: Path, value: Any, label: str) -> None:
         _fail(f"{label} schema failure at {location}: {first.message}")
 
 
+def _validate_provider_response_schema(node: Any, path: str = "$") -> None:
+    """Pin the strict response-schema subset required by Codex/OpenAI."""
+    if isinstance(node, list):
+        for index, value in enumerate(node):
+            _validate_provider_response_schema(value, f"{path}[{index}]")
+        return
+    if not isinstance(node, dict):
+        return
+    if ("const" in node or "enum" in node) and "type" not in node:
+        _fail(f"provider response schema requires explicit type at {path}")
+    if node.get("type") == "object":
+        properties = node.get("properties")
+        required = node.get("required")
+        if not isinstance(properties, dict) or node.get("additionalProperties") is not False:
+            _fail(f"provider response object must be closed at {path}")
+        if not isinstance(required, list) or set(required) != set(properties):
+            _fail(f"provider response object must require every property at {path}")
+    for key, value in node.items():
+        _validate_provider_response_schema(value, f"{path}.{key}")
+
+
 def _repo_ref(ref: str) -> Path:
     if not isinstance(ref, str) or not ref or ref.startswith("/") or "\\" in ref:
         _fail(f"invalid repository reference: {ref!r}")
@@ -386,6 +407,7 @@ def validate_assets() -> dict[str, Any]:
         EXECUTION_SCHEMA_PATH,
     ):
         _schema(schema_path)
+    _validate_provider_response_schema(_schema(OUTPUT_SCHEMA_PATH))
     return {
         "suite": SUITE,
         "assets": len(assets),

--- a/scripts/test_run_review_criteria_constructive_value.py
+++ b/scripts/test_run_review_criteria_constructive_value.py
@@ -161,6 +161,29 @@ def test_lock_hash_mutation_fails(monkeypatch, tmp_path) -> None:
         runner.validate_assets()
 
 
+@pytest.mark.parametrize("keyword", ["const", "enum"])
+def test_provider_response_schema_requires_explicit_types(keyword: str) -> None:
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["value"],
+        "properties": {"value": {keyword: "x" if keyword == "const" else ["x"]}},
+    }
+    with pytest.raises(runner.MeasurementError, match="requires explicit type"):
+        runner._validate_provider_response_schema(schema)
+
+
+def test_provider_response_schema_requires_closed_fully_required_objects() -> None:
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [],
+        "properties": {"value": {"type": "string"}},
+    }
+    with pytest.raises(runner.MeasurementError, match="require every property"):
+        runner._validate_provider_response_schema(schema)
+
+
 def test_init_run_seals_same_context_bytes_and_only_treatment_binding(
     monkeypatch, tmp_path
 ) -> None:


### PR DESCRIPTION
## Summary
- record plan 1.2 as permanently blocked after call 1 was rejected before subject generation
- add explicit string types to every subject-output const and enum for the strict provider response-schema subset
- add local guards requiring typed const/enum nodes and closed fully-required response objects
- update all sealed hashes; design, prompts, model budget, metrics, human panel, and USD 0 API ceiling are unchanged

## Evidence
- blocked plan 1.2 evidence is retained on `codex/684-heldout-run` commit 44df268
- provider response: invalid_json_schema before subject output; calls 2-24 were not dispatched
- focused suites: 218 passed
- ruff, py_compile, asset lock, held-out contract, #684 guard, CI manifest, spec consistency, and diff-check passed

No retry or further model/API request was made.

Advances #684; a new plan 1.3 run requires a new exact SHA and fresh explicit consent.

[skip-closes-check]
Justification: this schema compatibility fix must land before a new frozen run can be initialized. The expert-labelled measurement remains incomplete, so auto-closing #684 would be incorrect.