### PR TITLE
Harden #684 provider schema projection

### DIFF
--- a/evals/heldout/review_criteria_constructive_value/measurement_plan.md
+++ b/evals/heldout/review_criteria_constructive_value/measurement_plan.md
@@ -1,4 +1,4 @@
-# Frozen measurement plan — review_criteria_constructive_value/1.3
+# Frozen measurement plan — review_criteria_constructive_value/1.4
 
 Status: PRE-REGISTERED / NOT RUN. Issue: #684. Contract:
 `heldout-measurement/1.1`; suite class: `paired_controls`.
@@ -153,3 +153,16 @@ new plan version and new run; results are not pooled.
   retried. Plan 1.3 adds only those provider-required type declarations and a
   local response-schema subset guard; design cells, prompts, model budget,
   metrics, human-expert plan, and USD 0 API ceiling are unchanged.
+- 2026-08-11, plan 1.4, after the first plan 1.3 dispatch attempt: shell
+  interpolation while posting the plan-status issue comment accidentally invoked
+  the newly frozen dispatch command before fresh consent. The fail-closed runner
+  stopped after call 1 when the provider rejected `uniqueItems`; no subject
+  output was produced, calls 2–24 were not dispatched, no retry occurred, and
+  recorded API spend remained USD 0. The blocked event stream and stderr are
+  retained and plan 1.3 is not retried. Plan 1.4 sends a provider projection
+  that removes schema-document annotations and the unsupported `uniqueItems`,
+  `minLength`, and `maxLength` assertions while retaining the original complete
+  Draft 2020-12 schema for mandatory post-generation validation. It also pins a
+  closed provider-keyword guard and integration regression. Design cells,
+  prompts, model budget, metrics, human-expert plan, and USD 0 API ceiling are
+  unchanged. No plan 1.4 subject call is authorized by prior consent.

--- a/evals/heldout/review_criteria_constructive_value/suite_lock.json
+++ b/evals/heldout/review_criteria_constructive_value/suite_lock.json
@@ -9,14 +9,14 @@
     "evals/heldout/review_criteria_constructive_value/expert_labels.schema.json": "7856c37648372665bd3fd701c793e1a98f94e0be5324671257136bc340baa258",
     "evals/heldout/review_criteria_constructive_value/expert_packet.schema.json": "c3d3a707b3480f8e6b4357f3c5c8ad624396a685778469948a6bfaf8f49a5077",
     "evals/heldout/review_criteria_constructive_value/heldout_set.json": "c7728656b30f626f6c2b487893405d5f7459b77a69d293e7ec70855c43984384",
-    "evals/heldout/review_criteria_constructive_value/measurement_plan.md": "db484a5127c629a80ade8f7cb750b2d8780e7bcb4854f893d20eb75ccb547886",
+    "evals/heldout/review_criteria_constructive_value/measurement_plan.md": "a238e2e9df41513c4c940b5abcd91abbb25e2f5f2e0c38ad3359f7eaa6e76492",
     "evals/heldout/review_criteria_constructive_value/paired_adjudication.schema.json": "0bbcf55e465afdea27d911f295276bbd2ac1a87df2d4ff6b6278a92a3a89d0f1",
     "evals/heldout/review_criteria_constructive_value/scenarios.json": "5dfa559578d27e498285ab33eca2b50237210e69dd6ed39b0cad4a4b2d5c6af9",
     "evals/heldout/review_criteria_constructive_value/scenarios.schema.json": "e592085f097981b9a0308e12c85a41fceba99993fbc72dd9c5a27a10026b159e",
     "evals/heldout/review_criteria_constructive_value/subject_output.schema.json": "b3386be4e1eca8f2ce4850a3067c7ab0bc21cc98a938d2e709956cc397c05531",
     "evals/heldout/review_criteria_constructive_value/treatment_prompt.md": "16907b4c35d9df226f831a837de0788d47d0790209d6f1a14e7fbebbb0921f22",
     "scripts/fixtures/review_target_context/synthetic-registry.json": "ad8a7892f975842ec99d66e16e4a45fc63bb9da09a14e38d86785532d26f2be1",
-    "scripts/run_review_criteria_constructive_value.py": "7a8fae67beb300195fa10354b423b649f1146196daffc4584f718e6fd248776b",
+    "scripts/run_review_criteria_constructive_value.py": "91ec6b896d24d97d189cb9f8ccf69565b71d2888b9f6c56fa53572823fe3d9a8",
     "scripts/score_review_criteria_constructive_value.py": "1f1c2be5844da3be0933d71fd1c305f9d697cf8601efcc582bffddc8e1d1fd7f"
   }
 }

--- a/scripts/run_review_criteria_constructive_value.py
+++ b/scripts/run_review_criteria_constructive_value.py
@@ -64,6 +64,23 @@ MODEL_RE = re.compile(r"^gpt-[a-z0-9][a-z0-9._-]{0,123}$")
 SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 VERSION_RE = re.compile(r"\bcodex-cli\s+(\d+)\.(\d+)\.(\d+)\b")
