### PR TITLE
chore: ignore graphify-out/ local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ ROADMAP.md
 .coverage
 .coverage.*
 htmlcov/
+
+# Knowledge-graph local artifacts (do not commit)
+graphify-out/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ ROADMAP.md
 htmlcov/
 
 # Knowledge-graph local artifacts (do not commit)
-graphify-out/
+/graphify-out/


### PR DESCRIPTION
## What

Adds the repository-root `/graphify-out/` directory to `.gitignore`.

## Why

`graphify-out/` is a regenerable local artifact directory produced by knowledge-graph tooling that runs against this repo (and others). It holds caches, lock files (`.rebuild.lock`), and derived per-repo outputs that are specific to the machine that generated them and should never be committed. Currently these can show up as untracked noise in `git status` and risk an accidental commit.

## What's in the change

Three lines appended to `.gitignore`:

```gitignore
# Knowledge-graph local artifacts (do not commit)
/graphify-out/
```

The leading slash limits the rule to the repository root, so a legitimate nested directory with the same name remains trackable. No source, build, or test files are touched.

## Scope

Minimal additive change to `.gitignore` only.

[skip-closes-check]
Justification: repository housekeeping only; no issue-backed product behavior.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code), refined by the maintainer.
