### PR TITLE
docs: add OrcaRouter to THIRD_PARTY.md community directory

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -52,6 +52,7 @@ directory listing. See the Platform Port Reminder policy and open an issue to di
 | Project | Maintainer | What it does | Link |
 |---------|-----------|--------------|------|
 | ClawMama | kinhunt (third party) | Hosted OpenClaw/Hermes-style agent offering a first-run trial of the Academic Research Pipeline via Telegram or WhatsApp | [Try in Telegram or WhatsApp](https://app.clawmama.run/skills/639wu5/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_academic_research_skills) |
+| OrcaRouter | OrcaRouter team | OpenAI- and Anthropic-compatible gateway usable as the cross-model verification provider in Academic Research Skills via `ARS_OPENAI_COMPAT_BASE_URL` + `ARS_CROSS_MODEL`, with namespaced model IDs (e.g. `anthropic/claude-sonnet-5`) routing through the ungrounded OpenAI-compatible path | [orcarouter.ai](https://www.orcarouter.ai) |
 
 *Columns:* **Project** name as the third party calls it · **Maintainer** the account
 that submitted / operates it · **What it does** a one-line neutral description ·


### PR DESCRIPTION
## Summary

Adds an [OrcaRouter](https://www.orcarouter.ai) row to the "Listed projects" table in `THIRD_PARTY.md`, per the maintainer's invitation in the discussion on #775/#776 and the request in #781. The listing credits Academic Research Skills and describes the integration faithfully under the "How to get listed" bar.

OrcaRouter is an OpenAI- and Anthropic-compatible gateway (`https://api.orcarouter.ai`) that can serve as the cross-model verification provider for ARS via `ARS_OPENAI_COMPAT_BASE_URL` + `ARS_CROSS_MODEL`, with namespaced model IDs (e.g. `anthropic/claude-sonnet-5`) routing through the ungrounded OpenAI-compatible path. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This is a documentation-only change; no suite behavior is touched.

## Eval impact

No eval impact.

## Platform port?

Not a platform port.

## Checklist

- [x] Tests added/updated — N/A (docs-only change)
- [x] Eval impact section accurate

Closes #781

_I'm an engineer on the OrcaRouter team._
