### PR TITLE
fix(evals): preflight Codex feature flags

### DIFF
--- a/evals/heldout/review_criteria_constructive_value/measurement_plan.md
+++ b/evals/heldout/review_criteria_constructive_value/measurement_plan.md
@@ -52,9 +52,11 @@ the observed outcome; blocked/partial calls are retained and reported.
 
 The default subject transport is the contained Codex CLI authenticated with the
 operator's ChatGPT subscription. Before dispatch, detection must report
-`Logged in using ChatGPT`; the execution record pins the Codex CLI version,
-exact model id, reasoning effort, disabled tool surface, isolation settings, and
-every model-visible prompt hash. This plan fixes two replicates for each of six
+`Logged in using ChatGPT`, and every frozen `--disable` flag must exist in the
+CLI's no-call `features list` registry; an incompatible registry blocks before
+quota is consumed. The execution record pins the Codex CLI version, exact model
+id, reasoning effort, disabled tool surface, isolation settings, and every
+model-visible prompt hash. This plan fixes two replicates for each of six
 items, so it dispatches exactly 24 subject calls: six items x two arms x two
 fresh replicates. Human experts and the disclosed human adjudicator supply the
 required labels. The report selects the paired-controls-only

--- a/evals/heldout/review_criteria_constructive_value/suite_lock.json
+++ b/evals/heldout/review_criteria_constructive_value/suite_lock.json
@@ -9,14 +9,14 @@
     "evals/heldout/review_criteria_constructive_value/expert_labels.schema.json": "7856c37648372665bd3fd701c793e1a98f94e0be5324671257136bc340baa258",
     "evals/heldout/review_criteria_constructive_value/expert_packet.schema.json": "c3d3a707b3480f8e6b4357f3c5c8ad624396a685778469948a6bfaf8f49a5077",
     "evals/heldout/review_criteria_constructive_value/heldout_set.json": "c7728656b30f626f6c2b487893405d5f7459b77a69d293e7ec70855c43984384",
-    "evals/heldout/review_criteria_constructive_value/measurement_plan.md": "a238e2e9df41513c4c940b5abcd91abbb25e2f5f2e0c38ad3359f7eaa6e76492",
+    "evals/heldout/review_criteria_constructive_value/measurement_plan.md": "0e19e2a9d560384fcd2a67e64175a00fe59e697563fdb1bca0fecc8f7d0b4a5e",
     "evals/heldout/review_criteria_constructive_value/paired_adjudication.schema.json": "0bbcf55e465afdea27d911f295276bbd2ac1a87df2d4ff6b6278a92a3a89d0f1",
     "evals/heldout/review_criteria_constructive_value/scenarios.json": "5dfa559578d27e498285ab33eca2b50237210e69dd6ed39b0cad4a4b2d5c6af9",
     "evals/heldout/review_criteria_constructive_value/scenarios.schema.json": "e592085f097981b9a0308e12c85a41fceba99993fbc72dd9c5a27a10026b159e",
     "evals/heldout/review_criteria_constructive_value/subject_output.schema.json": "b3386be4e1eca8f2ce4850a3067c7ab0bc21cc98a938d2e709956cc397c05531",
     "evals/heldout/review_criteria_constructive_value/treatment_prompt.md": "16907b4c35d9df226f831a837de0788d47d0790209d6f1a14e7fbebbb0921f22",
     "scripts/fixtures/review_target_context/synthetic-registry.json": "ad8a7892f975842ec99d66e16e4a45fc63bb9da09a14e38d86785532d26f2be1",
-    "scripts/run_review_criteria_constructive_value.py": "91ec6b896d24d97d189cb9f8ccf69565b71d2888b9f6c56fa53572823fe3d9a8",
+    "scripts/run_review_criteria_constructive_value.py": "50a0ca64c6fa118714a26dab462dd311a7d2267c4cf8909203c27b0dc731cfa9",
     "scripts/score_review_criteria_constructive_value.py": "1f1c2be5844da3be0933d71fd1c305f9d697cf8601efcc582bffddc8e1d1fd7f"
   }
 }

