### PR TITLE
chore: ignore graphify-out local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ ROADMAP.md
 .coverage
 .coverage.*
 htmlcov/
+
+# Knowledge-graph local artifacts (do not commit)
+/graphify-out/


### PR DESCRIPTION
## Summary

- ignore the repository-root `/graphify-out/` local artifact directory;
- keep nested directories with the same name trackable by anchoring the rule;
- preserve the original contributor's authorship in the commit trailer.

This is the maintainer-owned replay of #712 by @chrislro. The patch was replayed from clean `main` so trusted-repository CI can run without approving workflows from an external fork. It supersedes #712 after merge.

## Validation

- `git diff --check`
- `git check-ignore -v --no-index graphify-out/.rebuild.lock`
- verified `docs/graphify-out/example.md` is not ignored

No runtime code or test behavior changes.

[skip-closes-check]
Justification: repository housekeeping only; no issue-backed product behavior.
