### PR TITLE
docs: CI workflow enforcement-class table + inventory lint (#755)

### DIFF
--- a/.github/workflows/spec-consistency.yml
+++ b/.github/workflows/spec-consistency.yml
@@ -234,6 +234,13 @@ jobs:
         # semantics stay in each row's authority file.
         run: python3 scripts/check_degradation_registry.py
 
+      - name: Validate workflow classification table (#755)
+        # Pins docs/ARCHITECTURE.md §7.1's completeness claim: every
+        # .github/workflows/*.yml has exactly one row (both directions,
+        # WC-1) and class cells use the closed four-term vocabulary (WC-2).
+        # Class semantics stay owned by code review.
+        run: python3 scripts/check_workflow_classification.py
+
       - name: Validate data-flow map coverage (#758)
         # Pins docs/DATA_FLOWS.md's exhaustiveness claim: every non-test
         # scripts/*.py with a network-module import (AST scan) and every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ The repo is maintained by [Cheng-I Wu](https://github.com/Imbad0202) (HEEACT). T
 
 ## Release checklist
 
-Most release mechanics are CI-enforced (`check_version_consistency.py` keeps CLAUDE.md / SKILL.md / CHANGELOG / plugin manifests / README badge in lockstep; the release-cooldown workflow paces tags; the `changelog-covers-merges` workflow gates release-prep PRs). One step still has a manual form for tag flows that skip a release branch:
+Most release mechanics are CI-enforced (`check_version_consistency.py` keeps CLAUDE.md / SKILL.md / CHANGELOG / plugin manifests / README badge in lockstep; the release-cooldown workflow paces tags; the `changelog-covers-merges` workflow gates release-prep PRs). Not every workflow enforces at the same strength — the per-workflow classification (blocking / advisory / administrative / post-push detection, with bypass tokens) lives in [docs/ARCHITECTURE.md §7.1](docs/ARCHITECTURE.md#71-ci-workflow-enforcement-classes-755). One step still has a manual form for tag flows that skip a release branch:
 
 ### Before tagging: CHANGELOG covers every merge
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,21 +275,27 @@ bypassed) before proceeding · **Advisory** — the audited condition warns, nev
 **Administrative** — produces work items, audits nothing · **Post-push detection** —
 triggered by a tag push that has already happened; nothing in GitHub Actions can
 reject a push after the fact, so a failure is a remediation signal, not prevention
-(the three tag workflows are conventionally *called* release gates; their stop-power
-is the maintainer acting on the failure).
+(the three tag-only workflows are conventionally *called* release gates; their
+stop-power is the maintainer acting on the failure).
+
+One GitHub Actions subtlety the Trigger column accounts for: an unfiltered or
+paths-only `push:` trigger ALSO matches tag pushes — GitHub does not evaluate `paths`
+filters for tags — so `spec-consistency`, `command-invariants`, and `freshness-check`
+additionally run on every `v*` tag push, where their failures are post-push detection
+exactly like the three tag-only workflows.
 
 | Workflow | Trigger | What it checks | Class | Bypass |
 |---|---|---|---|---|
-| `spec-consistency.yml` | push (all branches) + PR | the full lint/pytest battery: spec surfaces, contracts, content locks, the pytest manifest | Blocking | none |
+| `spec-consistency.yml` | push (all branches **and tags**) + PR | the full lint/pytest battery: spec surfaces, contracts, content locks, the pytest manifest | Blocking | none |
 | `pytest.yml` | PR + push to main, both path-filtered (scripts/tests/contracts/config, adapter references, `bibliography_agent`) | adapter + script test suite | Blocking | none |
-| `command-invariants.yml` | push (path-filtered: commands, announce script, frontmatter lint, plugin manifest, CHANGELOG, toolkit) + PR (all) | SessionStart announce list matches the command inventory; plugin-version ↔ CHANGELOG lockstep; command frontmatter `name` validation | Blocking | none |
+| `command-invariants.yml` | push (path-filtered for branch pushes; **also every tag push**) + PR (all) | SessionStart announce list matches the command inventory; plugin-version ↔ CHANGELOG lockstep; command frontmatter `name` validation | Blocking | none |
 | `repository-hygiene.yml` | PR targeting main + push to main | gitleaks secret scan | Blocking | none |
 | `eval-harness.yml` | PR + push to main, both path-filtered (scoring/generation surfaces + gold sets) | eval gold-set thresholds (aggregate + per-class) | Blocking on `pull_request` events only; report-only on push | `[eval-regression-acknowledged]` in the PR body + ≥1 open tracking-issue URL in this repo |
 | `test-count-monotonic.yml` | PR targeting main | collected test count must not drop | Blocking | `[skip-test-count]` in the PR body (justification requested, not machine-validated) |
 | `pr-closes-issue.yml` | PR targeting main | PR body references an issue via an auto-close keyword | Blocking | `[skip-closes-check]` in the PR body (justification requested, not machine-validated) |
 | `changelog-covers-merges.yml` | PR targeting main; the job runs only when the head branch is `release/**` | every release-worthy merge since the last tag is documented in CHANGELOG | Blocking (ordinary merges rely on the manual CONTRIBUTING fallback) | none |
 | `platform-port-reminder.yml` | PR targeting main | new top-level directory → platform-ports policy reminder | Advisory (one `::warning::`, always exits 0; the merge decision stays with the maintainer) | none |
-| `freshness-check.yml` | weekly schedule + push (two-file path filter) + manual dispatch | PRISMA-trAIce snapshot staleness | Advisory for staleness (warns on stderr, exits 0); malformed protocol metadata is a hard failure | none |
+| `freshness-check.yml` | weekly schedule + push (two-file path filter for branch pushes; **also every tag push**) + manual dispatch | PRISMA-trAIce snapshot staleness | Advisory for staleness (warns on stderr, exits 0); malformed protocol metadata is a hard failure | none |
 | `harness-retirement-monthly.yml` | monthly schedule + manual dispatch | opens the monthly prompt-debt audit issue | Administrative | none |
 | `defer-label-gate.yml` | tag push `v*` | open `defer:<tag>` issues must be closed or relabelled | Post-push detection | `[skip-defer-check]` in the tagged commit message |
 | `release-cooldown.yml` | tag push `v*` | paces consecutive release tags | Post-push detection | `[skip-cooldown]` in the commit/tag message |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -264,6 +264,47 @@ Two classes of gate: **🧑 decision-heavy** (user chooses a branch or approves 
 | Stage 5/6 boundary semantics (v3.17.0) | 🤖 + 🧑 | 5 (entry gate), 6 (terminal checkpoint) | Stage 5's "before finalization: always MANDATORY" names exactly one checkpoint — the entry gate between Stage 4.5 PASS and Stage 5 dispatch. Stage 6 gains a defined Stage 5→6 transition, a non-mandatory decline path, a terminal checkpoint after the Process Record is delivered, and canonical terminal-acknowledgement vocabulary (`finish`/`end`/`done`/`confirm`) that sets pipeline global state to `completed`. All five pipeline surfaces (`academic-pipeline/SKILL.md`, `agents/pipeline_orchestrator_agent.md`, `agents/state_tracker_agent.md`, `references/pipeline_state_machine.md`, `references/process_summary_protocol.md`) carry whole-file sha256 content locks in `scripts/check_pipeline_boundary_semantics.py` (66 mutation tests). | Any byte change to a locked surface fails CI until the pinned hash is updated in the same commit |
 | Cross-model handoff envelope (v3.17.0) | 🤖 (dispatch layer) | Design freeze (1), Final editorial decision (3), DA critique (3) | Canonical `[CROSS-MODEL-HANDOFF v1]` envelope + normative Python grammar (`scripts/cross_model_handoff.py`) for the #523 owner→dispatcher→owner transport path. Malformed envelope/result → `[CROSS-MODEL-ERROR]` → outcome `unavailable`, never a fabricated judgment; agreement → mechanical fill with no owner re-invocation; divergence → re-invoke the owner with minimum context. `scripts/check_cross_model_handoff_contract.py` pins the contract across all five surfaces. | `ARS_CROSS_MODEL` unset stays byte-equivalent; malformed transport degrades to `unavailable`, never silently treated as a deliverable |
 
+### 7.1 CI workflow enforcement classes (#755)
+
+The files under `.github/workflows/` are often described collectively as CI gates, but
+they enforce at four different strengths. A reader assessing the control environment
+needs the difference in one place; this table is that place (origin: ISO/IEC
+42001-spirit gap assessment, finding T-5).
+
+Classes: **Blocking** — a failure on the guarded event must be fixed (or explicitly
+bypassed) before proceeding · **Advisory** — warns, never fails · **Administrative** —
+produces work items, audits nothing · **Post-push detection** — triggered by a tag
+push that has already happened; nothing in GitHub Actions can reject a push after the
+fact, so a failure is a remediation signal, not prevention.
+
+| Workflow | Trigger | What it checks | Class | Bypass |
+|---|---|---|---|---|
+| `spec-consistency.yml` | push + PR | the full lint/pytest battery: spec surfaces, contracts, content locks, the pytest manifest | Blocking | none |
+| `pytest.yml` | PR + push to main, path-filtered (scripts/tests/contracts/config) | adapter + script test suite | Blocking when triggered | none |
+| `command-invariants.yml` | push + PR | SessionStart announce list matches the actual command inventory | Blocking | none |
+| `repository-hygiene.yml` | push + PR | gitleaks secret scan | Blocking | none |
+| `eval-harness.yml` | PR + push, path-filtered (scoring/generation logic + gold sets) | eval gold-set thresholds (aggregate + per-class) | Blocking on `pull_request` events only; report-only on push | `[eval-regression-acknowledged]` in the PR body + ≥1 open tracking-issue URL in this repo (passes as noted, by design) |
+| `test-count-monotonic.yml` | PR | collected test count must not drop | Blocking | `[skip-test-count]` in the PR body + justification |
+| `pr-closes-issue.yml` | PR | PR body references an issue via an auto-close keyword | Blocking | `[skip-closes-check]` in the PR body + justification |
+| `changelog-covers-merges.yml` | PR (job runs only when head is `release/**`) | every release-worthy merge since the last tag is documented in CHANGELOG | Blocking for release-prep PRs only; ordinary merges rely on the manual CONTRIBUTING fallback | n/a outside release PRs |
+| `platform-port-reminder.yml` | PR | new top-level directory → platform-ports policy reminder | Advisory (one `::warning::`, always exits 0; the merge decision stays with the maintainer) | n/a |
+| `freshness-check.yml` | schedule + push + dispatch | PRISMA-trAIce snapshot staleness | Advisory (warns on stderr, exits 0) | n/a |
+| `harness-retirement-monthly.yml` | schedule + dispatch | opens the monthly prompt-debt audit issue | Administrative | n/a |
+| `defer-label-gate.yml` | tag push `v*` | open `defer:<tag>` issues must be closed or relabelled | Post-push detection | `[skip-defer-check]` in the tagged commit message |
+| `release-cooldown.yml` | tag push `v*` | paces consecutive release tags | Post-push detection | `[skip-cooldown]` in the commit/tag message |
+| `tag-version-match.yml` | tag push `v*` | re-runs the full version-consistency lint at the tag | Post-push detection | none |
+
+Count, honestly stated: **14 workflows — 8 blocking on at least one event class, 2
+advisory, 1 administrative, 3 post-push detection.** The three tag workflows are
+conventionally called release gates; mechanically they detect after the push, and
+their stop-power is the maintainer acting on the failure.
+
+Inventory sync is pinned by `scripts/check_workflow_classification.py` (every file
+under `.github/workflows/` has exactly one row here and every row names an existing
+file; class values come from the closed four-term vocabulary). The class *semantics*
+— whether a row honestly describes its workflow's behavior — stay owned by code
+review, mirroring the degradation-registry posture.
+
 ## 8. ARS Evolution Timeline
 
 ```mermaid

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Full pipeline view across stages × skills × artifacts × gates. Every complete
 - **Matrix** (§3): the only place where (stage × skill × mode × data_level × artifacts × agents × gate) all co-exist. Use this when asking "what happens at Stage X?" The Gate column lists both machine checks and the user-confirmation checkpoint that closes the stage.
 - **Data access flow** (§4) and **skill graph** (§6): orthogonal views answering "who sees what" and "who depends on what" respectively.
 - **Literature corpus flow** (§5): producer/consumer view of the optional Material Passport `literature_corpus[]` input port (v3.6.4) and Phase 1 consumer integration (v3.6.5).
-- **Quality gates** (§7): zoom on the blocking checks — both machine-enforced and human-enforced.
+- **Quality gates** (§7): zoom on the blocking checks — both machine-enforced and human-enforced. §7.1 classifies the repo's CI workflows by enforcement strength (blocking / advisory / administrative / post-push detection).
 - **Timeline** (§8): why the architecture looks the way it does — each release added one honesty primitive or a new contract.
 - **Modes** (§9): reference when composing a pipeline invocation.
 
@@ -267,43 +267,41 @@ Two classes of gate: **🧑 decision-heavy** (user chooses a branch or approves 
 ### 7.1 CI workflow enforcement classes (#755)
 
 The files under `.github/workflows/` are often described collectively as CI gates, but
-they enforce at four different strengths. A reader assessing the control environment
-needs the difference in one place; this table is that place (origin: ISO/IEC
-42001-spirit gap assessment, finding T-5).
+they enforce at four different strengths (origin: ISO/IEC 42001-spirit gap assessment,
+finding T-5).
 
 Classes: **Blocking** — a failure on the guarded event must be fixed (or explicitly
-bypassed) before proceeding · **Advisory** — warns, never fails · **Administrative** —
-produces work items, audits nothing · **Post-push detection** — triggered by a tag
-push that has already happened; nothing in GitHub Actions can reject a push after the
-fact, so a failure is a remediation signal, not prevention.
+bypassed) before proceeding · **Advisory** — the audited condition warns, never fails ·
+**Administrative** — produces work items, audits nothing · **Post-push detection** —
+triggered by a tag push that has already happened; nothing in GitHub Actions can
+reject a push after the fact, so a failure is a remediation signal, not prevention
+(the three tag workflows are conventionally *called* release gates; their stop-power
+is the maintainer acting on the failure).
 
 | Workflow | Trigger | What it checks | Class | Bypass |
 |---|---|---|---|---|
-| `spec-consistency.yml` | push + PR | the full lint/pytest battery: spec surfaces, contracts, content locks, the pytest manifest | Blocking | none |
-| `pytest.yml` | PR + push to main, path-filtered (scripts/tests/contracts/config) | adapter + script test suite | Blocking when triggered | none |
-| `command-invariants.yml` | push + PR | SessionStart announce list matches the actual command inventory | Blocking | none |
-| `repository-hygiene.yml` | push + PR | gitleaks secret scan | Blocking | none |
-| `eval-harness.yml` | PR + push, path-filtered (scoring/generation logic + gold sets) | eval gold-set thresholds (aggregate + per-class) | Blocking on `pull_request` events only; report-only on push | `[eval-regression-acknowledged]` in the PR body + ≥1 open tracking-issue URL in this repo (passes as noted, by design) |
-| `test-count-monotonic.yml` | PR | collected test count must not drop | Blocking | `[skip-test-count]` in the PR body + justification |
-| `pr-closes-issue.yml` | PR | PR body references an issue via an auto-close keyword | Blocking | `[skip-closes-check]` in the PR body + justification |
-| `changelog-covers-merges.yml` | PR (job runs only when head is `release/**`) | every release-worthy merge since the last tag is documented in CHANGELOG | Blocking for release-prep PRs only; ordinary merges rely on the manual CONTRIBUTING fallback | n/a outside release PRs |
-| `platform-port-reminder.yml` | PR | new top-level directory → platform-ports policy reminder | Advisory (one `::warning::`, always exits 0; the merge decision stays with the maintainer) | n/a |
-| `freshness-check.yml` | schedule + push + dispatch | PRISMA-trAIce snapshot staleness | Advisory (warns on stderr, exits 0) | n/a |
-| `harness-retirement-monthly.yml` | schedule + dispatch | opens the monthly prompt-debt audit issue | Administrative | n/a |
+| `spec-consistency.yml` | push (all branches) + PR | the full lint/pytest battery: spec surfaces, contracts, content locks, the pytest manifest | Blocking | none |
+| `pytest.yml` | PR + push to main, both path-filtered (scripts/tests/contracts/config, adapter references, `bibliography_agent`) | adapter + script test suite | Blocking | none |
+| `command-invariants.yml` | push (path-filtered: commands, announce script, frontmatter lint, plugin manifest, CHANGELOG, toolkit) + PR (all) | SessionStart announce list matches the command inventory; plugin-version ↔ CHANGELOG lockstep; command frontmatter `name` validation | Blocking | none |
+| `repository-hygiene.yml` | PR targeting main + push to main | gitleaks secret scan | Blocking | none |
+| `eval-harness.yml` | PR + push to main, both path-filtered (scoring/generation surfaces + gold sets) | eval gold-set thresholds (aggregate + per-class) | Blocking on `pull_request` events only; report-only on push | `[eval-regression-acknowledged]` in the PR body + ≥1 open tracking-issue URL in this repo |
+| `test-count-monotonic.yml` | PR targeting main | collected test count must not drop | Blocking | `[skip-test-count]` in the PR body (justification requested, not machine-validated) |
+| `pr-closes-issue.yml` | PR targeting main | PR body references an issue via an auto-close keyword | Blocking | `[skip-closes-check]` in the PR body (justification requested, not machine-validated) |
+| `changelog-covers-merges.yml` | PR targeting main; the job runs only when the head branch is `release/**` | every release-worthy merge since the last tag is documented in CHANGELOG | Blocking (ordinary merges rely on the manual CONTRIBUTING fallback) | none |
+| `platform-port-reminder.yml` | PR targeting main | new top-level directory → platform-ports policy reminder | Advisory (one `::warning::`, always exits 0; the merge decision stays with the maintainer) | none |
+| `freshness-check.yml` | weekly schedule + push (two-file path filter) + manual dispatch | PRISMA-trAIce snapshot staleness | Advisory for staleness (warns on stderr, exits 0); malformed protocol metadata is a hard failure | none |
+| `harness-retirement-monthly.yml` | monthly schedule + manual dispatch | opens the monthly prompt-debt audit issue | Administrative | none |
 | `defer-label-gate.yml` | tag push `v*` | open `defer:<tag>` issues must be closed or relabelled | Post-push detection | `[skip-defer-check]` in the tagged commit message |
 | `release-cooldown.yml` | tag push `v*` | paces consecutive release tags | Post-push detection | `[skip-cooldown]` in the commit/tag message |
 | `tag-version-match.yml` | tag push `v*` | re-runs the full version-consistency lint at the tag | Post-push detection | none |
 
 Count, honestly stated: **14 workflows — 8 blocking on at least one event class, 2
-advisory, 1 administrative, 3 post-push detection.** The three tag workflows are
-conventionally called release gates; mechanically they detect after the push, and
-their stop-power is the maintainer acting on the failure.
+advisory, 1 administrative, 3 post-push detection.**
 
-Inventory sync is pinned by `scripts/check_workflow_classification.py` (every file
-under `.github/workflows/` has exactly one row here and every row names an existing
-file; class values come from the closed four-term vocabulary). The class *semantics*
-— whether a row honestly describes its workflow's behavior — stay owned by code
-review, mirroring the degradation-registry posture.
+Inventory sync, the count line, and the bypass tokens are pinned by
+`scripts/check_workflow_classification.py`; the class *semantics* — whether a row
+honestly describes its workflow's behavior — stay owned by code review, mirroring the
+degradation-registry posture.
 
 ## 8. ARS Evolution Timeline
 

--- a/docs/CONTROL_AVAILABILITY.md
+++ b/docs/CONTROL_AVAILABILITY.md
@@ -46,9 +46,12 @@ applying your channel's channel-wide limitation above.
 | Prompt-level checkpoints and integrity gates | Active ⁽⁷⁾ | Active ⁽⁷⁾ | Active ⁽⁷⁾ | Conditional | Absent | Conditional | Conditional |
 
 CI-side checks (mutation-tested lints, content locks, changelog gates) are deliberately
-not a matrix row: they run in this repository's GitHub Actions on every change,
-protecting the published artifact all channels ship from, and never run on a user
-machine — identical for every channel. The machine-readable index of the suite's
+not a matrix row: they run in this repository's GitHub Actions, protecting the
+published artifact all channels ship from, and never run on a user machine —
+identical for every channel. They do not all enforce at the same strength or fire on
+every change: the per-workflow classification (blocking / advisory / administrative /
+post-push detection, with triggers and bypass tokens) is
+[ARCHITECTURE.md §7.1](ARCHITECTURE.md#71-ci-workflow-enforcement-classes-755). The machine-readable index of the suite's
 runtime graceful-degradation mechanisms is
 [`shared/contracts/degradation_registry.json`](../shared/contracts/degradation_registry.json).
 

--- a/scripts/_ci_pytest_manifest.toml
+++ b/scripts/_ci_pytest_manifest.toml
@@ -625,6 +625,10 @@ id = "745-stage-capability-matrix"
 path = "scripts/test_check_stage_capability_matrix.py"
 
 [[pytest]]
+id = "755-workflow-classification"
+path = "scripts/test_check_workflow_classification.py"
+
+[[pytest]]
 id = "753-distribution-surface-claims"
 path = "scripts/test_check_distribution_surface_claims.py"
 

--- a/scripts/check_workflow_classification.py
+++ b/scripts/check_workflow_classification.py
@@ -2,20 +2,27 @@
 """Defrift lint for the CI workflow classification table (#755).
 
 docs/ARCHITECTURE.md §7.1 claims to classify EVERY workflow's enforcement
-strength — a completeness claim that silently rots when a workflow is added,
-renamed, or removed. This lint pins the two mechanical halves and
+strength — a completeness claim that silently rots when a workflow is
+added, renamed, or removed. This lint pins the mechanical halves and
 deliberately nothing else — whether a row's class honestly describes its
 workflow's behavior stays owned by code review (degradation-registry
 posture):
 
-  WC-1  Inventory sync, both directions: every *.yml under
-        .github/workflows/ has exactly one table row, and every row names
-        an existing workflow file.
+  WC-1  Inventory sync, both directions: every *.yml / *.yaml under
+        .github/workflows/ has exactly one well-formed 5-cell table row,
+        and every row names an existing workflow file.
   WC-2  Every row's Class cell begins with one of the closed four-term
-        vocabulary: Blocking / Advisory / Administrative / Post-push
-        detection (qualifiers may follow).
+        vocabulary — Blocking / Advisory / Administrative / Post-push
+        detection — as a whole term (qualifiers may follow after a
+        boundary; `Blockingg` does not count).
+  WC-3  The bolded count line recomputes from the Class column: total,
+        blocking, advisory, administrative, and post-push numbers must
+        all match the table.
+  WC-4  Every `[bypass-token]` named in a row's Bypass cell appears
+        verbatim in that row's workflow file (a renamed token cannot
+        leave the table stale while CI stays green).
 
-Exit 0 when both hold; exit 1 with one line per violation.
+Exit 0 when all hold; exit 1 with one line per violation.
 """
 from __future__ import annotations
 
@@ -23,8 +30,10 @@ import re
 import sys
 from pathlib import Path
 
+from _skill_lint import heading_section
+
 DOC_RELPATH = Path("docs/ARCHITECTURE.md")
-SECTION_HEADING = "### 7.1 CI workflow enforcement classes"
+SECTION_HEADING = "### 7.1 CI workflow enforcement classes (#755)"
 WORKFLOWS_DIR = Path(".github/workflows")
 
 CLASS_VOCABULARY = (
@@ -33,45 +42,55 @@ CLASS_VOCABULARY = (
     "Administrative",
     "Post-push detection",
 )
-
-# A table row whose first cell is a backticked workflow filename.
-_ROW_RE = re.compile(r"^\|\s*`([^`]+\.yml)`\s*\|")
-
-
-def _section_body(md_text: str) -> str | None:
-    """Body of the §7.1 section, up to the next heading of any level."""
-    lines = md_text.split("\n")
-    body: list[str] = []
-    in_section = False
-    for line in lines:
-        if line.startswith(SECTION_HEADING):
-            in_section = True
-            continue
-        if in_section and re.match(r"#{2,3} ", line):
-            break
-        if in_section:
-            body.append(line)
-    return "\n".join(body) if in_section else None
+# The count line tallies by leading class term (order: total, then one count
+# per vocabulary term as worded in the sentence).
+_COUNT_LINE_RE = re.compile(
+    r"\*\*(\d+) workflows — (\d+) blocking[^,]*,\s+(\d+)\s+advisory,"
+    r"\s+(\d+) administrative,\s+(\d+) post-push detection\.\*\*",
+    re.DOTALL,
+)
+_FILENAME_CELL_RE = re.compile(r"`([^`]+\.ya?ml)`")
+_BYPASS_TOKEN_RE = re.compile(r"\[[a-z][a-z-]*\]")
+# Markdown cell split on unescaped pipes only (`\|` stays inside a cell).
+_CELL_SPLIT_RE = re.compile(r"(?<!\\)\|")
 
 
-def _table_rows(section: str) -> list[tuple[str, list[str]]]:
-    """(workflow filename, all cells) per data row of the classification
-    table."""
-    rows: list[tuple[str, list[str]]] = []
+def _table_rows(section: str) -> list[list[str]]:
+    """Cell lists for data rows whose first cell is a backticked workflow
+    filename."""
+    rows: list[list[str]] = []
     for line in section.split("\n"):
-        match = _ROW_RE.match(line)
-        if not match:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
             continue
-        cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        rows.append((match.group(1), cells))
+        cells = [c.strip() for c in _CELL_SPLIT_RE.split(stripped)]
+        # Leading/trailing empties from the outer pipes.
+        if cells and cells[0] == "":
+            cells = cells[1:]
+        if cells and cells[-1] == "":
+            cells = cells[:-1]
+        if cells and _FILENAME_CELL_RE.fullmatch(cells[0]):
+            rows.append(cells)
     return rows
+
+
+def _class_term(class_cell: str) -> str | None:
+    """The vocabulary term the cell begins with — as a whole term, followed
+    by end-of-cell, whitespace, or an opening parenthesis."""
+    for term in sorted(CLASS_VOCABULARY, key=len, reverse=True):
+        if class_cell == term or class_cell.startswith(term + " ") or (
+            class_cell.startswith(term + "(")
+        ):
+            return term
+    return None
 
 
 def run_all_checks(root: Path) -> list[str]:
     doc_path = root / DOC_RELPATH
     if not doc_path.exists():
         return [f"WC-1: {DOC_RELPATH} is missing"]
-    section = _section_body(doc_path.read_text(encoding="utf-8"))
+    doc_text = doc_path.read_text(encoding="utf-8")
+    section = heading_section(doc_text, SECTION_HEADING)
     if section is None:
         return [
             f"WC-1: section '{SECTION_HEADING}' not found in {DOC_RELPATH}"
@@ -80,9 +99,13 @@ def run_all_checks(root: Path) -> list[str]:
     errors: list[str] = []
 
     on_disk = {
-        p.name for p in sorted((root / WORKFLOWS_DIR).glob("*.yml"))
+        p.name
+        for pattern in ("*.yml", "*.yaml")
+        for p in (root / WORKFLOWS_DIR).glob(pattern)
     }
-    in_table = [name for name, _ in rows]
+    in_table = [
+        _FILENAME_CELL_RE.fullmatch(cells[0]).group(1) for cells in rows
+    ]
     for name in sorted(on_disk - set(in_table)):
         errors.append(
             f"WC-1: workflow '{name}' exists on disk but has no row in the "
@@ -94,22 +117,57 @@ def run_all_checks(root: Path) -> list[str]:
             f"WC-1: table row '{name}' names no file under {WORKFLOWS_DIR} "
             f"(removed or renamed workflow)"
         )
-    duplicates = {n for n in in_table if in_table.count(n) > 1}
-    for name in sorted(duplicates):
+    for name in sorted({n for n in in_table if in_table.count(n) > 1}):
         errors.append(f"WC-1: workflow '{name}' has more than one table row")
 
-    for name, cells in rows:
+    tally: dict[str, int] = {term: 0 for term in CLASS_VOCABULARY}
+    for name, cells in zip(in_table, rows):
         # Cells: workflow | trigger | what it checks | class | bypass.
-        if len(cells) < 5:
+        if len(cells) != 5:
             errors.append(
-                f"WC-2: row '{name}' has {len(cells)} cells, expected 5"
+                f"WC-1: row '{name}' has {len(cells)} cells, expected 5"
             )
             continue
-        class_cell = cells[3]
-        if not class_cell.startswith(CLASS_VOCABULARY):
+        term = _class_term(cells[3])
+        if term is None:
             errors.append(
-                f"WC-2: row '{name}' class cell {class_cell!r} does not "
-                f"begin with one of {list(CLASS_VOCABULARY)}"
+                f"WC-2: row '{name}' class cell {cells[3]!r} does not begin "
+                f"with a whole term from {list(CLASS_VOCABULARY)}"
+            )
+        else:
+            tally[term] += 1
+        if name in on_disk:
+            workflow_text = (root / WORKFLOWS_DIR / name).read_text(
+                encoding="utf-8"
+            )
+            for token in _BYPASS_TOKEN_RE.findall(cells[4]):
+                if token not in workflow_text:
+                    errors.append(
+                        f"WC-4: bypass token '{token}' in the '{name}' row "
+                        f"does not appear in {WORKFLOWS_DIR / name} — "
+                        f"renamed or removed token"
+                    )
+
+    count_match = _COUNT_LINE_RE.search(section)
+    if not count_match:
+        errors.append(
+            "WC-3: the bolded count line is missing or no longer matches "
+            "the expected sentence shape"
+        )
+    else:
+        stated = [int(g) for g in count_match.groups()]
+        actual = [
+            len(rows),
+            tally["Blocking"],
+            tally["Advisory"],
+            tally["Administrative"],
+            tally["Post-push detection"],
+        ]
+        if stated != actual:
+            errors.append(
+                f"WC-3: count line states "
+                f"total/blocking/advisory/administrative/post-push = "
+                f"{stated}, table has {actual}"
             )
     return errors
 
@@ -125,7 +183,7 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    print("check_workflow_classification: OK (WC-1..WC-2)")
+    print("check_workflow_classification: OK (WC-1..WC-4)")
     return 0
 
 

--- a/scripts/check_workflow_classification.py
+++ b/scripts/check_workflow_classification.py
@@ -54,6 +54,10 @@ _COUNT_LINE_RE = re.compile(
 )
 _FILENAME_CELL_RE = re.compile(r"`([^`]+\.ya?ml)`")
 _BYPASS_TOKEN_RE = re.compile(r"\[[a-z][a-z-]*\]")
+# Any bracketed span in a Bypass cell must BE a well-formed token — a typo
+# spelling like `[skip_cooldown]` fails loudly instead of silently skipping
+# WC-4.
+_ANY_BRACKET_RE = re.compile(r"\[[^\]\s]+\]")
 # Markdown cell split on unescaped pipes only (`\|` stays inside a cell).
 _CELL_SPLIT_RE = re.compile(r"(?<!\\)\|")
 
@@ -149,6 +153,13 @@ def run_all_checks(root: Path) -> list[str]:
                 .split("\n")
                 if not line.lstrip().startswith("#")
             )
+            for span in _ANY_BRACKET_RE.findall(cells[4]):
+                if not _BYPASS_TOKEN_RE.fullmatch(span):
+                    errors.append(
+                        f"WC-4: bypass cell of '{name}' carries {span!r}, "
+                        f"which is not a well-formed [lowercase-hyphen] "
+                        f"token — typo or unsupported spelling"
+                    )
             for token in _BYPASS_TOKEN_RE.findall(cells[4]):
                 if token not in workflow_text:
                     errors.append(

--- a/scripts/check_workflow_classification.py
+++ b/scripts/check_workflow_classification.py
@@ -57,7 +57,7 @@ _BYPASS_TOKEN_RE = re.compile(r"\[[a-z][a-z-]*\]")
 # Any bracketed span in a Bypass cell must BE a well-formed token — a typo
 # spelling like `[skip_cooldown]` fails loudly instead of silently skipping
 # WC-4.
-_ANY_BRACKET_RE = re.compile(r"\[[^\]\s]+\]")
+_ANY_BRACKET_RE = re.compile(r"\[[^\]]+\]")
 # Markdown cell split on unescaped pipes only (`\|` stays inside a cell).
 _CELL_SPLIT_RE = re.compile(r"(?<!\\)\|")
 

--- a/scripts/check_workflow_classification.py
+++ b/scripts/check_workflow_classification.py
@@ -62,10 +62,12 @@ _ANY_BRACKET_RE = re.compile(r"\[[^\]]+\]")
 _CELL_SPLIT_RE = re.compile(r"(?<!\\)\|")
 
 
-def _table_rows(section: str) -> list[list[str]]:
-    """Cell lists for data rows whose first cell is a backticked workflow
-    filename."""
+def _table_rows(section: str) -> tuple[list[list[str]], list[str]]:
+    """(data rows, malformed-first-cell errors). Every pipe row that is not
+    the header or the separator must open with a backticked workflow
+    filename — a bogus row cannot silently drop out of WC-1/WC-3."""
     rows: list[list[str]] = []
+    errors: list[str] = []
     for line in section.split("\n"):
         stripped = line.strip()
         if not stripped.startswith("|"):
@@ -76,9 +78,20 @@ def _table_rows(section: str) -> list[list[str]]:
             cells = cells[1:]
         if cells and cells[-1] == "":
             cells = cells[:-1]
-        if cells and _FILENAME_CELL_RE.fullmatch(cells[0]):
+        if not cells:
+            continue
+        if cells[0] == "Workflow":
+            continue  # header row
+        if all(re.fullmatch(r":?-{3,}:?", c) for c in cells):
+            continue  # separator row
+        if _FILENAME_CELL_RE.fullmatch(cells[0]):
             rows.append(cells)
-    return rows
+        else:
+            errors.append(
+                f"WC-1: table row opening with {cells[0]!r} does not name a "
+                f"backticked workflow file — malformed or misplaced row"
+            )
+    return rows, errors
 
 
 def _class_term(class_cell: str) -> str | None:
@@ -102,8 +115,7 @@ def run_all_checks(root: Path) -> list[str]:
         return [
             f"WC-1: section '{SECTION_HEADING}' not found in {DOC_RELPATH}"
         ]
-    rows = _table_rows(section)
-    errors: list[str] = []
+    rows, errors = _table_rows(section)
 
     on_disk = {
         p.name

--- a/scripts/check_workflow_classification.py
+++ b/scripts/check_workflow_classification.py
@@ -19,8 +19,11 @@ posture):
         blocking, advisory, administrative, and post-push numbers must
         all match the table.
   WC-4  Every `[bypass-token]` named in a row's Bypass cell appears
-        verbatim in that row's workflow file (a renamed token cannot
-        leave the table stale while CI stays green).
+        verbatim in that row's workflow file, on a non-comment line (a
+        renamed token cannot leave the table stale while CI stays green,
+        and a stale token surviving only in a YAML comment does not
+        count; one surviving only inside a non-comment echo/log string
+        is an accepted edge).
 
 Exit 0 when all hold; exit 1 with one line per violation.
 """
@@ -137,8 +140,14 @@ def run_all_checks(root: Path) -> list[str]:
         else:
             tally[term] += 1
         if name in on_disk:
-            workflow_text = (root / WORKFLOWS_DIR / name).read_text(
-                encoding="utf-8"
+            # Full-comment lines don't execute: a token surviving only in a
+            # comment must not satisfy WC-4.
+            workflow_text = "\n".join(
+                line
+                for line in (root / WORKFLOWS_DIR / name)
+                .read_text(encoding="utf-8")
+                .split("\n")
+                if not line.lstrip().startswith("#")
             )
             for token in _BYPASS_TOKEN_RE.findall(cells[4]):
                 if token not in workflow_text:

--- a/scripts/check_workflow_classification.py
+++ b/scripts/check_workflow_classification.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Defrift lint for the CI workflow classification table (#755).
+
+docs/ARCHITECTURE.md §7.1 claims to classify EVERY workflow's enforcement
+strength — a completeness claim that silently rots when a workflow is added,
+renamed, or removed. This lint pins the two mechanical halves and
+deliberately nothing else — whether a row's class honestly describes its
+workflow's behavior stays owned by code review (degradation-registry
+posture):
+
+  WC-1  Inventory sync, both directions: every *.yml under
+        .github/workflows/ has exactly one table row, and every row names
+        an existing workflow file.
+  WC-2  Every row's Class cell begins with one of the closed four-term
+        vocabulary: Blocking / Advisory / Administrative / Post-push
+        detection (qualifiers may follow).
+
+Exit 0 when both hold; exit 1 with one line per violation.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+DOC_RELPATH = Path("docs/ARCHITECTURE.md")
+SECTION_HEADING = "### 7.1 CI workflow enforcement classes"
+WORKFLOWS_DIR = Path(".github/workflows")
+
+CLASS_VOCABULARY = (
+    "Blocking",
+    "Advisory",
+    "Administrative",
+    "Post-push detection",
+)
+
+# A table row whose first cell is a backticked workflow filename.
+_ROW_RE = re.compile(r"^\|\s*`([^`]+\.yml)`\s*\|")
+
+
+def _section_body(md_text: str) -> str | None:
+    """Body of the §7.1 section, up to the next heading of any level."""
+    lines = md_text.split("\n")
+    body: list[str] = []
+    in_section = False
+    for line in lines:
+        if line.startswith(SECTION_HEADING):
+            in_section = True
+            continue
+        if in_section and re.match(r"#{2,3} ", line):
+            break
+        if in_section:
+            body.append(line)
+    return "\n".join(body) if in_section else None
+
+
+def _table_rows(section: str) -> list[tuple[str, list[str]]]:
+    """(workflow filename, all cells) per data row of the classification
+    table."""
+    rows: list[tuple[str, list[str]]] = []
+    for line in section.split("\n"):
+        match = _ROW_RE.match(line)
+        if not match:
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        rows.append((match.group(1), cells))
+    return rows
+
+
+def run_all_checks(root: Path) -> list[str]:
+    doc_path = root / DOC_RELPATH
+    if not doc_path.exists():
+        return [f"WC-1: {DOC_RELPATH} is missing"]
+    section = _section_body(doc_path.read_text(encoding="utf-8"))
+    if section is None:
+        return [
+            f"WC-1: section '{SECTION_HEADING}' not found in {DOC_RELPATH}"
+        ]
+    rows = _table_rows(section)
+    errors: list[str] = []
+
+    on_disk = {
+        p.name for p in sorted((root / WORKFLOWS_DIR).glob("*.yml"))
+    }
+    in_table = [name for name, _ in rows]
+    for name in sorted(on_disk - set(in_table)):
+        errors.append(
+            f"WC-1: workflow '{name}' exists on disk but has no row in the "
+            f"§7.1 classification table — classify it (new or renamed "
+            f"workflow)"
+        )
+    for name in sorted(set(in_table) - on_disk):
+        errors.append(
+            f"WC-1: table row '{name}' names no file under {WORKFLOWS_DIR} "
+            f"(removed or renamed workflow)"
+        )
+    duplicates = {n for n in in_table if in_table.count(n) > 1}
+    for name in sorted(duplicates):
+        errors.append(f"WC-1: workflow '{name}' has more than one table row")
+
+    for name, cells in rows:
+        # Cells: workflow | trigger | what it checks | class | bypass.
+        if len(cells) < 5:
+            errors.append(
+                f"WC-2: row '{name}' has {len(cells)} cells, expected 5"
+            )
+            continue
+        class_cell = cells[3]
+        if not class_cell.startswith(CLASS_VOCABULARY):
+            errors.append(
+                f"WC-2: row '{name}' class cell {class_cell!r} does not "
+                f"begin with one of {list(CLASS_VOCABULARY)}"
+            )
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    errors = run_all_checks(root)
+    if errors:
+        for line in errors:
+            print(f"ERROR: {line}", file=sys.stderr)
+        print(
+            f"check_workflow_classification: {len(errors)} violation(s)",
+            file=sys.stderr,
+        )
+        return 1
+    print("check_workflow_classification: OK (WC-1..WC-2)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_control_availability.py
+++ b/scripts/test_check_control_availability.py
@@ -26,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 _MIRRORED_FILES = (
     "docs/CONTROL_AVAILABILITY.md",
     "docs/SETUP.md",
+    "docs/ARCHITECTURE.md",
     "README.md",
     "audits/iso42001-spirit-gap-assessment-2026-08-17.md",
     "pi/README.md",

--- a/scripts/test_check_workflow_classification.py
+++ b/scripts/test_check_workflow_classification.py
@@ -185,6 +185,16 @@ def test_malformed_token_spelling_fires(repo: Path) -> None:
     )
 
 
+def test_whitespace_token_spelling_fires(repo: Path) -> None:
+    # `[skip cooldown]` (space typo) must also fail loudly (codex R5).
+    _mutate_doc(repo, "[skip-cooldown]", "[skip cooldown]")
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-4" in e and "skip cooldown" in e and "not a well-formed" in e
+        for e in errors
+    )
+
+
 def test_malformed_row_arity_fires(repo: Path) -> None:
     _mutate_doc(
         repo,

--- a/scripts/test_check_workflow_classification.py
+++ b/scripts/test_check_workflow_classification.py
@@ -22,8 +22,9 @@ def repo(tmp_path: Path) -> Path:
     dst_doc.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(REPO_ROOT / DOC_RELPATH, dst_doc)
     (tmp_path / WORKFLOWS_DIR).mkdir(parents=True, exist_ok=True)
-    for wf in sorted((REPO_ROOT / WORKFLOWS_DIR).glob("*.yml")):
-        shutil.copyfile(wf, tmp_path / WORKFLOWS_DIR / wf.name)
+    for pattern in ("*.yml", "*.yaml"):
+        for wf in sorted((REPO_ROOT / WORKFLOWS_DIR).glob(pattern)):
+            shutil.copyfile(wf, tmp_path / WORKFLOWS_DIR / wf.name)
     return tmp_path
 
 
@@ -149,6 +150,22 @@ def test_renamed_bypass_token_fires(repo: Path) -> None:
         wf.read_text(encoding="utf-8").replace(
             "[skip-cooldown]", "[cooldown-override]"
         ),
+        encoding="utf-8",
+    )
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-4" in e and "[skip-cooldown]" in e for e in errors
+    )
+
+
+def test_token_surviving_only_in_comment_fires(repo: Path) -> None:
+    # Renaming the executable token while an old comment still mentions it
+    # must not satisfy WC-4 (codex R2 finding).
+    wf = repo / WORKFLOWS_DIR / "release-cooldown.yml"
+    text = wf.read_text(encoding="utf-8")
+    text = text.replace("[skip-cooldown]", "[cooldown-override]")
+    wf.write_text(
+        text + "\n# legacy note: the old token was [skip-cooldown]\n",
         encoding="utf-8",
     )
     errors = run_all_checks(repo)

--- a/scripts/test_check_workflow_classification.py
+++ b/scripts/test_check_workflow_classification.py
@@ -195,6 +195,23 @@ def test_whitespace_token_spelling_fires(repo: Path) -> None:
     )
 
 
+def test_bogus_unbackticked_row_fires(repo: Path) -> None:
+    # A data row whose first cell is not a backticked workflow filename
+    # must fail WC-1, not silently drop out of the inventory and count
+    # (codex R6 finding).
+    _mutate_doc(
+        repo,
+        "| `tag-version-match.yml` |",
+        "| not-a-workflow | bogus | bogus | Advisory | none |\n"
+        "| `tag-version-match.yml` |",
+    )
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-1" in e and "not-a-workflow" in e and "malformed" in e
+        for e in errors
+    )
+
+
 def test_malformed_row_arity_fires(repo: Path) -> None:
     _mutate_doc(
         repo,

--- a/scripts/test_check_workflow_classification.py
+++ b/scripts/test_check_workflow_classification.py
@@ -1,0 +1,112 @@
+"""Mutation tests for check_workflow_classification.py (#755)."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from check_workflow_classification import (
+    DOC_RELPATH,
+    WORKFLOWS_DIR,
+    run_all_checks,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """Real doc + real workflow inventory, copied so mutations are isolated."""
+    dst_doc = tmp_path / DOC_RELPATH
+    dst_doc.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(REPO_ROOT / DOC_RELPATH, dst_doc)
+    (tmp_path / WORKFLOWS_DIR).mkdir(parents=True, exist_ok=True)
+    for wf in sorted((REPO_ROOT / WORKFLOWS_DIR).glob("*.yml")):
+        shutil.copyfile(wf, tmp_path / WORKFLOWS_DIR / wf.name)
+    return tmp_path
+
+
+def _mutate_doc(root: Path, old: str, new: str) -> None:
+    doc = root / DOC_RELPATH
+    text = doc.read_text(encoding="utf-8")
+    assert old in text, f"mutation anchor not found: {old!r}"
+    doc.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def test_real_tree_passes() -> None:
+    assert run_all_checks(REPO_ROOT) == []
+
+
+def test_fixture_baseline_passes(repo: Path) -> None:
+    assert run_all_checks(repo) == []
+
+
+def test_missing_doc_is_single_fatal_error(repo: Path) -> None:
+    (repo / DOC_RELPATH).unlink()
+    errors = run_all_checks(repo)
+    assert len(errors) == 1
+    assert "missing" in errors[0]
+
+
+def test_missing_section_fires(repo: Path) -> None:
+    _mutate_doc(
+        repo,
+        "### 7.1 CI workflow enforcement classes",
+        "### 7.1 CI workflow something else",
+    )
+    errors = run_all_checks(repo)
+    assert any("WC-1" in e and "not found" in e for e in errors)
+
+
+def test_new_workflow_without_row_fires(repo: Path) -> None:
+    (repo / WORKFLOWS_DIR / "brand-new-check.yml").write_text(
+        "name: Brand New\non:\n  push:\n", encoding="utf-8"
+    )
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-1" in e and "brand-new-check.yml" in e and "no row" in e
+        for e in errors
+    )
+
+
+def test_row_for_removed_workflow_fires(repo: Path) -> None:
+    (repo / WORKFLOWS_DIR / "freshness-check.yml").unlink()
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-1" in e and "freshness-check.yml" in e and "names no file" in e
+        for e in errors
+    )
+
+
+def test_duplicate_row_fires(repo: Path) -> None:
+    doc = repo / DOC_RELPATH
+    lines = doc.read_text(encoding="utf-8").split("\n")
+    idx = next(
+        i for i, line in enumerate(lines) if line.startswith("| `pytest.yml`")
+    )
+    lines.insert(idx, lines[idx])
+    doc.write_text("\n".join(lines), encoding="utf-8")
+    errors = run_all_checks(repo)
+    assert any(
+        "pytest.yml" in e and "more than one table row" in e for e in errors
+    )
+
+
+def test_off_vocabulary_class_fires(repo: Path) -> None:
+    _mutate_doc(repo, "| Administrative |", "| Mandatory |")
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-2" in e and "Mandatory" in e for e in errors
+    )
+
+
+def test_class_with_qualifier_still_passes(repo: Path) -> None:
+    # Qualified cells like "Blocking when triggered" are in-vocabulary by
+    # prefix; the baseline table already contains them — pin that explicitly.
+    _mutate_doc(
+        repo,
+        "| Administrative |",
+        "| Administrative (opens an issue) |",
+    )
+    assert run_all_checks(repo) == []

--- a/scripts/test_check_workflow_classification.py
+++ b/scripts/test_check_workflow_classification.py
@@ -174,6 +174,17 @@ def test_token_surviving_only_in_comment_fires(repo: Path) -> None:
     )
 
 
+def test_malformed_token_spelling_fires(repo: Path) -> None:
+    # `[skip_cooldown]` (underscore typo) must fail loudly, not silently
+    # fall out of the token grammar (codex R4 finding).
+    _mutate_doc(repo, "[skip-cooldown]", "[skip_cooldown]")
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-4" in e and "skip_cooldown" in e and "not a well-formed" in e
+        for e in errors
+    )
+
+
 def test_malformed_row_arity_fires(repo: Path) -> None:
     _mutate_doc(
         repo,

--- a/scripts/test_check_workflow_classification.py
+++ b/scripts/test_check_workflow_classification.py
@@ -99,14 +99,72 @@ def test_off_vocabulary_class_fires(repo: Path) -> None:
     assert any(
         "WC-2" in e and "Mandatory" in e for e in errors
     )
+    # The count line still says 1 administrative; the reclassified table
+    # has 0 — WC-3 must fire alongside.
+    assert any("WC-3" in e for e in errors)
+
+
+def test_typo_suffix_class_fires(repo: Path) -> None:
+    # `Blockingg` must not pass on a prefix match — the vocabulary term is
+    # matched as a whole word (codex R1 finding).
+    _mutate_doc(repo, "| Administrative |", "| Administrativee |")
+    errors = run_all_checks(repo)
+    assert any("WC-2" in e and "Administrativee" in e for e in errors)
 
 
 def test_class_with_qualifier_still_passes(repo: Path) -> None:
-    # Qualified cells like "Blocking when triggered" are in-vocabulary by
-    # prefix; the baseline table already contains them — pin that explicitly.
+    # Qualifiers after a boundary are in-vocabulary; the count is unchanged,
+    # so WC-3 stays quiet too.
     _mutate_doc(
         repo,
         "| Administrative |",
         "| Administrative (opens an issue) |",
     )
     assert run_all_checks(repo) == []
+
+
+def test_yaml_extension_workflow_fires(repo: Path) -> None:
+    # GitHub Actions also reads *.yaml — a completeness lint bypassable by a
+    # file extension fails open in the exact direction it exists to prevent.
+    (repo / WORKFLOWS_DIR / "alt-ext.yaml").write_text(
+        "name: Alt\non:\n  push:\n", encoding="utf-8"
+    )
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-1" in e and "alt-ext.yaml" in e and "no row" in e for e in errors
+    )
+
+
+def test_count_line_drift_fires(repo: Path) -> None:
+    _mutate_doc(repo, "8 blocking", "9 blocking")
+    errors = run_all_checks(repo)
+    assert any("WC-3" in e and "count line" in e for e in errors)
+
+
+def test_renamed_bypass_token_fires(repo: Path) -> None:
+    # The table's `[skip-cooldown]` must exist verbatim in the workflow —
+    # renaming it there cannot leave the table stale with CI green.
+    wf = repo / WORKFLOWS_DIR / "release-cooldown.yml"
+    wf.write_text(
+        wf.read_text(encoding="utf-8").replace(
+            "[skip-cooldown]", "[cooldown-override]"
+        ),
+        encoding="utf-8",
+    )
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-4" in e and "[skip-cooldown]" in e for e in errors
+    )
+
+
+def test_malformed_row_arity_fires(repo: Path) -> None:
+    _mutate_doc(
+        repo,
+        "| `tag-version-match.yml` | tag push `v*` | re-runs the full version-consistency lint at the tag | Post-push detection | none |",
+        "| `tag-version-match.yml` | tag push `v*` | Post-push detection | none |",
+    )
+    errors = run_all_checks(repo)
+    assert any(
+        "WC-1" in e and "tag-version-match.yml" in e and "expected 5" in e
+        for e in errors
+    )


### PR DESCRIPTION
## Summary

Closes the T-5 audit finding: the 14 files under `.github/workflows/` were described collectively as CI gates while enforcing at four different strengths, summarized nowhere.

- **`docs/ARCHITECTURE.md` §7.1**: one row per workflow — trigger (actual branch/path/tag filters, verified row by row), what it checks, enforcement class (**blocking / advisory / administrative / post-push detection**), bypass. Count line: 14 workflows — 8 blocking on at least one event class, 2 advisory, 1 administrative, 3 post-push detection. Honesty details that survived review: the three tag-only workflows detect after the push (their stop-power is the maintainer acting on the failure); an unfiltered or paths-only `push:` also matches tag pushes, so `spec-consistency` / `command-invariants` / `freshness-check` additionally run on every tag; `freshness-check` is advisory for staleness but hard-fails malformed metadata; the `[skip-*]` bypass justifications are requested, not machine-validated.
- **CONTRIBUTING.md** links the classification; **docs/CONTROL_AVAILABILITY.md** corrects its "on every change" claim and links §7.1; the ARCHITECTURE "How to read" bullet indexes the sub-view.
- **Lint in the same PR**: `scripts/check_workflow_classification.py` — WC-1 inventory sync both directions incl. `*.yaml`, well-formed 5-cell rows, bogus rows fail instead of dropping out; WC-2 whole-term class vocabulary; WC-3 recomputes the bolded count line from the Class column (the honesty sentence cannot self-invalidate); WC-4 pins every bypass token to verbatim non-comment presence in its workflow file, with malformed token spellings (underscore/whitespace typos) failing loudly. Class semantics stay review-owned (degradation-registry posture). 18 mutation tests, CI-wired. Section extraction reuses the shared `_skill_lint.heading_section` (fence-aware, exact full-line heading).

## Review trajectory

- `/simplify` 3-agent pass applied (shared-helper reuse verified as a drop-in by the reviewing agent itself; trigger-cell birth drift caught; count-line pin chosen over deletion; CONTROL_AVAILABILITY surface identified).
- Cross-model review: codex gpt-5.6-sol xhigh, **7 rounds to convergence** — R1 5P2+1P3 (row accuracy incl. freshness-check's hard-failure path and unvalidated bypass justifications; lint word-boundary and pipe-escape) → R2 2P2 → R3 the tag-push/paths-not-evaluated subtlety → R4–R6 token-grammar and row-shape hardening → **R7 CLOSED, no findings**.
- `/security-review`: **0 findings** (documented tokens are already public and maintainer-review-visible; doc-derived filenames guarded by the on-disk glob allowlist; tests confined to tmp_path).

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EosnA4RdUYgbF2KmZ1DTmc