--- a/scripts/run_review_criteria_constructive_value.py
+++ b/scripts/run_review_criteria_constructive_value.py
@@ -64,6 +64,7 @@ MODEL_RE = re.compile(r"^gpt-[a-z0-9][a-z0-9._-]{0,123}$")
 SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 VERSION_RE = re.compile(r"\bcodex-cli\s+(\d+)\.(\d+)\.(\d+)\b")
+FEATURE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 PROVIDER_SCHEMA_STRIPPED_KEYWORDS = frozenset(
     {"$schema", "$id", "title", "uniqueItems", "minLength", "maxLength"}
 )
@@ -109,7 +110,6 @@ LOCKED_ASSET_REFS = {
 DISABLED_FEATURES = (
     "shell_tool",
     "unified_exec",
-    "view_image",
     "apps",
     "plugins",
     "plugin_sharing",
@@ -676,6 +676,22 @@ def _codex_home(environ: dict[str, str]) -> Path:
     return (Path(environ["HOME"]).expanduser() / ".codex").resolve()
 
 
+def _feature_names(raw: str) -> set[str]:
+    names = {
+        parts[0]
+        for line in raw.splitlines()
+        if (
+            (parts := line.split())
+            and len(parts) >= 3
+            and FEATURE_NAME_RE.fullmatch(parts[0]) is not None
+            and parts[-1] in {"true", "false"}
+        )
+    }
+    if not names:
+        raise ValueError("empty or malformed Codex feature registry")
+    return names
+
+
 def detect(model: str, environ: dict[str, str] | None = None) -> dict[str, Any]:
     _model(model)
     env = dict(os.environ if environ is None else environ)
@@ -733,6 +749,27 @@ def detect(model: str, environ: dict[str, str] | None = None) -> dict[str, Any]:
     }
     if status_run.returncode or "Logged in using ChatGPT" not in status_lines:
         result["reason_code"] = "AUTH_NOT_CHATGPT_SUBSCRIPTION"
+        return result
+    try:
+        features_run = subprocess.run(
+            [codex, "features", "list"], env=status_env, stdin=subprocess.DEVNULL,
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        result["reason_code"] = "CODEX_FEATURES_UNAVAILABLE"
+        return result
+    if features_run.returncode:
+        result["reason_code"] = "CODEX_FEATURES_UNAVAILABLE"
+        return result
+    try:
+        feature_names = _feature_names(features_run.stdout)
+    except ValueError:
+        result["reason_code"] = "CODEX_FEATURES_UNAVAILABLE"
+        return result
+    unsupported = sorted(set(DISABLED_FEATURES) - feature_names)
+    if unsupported:
+        result["reason_code"] = "CODEX_FEATURE_FLAGS_INCOMPATIBLE"
+        result["unsupported_feature_flags"] = unsupported
         return result
     result.update(
         available=True,

--- a/scripts/test_run_review_criteria_constructive_value.py
+++ b/scripts/test_run_review_criteria_constructive_value.py
@@ -17,8 +17,10 @@ import score_review_criteria_constructive_value as scorer
 def _fake_codex(
     tmp_path: Path, *, status: str = "Logged in using ChatGPT",
     status_to_stderr: bool = False, forbidden_event: bool = False,
-    invalid_output: bool = False,
+    invalid_output: bool = False, feature_names: tuple[str, ...] | None = None,
 ) -> tuple[Path, Path]:
+    if feature_names is None:
+        feature_names = runner.DISABLED_FEATURES
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     executable = fake_bin / "codex"
@@ -34,6 +36,7 @@ STATUS = {status!r}
 STATUS_TO_STDERR = {status_to_stderr!r}
 FORBIDDEN = {forbidden_event!r}
 INVALID = {invalid_output!r}
+FEATURE_NAMES = {feature_names!r}
 CAPTURE = Path(__file__).with_name("capture.jsonl")
 
 if sys.argv[1:] == ["--version"]:
@@ -41,6 +44,10 @@ if sys.argv[1:] == ["--version"]:
     raise SystemExit(0)
 if sys.argv[1:] == ["login", "status"]:
     print(STATUS, file=sys.stderr if STATUS_TO_STDERR else sys.stdout)
+    raise SystemExit(0)
+if sys.argv[1:] == ["features", "list"]:
+    for name in FEATURE_NAMES:
+        print(name + " stable false")
     raise SystemExit(0)
 if not sys.argv[1:] or sys.argv[1] != "exec":
     raise SystemExit(9)
@@ -283,6 +290,18 @@ def test_detection_requires_exact_chatgpt_subscription_status(tmp_path) -> None:
     assert detected["auth_mode"] == "chatgpt_subscription"
 
 
+def test_detection_fails_closed_on_unknown_disable_feature(tmp_path) -> None:
+    missing = runner.DISABLED_FEATURES[0]
+    feature_names = tuple(
+        name for name in runner.DISABLED_FEATURES if name != missing
+    )
+    fake_bin, _ = _fake_codex(tmp_path, feature_names=feature_names)
+    detected = runner.detect("gpt-5.6", _env(tmp_path, fake_bin))
+    assert detected["available"] is False
+    assert detected["reason_code"] == "CODEX_FEATURE_FLAGS_INCOMPATIBLE"
+    assert detected["unsupported_feature_flags"] == [missing]
+
+
 def test_dispatch_requires_flag_and_exact_plan_hash(monkeypatch, tmp_path) -> None:
     run_dir, environ, capture = _prepare_run(tmp_path, monkeypatch)
     with pytest.raises(runner.MeasurementError, match="execute-24"):
@@ -317,6 +336,13 @@ def test_fake_subscription_dispatch_is_contained_complete_and_idempotent(
         assert "--ephemeral" in row["argv"]
         assert "--ignore-user-config" in row["argv"]
         assert "read-only" in row["argv"]
+        disabled = [
+            row["argv"][index + 1]
+            for index, value in enumerate(row["argv"][:-1])
+            if value == "--disable"
+        ]
+        assert disabled == list(runner.DISABLED_FEATURES)
+        assert "view_image" not in disabled
         assert row["output_schema_sha256"] == provider_schema_sha256
     before = capture.read_bytes()
     manifest_before = (run_dir / "execution-manifest.json").read_bytes()


### PR DESCRIPTION
## Summary

- remove the invalid `view_image` feature disable that blocked plan 1.4 before subject generation
- make no-call detection compare every frozen `--disable` flag against `codex features list`
- fail closed with `CODEX_FEATURE_FLAGS_INCOMPATIBLE` and update the normative measurement plan and suite lock

## Root cause

The runner hard-coded `view_image` in `DISABLED_FEATURES`, but bundled Codex CLI 0.147.0 has no registry entry for that name. Detection only checked version and authentication, so it reported the environment available and dispatch failed during CLI argument validation.

## Validation

- 283 passed (complete related gate)
- 95 passed (#684 focused)
- actual bundled CLI detection: `available=true`
- live negative mutation: `view_image` produces `CODEX_FEATURE_FLAGS_INCOMPATIBLE`
- `validate-assets`, #684 guard, manifest lint, spec consistency, `py_compile`, and diff-check all green
- Ruff was unavailable locally; no install was performed

## Boundaries

- plan 1.4 remains permanently blocked and is not retried
- this PR performs no model call and creates no new run plan
- any future run requires a new suite commit, a new frozen plan, and fresh explicit consent

Refs #684

[skip-closes-check] This runner compatibility fix does not complete #684; the issue must remain open for a newly frozen run, fresh dispatch consent, and the required independent human expert and adjudicator stages.