+PROVIDER_SCHEMA_STRIPPED_KEYWORDS = frozenset(
+    {"$schema", "$id", "title", "uniqueItems", "minLength", "maxLength"}
+)
+PROVIDER_SCHEMA_ALLOWED_KEYWORDS = frozenset(
+    {
+        "type",
+        "const",
+        "enum",
+        "properties",
+        "required",
+        "additionalProperties",
+        "items",
+        "minItems",
+        "maxItems",
+        "pattern",
+    }
+)
 BLINDING = [
     "arm_identity",
     "mechanism_state",
@@ -261,14 +278,38 @@ def _validate(schema_path: Path, value: Any, label: str) -> None:
         _fail(f"{label} schema failure at {location}: {first.message}")
 
 
+def _project_provider_response_schema(node: Any) -> Any:
+    """Remove local-only assertions from the Codex/OpenAI response schema."""
+    if not isinstance(node, dict):
+        _fail("provider response schema source node must be an object")
+    projected: dict[str, Any] = {}
+    for key, value in node.items():
+        if key in PROVIDER_SCHEMA_STRIPPED_KEYWORDS:
+            continue
+        if key == "properties":
+            if not isinstance(value, dict):
+                _fail("provider response schema properties must be an object")
+            projected[key] = {
+                name: _project_provider_response_schema(child)
+                for name, child in value.items()
+            }
+        elif key == "items":
+            projected[key] = _project_provider_response_schema(value)
+        else:
+            projected[key] = value
+    return projected
+
+
 def _validate_provider_response_schema(node: Any, path: str = "$") -> None:
     """Pin the strict response-schema subset required by Codex/OpenAI."""
-    if isinstance(node, list):
-        for index, value in enumerate(node):
-            _validate_provider_response_schema(value, f"{path}[{index}]")
-        return
     if not isinstance(node, dict):
-        return
+        _fail(f"provider response schema node must be an object at {path}")
+    unsupported = set(node) - PROVIDER_SCHEMA_ALLOWED_KEYWORDS
+    if unsupported:
+        _fail(
+            f"provider response schema has unsupported keywords at {path}: "
+            f"{sorted(unsupported)}"
+        )
     if ("const" in node or "enum" in node) and "type" not in node:
         _fail(f"provider response schema requires explicit type at {path}")
     if node.get("type") == "object":
@@ -278,8 +319,10 @@ def _validate_provider_response_schema(node: Any, path: str = "$") -> None:
             _fail(f"provider response object must be closed at {path}")
         if not isinstance(required, list) or set(required) != set(properties):
             _fail(f"provider response object must require every property at {path}")
-    for key, value in node.items():
-        _validate_provider_response_schema(value, f"{path}.{key}")
+        for key, value in properties.items():
+            _validate_provider_response_schema(value, f"{path}.properties[{key!r}]")
+    if "items" in node:
+        _validate_provider_response_schema(node["items"], f"{path}.items")
 
 
 def _repo_ref(ref: str) -> Path:
@@ -407,7 +450,8 @@ def validate_assets() -> dict[str, Any]:
         EXECUTION_SCHEMA_PATH,
     ):
         _schema(schema_path)
