### PR TITLE
fix: make /ars-mark-read work on Windows (#843)

### DIFF
--- a/scripts/ars_mark_read.py
+++ b/scripts/ars_mark_read.py
@@ -157,8 +157,6 @@ def _ledger_lock(
 
     acquired = False
     try:
-        if fcntl is None and os.fstat(fd).st_size == 0:
-            os.write(fd, b"\0")
         os.lseek(fd, 0, os.SEEK_SET)
         deadline = time.monotonic() + timeout
         while True:

--- a/scripts/ars_mark_read.py
+++ b/scripts/ars_mark_read.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import argparse
 import errno
-import fcntl
 import os
 import sys
 import tempfile
@@ -49,6 +48,12 @@ from pathlib import Path
 from typing import Any, Iterator
 
 import yaml
+
+try:
+    import fcntl
+except ModuleNotFoundError:  # pragma: no cover - exercised on Windows
+    fcntl = None  # type: ignore[assignment]
+    import msvcrt
 
 try:
     from scripts.human_read_attestation_resolver import (
@@ -75,6 +80,22 @@ LOCATOR_MAX_LEN = 200
 NOTE_MAX_LEN = 1000
 LEDGER_LOCK_TIMEOUT_SECONDS = 10.0
 LEDGER_LOCK_POLL_SECONDS = 0.05
+
+
+def _lock_nonblocking(fd: int) -> None:
+    """Acquire one byte of the peer lock using the host OS backend."""
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return
+    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+
+def _unlock(fd: int) -> None:
+    """Release the peer lock using the host OS backend."""
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return
+    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
 
 
 class LedgerLockError(RuntimeError):
@@ -136,10 +157,13 @@ def _ledger_lock(
 
     acquired = False
     try:
+        if fcntl is None and os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+        os.lseek(fd, 0, os.SEEK_SET)
         deadline = time.monotonic() + timeout
         while True:
             try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                _lock_nonblocking(fd)
                 acquired = True
                 break
             except InterruptedError:
@@ -163,7 +187,7 @@ def _ledger_lock(
         release_error: OSError | None = None
         if acquired:
             try:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                _unlock(fd)
             except OSError as exc:
                 release_error = exc
         try:


### PR DESCRIPTION
## Summary

Fixes #843. scripts/ars_mark_read.py imported POSIX-only fcntl at module load, so the documented /ars-mark-read CLI failed on Windows before parsing arguments.

The patch keeps fcntl.flock on POSIX and adds a stdlib msvcrt.locking fallback on Windows. It preserves the existing bounded retry loop, exclusive lock, persistent lock file, and clean release behavior.

## Verification

- pytest -q tests/test_mark_read_args.py — 4 passed on Windows/Python 3.13.
- Before the patch, the same focused suite had 4 collection/runtime failures with ModuleNotFoundError: No module named 'fcntl'.
- Full pytest -q remains blocked by pre-existing Windows-only fcntl imports in other scripts and missing ruamel.yaml; those are recorded in the campaign audit.

This is a narrow external-contributor PR; no maintainer approval or merge is implied.
