### PR TITLE
fix(docs): co-locate passport_as_reset_boundary reference in #743 design doc

### DIFF
--- a/docs/design/2026-08-17-743-inquiry-branch-ledger-design.md
+++ b/docs/design/2026-08-17-743-inquiry-branch-ledger-design.md
@@ -253,7 +253,9 @@ boundary). The passport references it through one optional aggregate:
   passport is the authority).
 
 This is purely additive: existing passports need no migration. Cross-session
-resume (`ARS_PASSPORT_RESET`) carries the pointer like any other aggregate.
+resume (`ARS_PASSPORT_RESET`, per the reset-boundary protocol in
+`academic-pipeline/references/passport_as_reset_boundary.md`) carries the
+pointer like any other aggregate.
 
 ## 8. Evidence registration and evaluation (NOT_RUN)
 


### PR DESCRIPTION
## What

One-line CI hotfix: the #743 inquiry-branch-ledger design doc (merged earlier today) mentions `ARS_PASSPORT_RESET` at its §7 tail without referencing `passport_as_reset_boundary`, which fails `check_passport_reset_contract.py` — so **main's spec-consistency gate is currently red and blocks every open PR** (#762, #763 both hit it). This adds the protocol reference at the mention site per the v3.6.3 co-location contract.

Verified locally: `python3 scripts/check_passport_reset_contract.py --root .` red before, green after.

Refs #743.

[skip-closes-check] CI hotfix restoring a green main; #743 is the feature's tracking issue and must stay open — a one-line doc-reference fix must not auto-close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011n3WG8Z3Us8fX8UhXS51Ki