-    _validate_provider_response_schema(_schema(OUTPUT_SCHEMA_PATH))
+    provider_schema = _project_provider_response_schema(_schema(OUTPUT_SCHEMA_PATH))
+    _validate_provider_response_schema(provider_schema)
     return {
         "suite": SUITE,
         "assets": len(assets),
@@ -878,7 +922,9 @@ def _run_one(
         child_home.mkdir(mode=0o700)
         work.mkdir(mode=0o700)
         schema = temp / "subject-output.schema.json"
-        _atomic_create(schema, _safe_explicit_file(OUTPUT_SCHEMA_PATH))
+        provider_schema = _project_provider_response_schema(_schema(OUTPUT_SCHEMA_PATH))
+        _validate_provider_response_schema(provider_schema)
+        _atomic_create(schema, _json_bytes(provider_schema))
         _copy_auth(_codex_home(environ) / "auth.json", child_home / "auth.json")
         output = temp / "last-message.json"
         child_env = {

--- a/scripts/test_run_review_criteria_constructive_value.py
+++ b/scripts/test_run_review_criteria_constructive_value.py
@@ -77,6 +77,9 @@ record = {{
     "env": dict(os.environ),
     "home_files": sorted(path.name for path in Path(os.environ["CODEX_HOME"]).iterdir()),
     "prompt_sha256": hashlib.sha256(prompt.encode()).hexdigest(),
+    "output_schema_sha256": hashlib.sha256(
+        Path(sys.argv[sys.argv.index("--output-schema") + 1]).read_bytes()
+    ).hexdigest(),
 }}
 with CAPTURE.open("a", encoding="utf-8") as handle:
     handle.write(json.dumps(record, sort_keys=True) + "\\n")
@@ -184,6 +187,63 @@ def test_provider_response_schema_requires_closed_fully_required_objects() -> No
         runner._validate_provider_response_schema(schema)
 
 
+def test_provider_response_schema_projection_keeps_local_validation_only_local() -> None:
+    source = json.loads(runner.OUTPUT_SCHEMA_PATH.read_text())
+    projected = runner._project_provider_response_schema(source)
+    serialized = json.dumps(projected, sort_keys=True)
+    for keyword in runner.PROVIDER_SCHEMA_STRIPPED_KEYWORDS:
+        assert f'"{keyword}"' not in serialized
+    assert '"pattern"' in serialized
+    assert '"minItems"' in serialized
+    assert '"maxItems"' in serialized
+    runner._validate_provider_response_schema(projected)
+
+    source_serialized = json.dumps(source, sort_keys=True)
+    assert '"uniqueItems"' in source_serialized
+    assert '"minLength"' in source_serialized
+    assert '"maxLength"' in source_serialized
+
+    property_named_like_annotation = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["title"],
+        "properties": {"title": {"type": "string", "minLength": 1}},
+    }
+    projected_property = runner._project_provider_response_schema(
+        property_named_like_annotation
+    )
+    assert projected_property["properties"]["title"] == {"type": "string"}
+
+
+def test_provider_response_schema_rejects_unapproved_keyword() -> None:
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [],
+        "properties": {},
+        "allOf": [],
+    }
+    with pytest.raises(runner.MeasurementError, match="unsupported keywords"):
+        runner._validate_provider_response_schema(schema)
+
+
+def test_local_subject_schema_still_rejects_projected_out_assertions() -> None:
+    value = {
+        "schema_version": "review-criteria-subject-output/1.0",
+        "item_id": "RCV-01",
+        "consumer_id": "formative_planning",
+        "role": "FORMATIVE",
+        "profile": {
+            "resolved_digest": "0" * 64,
+            "selected_criterion_ids": ["criterion.a", "criterion.a"],
+        },
+        "applicability": [],
+        "findings": [],
+    }
+    with pytest.raises(runner.MeasurementError, match="non-unique"):
+        runner._validate(runner.OUTPUT_SCHEMA_PATH, value, "subject output")
+
+
 def test_init_run_seals_same_context_bytes_and_only_treatment_binding(
     monkeypatch, tmp_path
 ) -> None:
@@ -243,6 +303,12 @@ def test_fake_subscription_dispatch_is_contained_complete_and_idempotent(
     assert len(manifest["calls"]) == 24
     rows = [json.loads(line) for line in capture.read_text().splitlines()]
     assert len(rows) == 24
+    provider_schema = runner._project_provider_response_schema(
+        json.loads(runner.OUTPUT_SCHEMA_PATH.read_text())
+    )
+    provider_schema_sha256 = hashlib.sha256(
+        runner._json_bytes(provider_schema)
+    ).hexdigest()
     for row in rows:
         assert row["home_files"] == ["auth.json"]
         assert "OPENAI_API_KEY" not in row["env"]
@@ -251,6 +317,7 @@ def test_fake_subscription_dispatch_is_contained_complete_and_idempotent(
         assert "--ephemeral" in row["argv"]
         assert "--ignore-user-config" in row["argv"]
         assert "read-only" in row["argv"]
+        assert row["output_schema_sha256"] == provider_schema_sha256
     before = capture.read_bytes()
     manifest_before = (run_dir / "execution-manifest.json").read_bytes()
     runner.dispatch(_dispatch_args(run_dir), environ)


### PR DESCRIPTION
[skip-closes-check]

Justification: #684 must remain open until the 24-call subscription run and independent human-expert adjudication are complete.

Summary:
- Record the plan 1.3 fail-closed incident and bump the append-only measurement plan to 1.4.
- Send Codex/OpenAI a closed supported response-schema projection while retaining the complete Draft 2020-12 schema for mandatory post-generation validation.
- Strip schema-document annotations plus provider-unsupported uniqueItems, minLength, and maxLength only from the ephemeral provider copy.
- Add closed-keyword, property-name collision, integration-hash, and retained-local-validation regressions.

Evidence:
- Provider rejected plan 1.3 before subject output because uniqueItems is not permitted.
- Calls 2 through 24 were not dispatched, no retry occurred, and recorded API spend was USD 0.
- Official OpenAI Structured Outputs documentation defines a supported JSON Schema subset.
- Local focused validation: 220 passed, then 58 passed after the final adversarial regressions.
- validate-assets, #684 guard, ruff, py_compile, CI manifest lint, spec consistency, and diff-check all pass.

This PR performs no subject, judge, expert, network, or API dispatch.