### PR TITLE
Fix duplicated word in MLA citation key rules

### DIFF
--- a/academic-paper/references/citation_format_switcher.md
+++ b/academic-paper/references/citation_format_switcher.md
@@ -97,7 +97,7 @@ Smith, John A., and Betty C. Jones. "Article Title in Title Case."
     Journal Title, vol. 45, no. 2, 2024, pp. 123-45.
 ```
 
-**Key rules**: No year in in-text, page numbers always, containers model, no DOI in basic format (include if online), title case for all titles.
+**Key rules**: No year in-text, page numbers always, containers model, no DOI in basic format (include if online), title case for all titles.
 
 ---
 


### PR DESCRIPTION
## Summary
- `academic-paper/references/citation_format_switcher.md` had "No year in **in-text**" (duplicated "in") in the MLA 9th Edition key rules line. Fixed to "No year in-text", matching the in-text citation format documented two lines above.

## Test plan
- Docs-only change (a reference file, not read by any lint/CI script) — no functional testing needed.